### PR TITLE
CRM457-1156: optional next hearing date - non-prison law

### DIFF
--- a/app/forms/prior_authority/steps/hearing_detail_form.rb
+++ b/app/forms/prior_authority/steps/hearing_detail_form.rb
@@ -1,11 +1,17 @@
 module PriorAuthority
   module Steps
     class HearingDetailForm < ::Steps::BaseFormObject
+      attribute :next_hearing, :boolean
       attribute :next_hearing_date, :multiparam_date
       attribute :plea, :value_object, source: PleaOptions
       attribute :court_type, :value_object, source: CourtTypeOptions
 
-      validates :next_hearing_date, multiparam_date: { allow_past: true, allow_future: true }
+      validates :next_hearing, inclusion: { in: [true, false] }
+      validates :next_hearing_date,
+                presence: true,
+                multiparam_date: { allow_past: true, allow_future: true },
+                if: :next_hearing
+
       validates :plea, inclusion: { in: PleaOptions.values }
       validates :court_type, inclusion: { in: CourtTypeOptions.values }
 
@@ -28,6 +34,16 @@ module PriorAuthority
       end
 
       def reset_attributes
+        next_hearing_attributes_to_reset.merge(court_type_attributes_to_reset)
+      end
+
+      def next_hearing_attributes_to_reset
+        {
+          next_hearing_date: next_hearing ? next_hearing_date : nil
+        }
+      end
+
+      def court_type_attributes_to_reset
         if court_type.magistrates_court?
           { psychiatric_liaison: nil,
             psychiatric_liaison_reason_not: nil }

--- a/app/views/prior_authority/steps/hearing_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/hearing_detail/edit.html.erb
@@ -8,7 +8,12 @@
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
 
     <%= step_form @form_object do |form| %>
-      <%= form.govuk_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
+      <%= form.govuk_radio_buttons_fieldset :next_hearing, legend: { text: t('.next_hearing'), size: 's' } do %>
+        <%= form.govuk_radio_button :next_hearing, true, label: { text: t('generic.yes') }, link_errors: true do %>
+              <%= form.govuk_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
+          <% end %>
+          <%= form.govuk_radio_button :next_hearing, false, label: { text: t('generic.no') } %>
+      <% end %>
 
       <%= form.govuk_radio_buttons_fieldset :plea, legend: { text: t('.plea'), size: 's', class: 'govuk-!-margin-bottom-6' } do %>
         <% form.object.pleas.each_with_index do |plea, index| %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -111,6 +111,8 @@ en:
               blank: Enter an account number
         prior_authority/steps/hearing_detail_form:
           attributes:
+            next_hearing:
+              inclusion: Select yes if you know the date of the next hearing
             next_hearing_date: *shared_date_errors
             plea:
               inclusion: Select the likely or actual plea

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -39,6 +39,7 @@ en:
       hearing_detail:
         edit:
           caption: 2. About the case
+          next_hearing: Do you know the date of the next hearing?
           next_hearing_date: Date of next hearing
           next_hearing_date_hint: For example, 27 3 2022
           plea: Likely or actual plea

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
   describe '#validate' do
     let(:application) { instance_double(PriorAuthorityApplication) }
 
-    context 'with hearing details' do
+    context 'with hearing details including next hearing date' do
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'central_criminal_court',
@@ -25,9 +26,10 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
       it { is_expected.to be_valid }
     end
 
