### PR TITLE
crm457-1109: Fix missing translations on CYA page

### DIFF
--- a/app/presenters/nsm/check_answers/disbursement_costs_card.rb
+++ b/app/presenters/nsm/check_answers/disbursement_costs_card.rb
@@ -30,7 +30,7 @@ module Nsm
       def disbursement_rows
         disbursements.rows.map do |row|
           {
-            head_key: row[:key][:text],
+            head_key: row[:key][:text].parameterize.underscore,
             text: row[:value][:text]
           }
         end

--- a/app/presenters/nsm/check_answers/work_items_card.rb
+++ b/app/presenters/nsm/check_answers/work_items_card.rb
@@ -40,7 +40,7 @@ module Nsm
       def work_item_rows
         work_items.rows.map do |row|
           {
-            head_key: row[:key][:text],
+            head_key: row[:key][:text].parameterize.underscore,
             text: row[:value][:text]
           }
         end

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -82,6 +82,7 @@ en:
               total: Total
               total_inc_vat: Total (including VAT)
             disbursements:
+              car: Car
               items: Items
               items_total: <strong>Total per item</strong>
               total: Total

--- a/spec/presenters/nsm/check_answers/disbursement_cost_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/disbursement_cost_card_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Nsm::CheckAnswers::DisbursementCostsCard do
             text: '<strong>Total per item</strong>'
           },
           {
-            head_key: 'Accident Reconstruction Report',
+            head_key: 'accident_reconstruction_report',
             text: '£90.00'
           },
           {

--- a/spec/presenters/nsm/check_answers/work_items_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/work_items_card_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe Nsm::CheckAnswers::WorkItemsCard do
               text: '<strong>Total per item</strong>'
             },
             {
-              head_key: 'Attendance without counsel',
+              head_key: 'attendance_without_counsel',
               text: '£0.00'
             },
             {
-              head_key: 'Preparation',
+              head_key: 'preparation',
               text: '£104.30'
             },
             {
-              head_key: 'Advocacy',
+              head_key: 'advocacy',
               text: '£392.52'
             },
             {
@@ -81,15 +81,15 @@ RSpec.describe Nsm::CheckAnswers::WorkItemsCard do
               text: '<strong>Total per item</strong>'
             },
             {
-              head_key: 'Attendance without counsel',
+              head_key: 'attendance_without_counsel',
               text: '£0.00'
             },
             {
-              head_key: 'Preparation',
+              head_key: 'preparation',
               text: '£104.30'
             },
             {
-              head_key: 'Advocacy',
+              head_key: 'advocacy',
               text: '£392.52'
             },
             {


### PR DESCRIPTION
## Description of change
Fix missing translations on CYA page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1109)

The check your answers page for NSM encounters
multiple missing translation errors when running
in local/development. This error does not occur on
hosted environments because any missing translations fall back to using a humanized version of whatever “key” has been supplied.

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1130" alt="Screenshot 2024-02-08 at 11 52 34" src="https://github.com/ministryofjustice/laa-claim-non-standard-magistrate-fee-backend/assets/7016425/cb6d338d-c623-48f0-91e7-be67a7fda07a">

### Before changes:

### After changes:

## How to manually test the feature