-    context 'without next hearing date' do
+    context 'with hearing details excluding next hearing date' do
       let(:hearing_detail_attributes) do
         {
+          next_hearing: false,
           next_hearing_date: nil,
           plea: 'not_guilty',
           court_type: 'central_criminal_court',
@@ -40,6 +42,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
     context 'with invalid hearing details' do
       let(:hearing_detail_attributes) do
         {
+          next_hearing: nil,
           next_hearing_date: nil,
           plea: nil,
           court_type: nil,
@@ -49,8 +52,26 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
       it 'has expected validation errors on the field' do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
-          .to include('Select the likely or actual plea',
+          .to include('Select yes if you know the date of the next hearing',
+                      'Select the likely or actual plea',
                       'Select the type of court')
+      end
+    end
+
+    context 'without next hearing date when it is expected' do
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: nil,
+          plea: 'not_guilty',
+          court_type: 'central_criminal_court',
+        }
+      end
+
+      it 'has expected validation errors on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.messages.values.flatten)
+          .to include('Date cannot be blank')
       end
     end
   end
@@ -63,6 +84,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
     context 'with valid hearing details' do
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'central_criminal_court',
@@ -73,6 +95,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
         expect { save }.to change { application.reload.attributes }
           .from(
             hash_including(
+              'next_hearing' => nil,
               'next_hearing_date' => nil,
               'plea' => nil,
               'court_type' => nil,
@@ -80,6 +103,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
           )
           .to(
             hash_including(
+              'next_hearing' => true,
               'next_hearing_date' => Date.tomorrow,
               'plea' => 'not_guilty',
               'court_type' => 'central_criminal_court',
@@ -91,6 +115,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
     context 'with incomplete hearing details' do
       let(:hearing_detail_attributes) do
         {
+          next_hearing: nil,
           next_hearing_date: nil,
           plea: nil,
           court_type: nil,
@@ -101,9 +126,40 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
         expect { save }.not_to change { application.reload.attributes }
           .from(
             hash_including(
+              'next_hearing' => nil,
               'next_hearing_date' => nil,
               'plea' => nil,
               'court_type' => nil,
+            )
+          )
+      end
+    end
+
+    context 'when changing next_hering from true to false' do
+      let(:application) { create(:prior_authority_application, next_hearing: true, next_hearing_date: a_date) }
+      let(:a_date) { Date.tomorrow }
+
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing: false,
+          next_hearing_date: a_date,
+          plea: 'not_guilty',
+          court_type: 'central_criminal_court',
+        }
+      end
+
+      it 'nullifies next_hearing_date field' do
+        expect { save }.to change { application.reload.attributes }
+          .from(
+            hash_including(
+              'next_hearing' => true,
+              'next_hearing_date' => a_date,
+            )
+          )
+          .to(
+            hash_including(
+              'next_hearing' => false,
+              'next_hearing_date' => nil,
             )
           )
       end
@@ -114,6 +170,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
 
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'central_criminal_court',
@@ -142,6 +199,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
 
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'magistrates_court',
@@ -172,6 +230,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
 
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'crown_court',
@@ -202,6 +261,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
 
       let(:hearing_detail_attributes) do
         {
+          next_hearing: true,
           next_hearing_date: Date.tomorrow,
           plea: 'not_guilty',
           court_type: 'crown_court',

--- a/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
+++ b/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
       it { is_expected.to be_valid }
     end
 
+    context 'without next hearing date' do
+      let(:next_hearing_attributes) do
+        {
+          next_hearing: false,
+          next_hearing_date: nil,
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+
     context 'with invalid next hearing details' do
       let(:next_hearing_attributes) do
         {
@@ -36,6 +47,21 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
           .to contain_exactly('Select yes if you know the date of the next hearing')
+      end
+    end
+
+    context 'with invalid combination of next hearing details' do
+      let(:next_hearing_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: nil,
+        }
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.messages.values.flatten)
+          .to contain_exactly('Date cannot be blank')
       end
     end
   end

--- a/spec/system/prior_authority/hearing_details_spec.rb
+++ b/spec/system/prior_authority/hearing_details_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe 'Prior authority applications - add hearing details' do
     fill_in_until_step(:hearing_detail)
   end
 
-  it 'allows hearing detail creation' do
+  it 'allows hearing detail creation with next hearing date' do
     expect(page).to have_title 'Hearing details'
 
-    within('.govuk-form-group', text: 'Date of next hearing') do
+    choose 'Yes'
+    within('.govuk-form-group', text: 'Date of next hearing', match: :first) do
       dt = Date.tomorrow
       fill_in 'Day', with: dt.day
       fill_in 'Month', with: dt.month
@@ -22,9 +23,22 @@ RSpec.describe 'Prior authority applications - add hearing details' do
     expect(page).to have_title 'Have you accessed the psychiatric liaison service?'
   end
 
+  it 'allows hearing detail creation without next hearing date' do
+    expect(page).to have_title 'Hearing details'
+
+    choose 'No'
+    choose 'Not guilty'
+    choose 'Central Criminal Court'
+
+    click_on 'Save and continue'
+    expect(page).to have_title 'Have you accessed the psychiatric liaison service?'
+  end
+
   context 'when navigating to next page' do
     before do
-      within('.govuk-form-group', text: 'Date of next hearing') do
+      choose 'Yes'
+
+      within('.govuk-form-group', text: 'Date of next hearing', match: :first) do
         dt = Date.tomorrow
         fill_in 'Day', with: dt.day
         fill_in 'Month', with: dt.month

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -142,7 +142,9 @@ module PriorAuthority
     end
 
     def fill_in_hearing_detail(plea: 'Not guilty', court_type: "Magistrates' court")
-      within('.govuk-form-group', text: 'Date of next hearing') do
+      choose 'Yes'
+
+      within('.govuk-form-group', text: 'Date of next hearing', match: :first) do
         dt = Date.tomorrow
         fill_in 'Day', with: dt.day
         fill_in 'Month', with: dt.month


### PR DESCRIPTION
## Description of change
Add question for optional next hearing date - non-prison law

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1156)

An additional question has been added to designs
for the user to answer whether they have a next hearing
date or not before entering the date, if Yes selected.

### Before changes:
<img width="431" alt="Screenshot 2024-02-22 at 13 43 29" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/76ab7a48-3198-4913-a7dc-78f8d09fca4c">


### After changes:
<img width="685" alt="Screenshot 2024-02-22 at 13 41 47" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/869df6c5-8bdd-4c6b-96d8-3abf431151fd">

