### PR TITLE
Replace linebreaks in, and sanitize, text fields

### DIFF
--- a/app/presenters/prior_authority/check_answers/base.rb
+++ b/app/presenters/prior_authority/check_answers/base.rb
@@ -7,6 +7,7 @@ module PriorAuthority
       include GovukLinkHelper
       include GovukVisuallyHiddenHelper
       include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::TextHelper
 
       attr_accessor :group, :section
 

--- a/app/presenters/prior_authority/check_answers/primary_quote_card.rb
+++ b/app/presenters/prior_authority/check_answers/primary_quote_card.rb
@@ -104,7 +104,7 @@ module PriorAuthority
         [
           {
             head_key: 'travel_cost_reason',
-            text: application.primary_quote.travel_cost_reason,
+            text: simple_format(application.primary_quote.travel_cost_reason),
           },
         ]
       end

--- a/app/presenters/prior_authority/check_answers/reason_why_card.rb
+++ b/app/presenters/prior_authority/check_answers/reason_why_card.rb
@@ -20,7 +20,7 @@ module PriorAuthority
         [
           {
             head_key: 'reason_why',
-            text: application.reason_why,
+            text: simple_format(application.reason_why),
           },
           {
             head_key: 'supporting_documents',

--- a/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
       end
 
       let(:primary_quote) do
-        build(:quote, :primary, travel_cost_reason: 'client lives in northern ireland')
+        build(:quote, :primary, travel_cost_reason: "reason 1\nreason 2")
       end
 
       it 'adds the travel cost reason row' do
@@ -215,7 +215,7 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
           .to include(
             {
               head_key: 'travel_cost_reason',
-              text: 'client lives in northern ireland',
+              text: "<p>reason 1\n<br />reason 2</p>",
             },
           )
       end

--- a/spec/presenters/prior_authority/check_answers/reason_why_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/reason_why_card_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PriorAuthority::CheckAnswers::ReasonWhyCard do
   describe '#row_data' do
     let(:application) do
       build(:prior_authority_application,
-            reason_why: 'because',
+            reason_why: "reason 1\nreason 2",
             supporting_documents: supporting_documents)
     end
 
@@ -32,7 +32,7 @@ RSpec.describe PriorAuthority::CheckAnswers::ReasonWhyCard do
         [
           {
             head_key: 'reason_why',
-            text: 'because',
+            text: "<p>reason 1\n<br />reason 2</p>",
           },
           {
             head_key: 'supporting_documents',

--- a/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe 'Prior authority applications, no prison law - check your answers
         .and have_css('.govuk-summary-card__content', text: 'Service detailsJoe BloggsLAA, CR0 1RE')
         .and have_css('.govuk-summary-card__content', text: 'Quote uploadtest.png')
         .and have_css('.govuk-summary-card__content', text: 'Existing prior authority grantedYes')
-        .and have_css('.govuk-summary-card__content', text: 'Why travel costs are requiredClient lives in Wales')
+        .and have_css('.govuk-summary-card__content', text: /Why travel costs are required.*Client lives in Wales/)
 
       expect(page)
         .to have_css('.govuk-table__caption', text: 'Primary quote summary')
@@ -179,7 +179,7 @@ RSpec.describe 'Prior authority applications, no prison law - check your answers
   it 'shows the reason for prior authority card' do
     within('.govuk-summary-card', text: 'Reason for prior authority') do
       expect(page)
-        .to have_css('.govuk-summary-card__content', text: 'Why prior authority is requiredRequired because...')
+        .to have_css('.govuk-summary-card__content', text: /Why prior authority is required.*Required because.../)
       # TODO: supporting document upload file names
 
       click_on 'Change'


### PR DESCRIPTION
## Description of change
Replace linebreaks in and sanitize text fields

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

Request from designer as helps readability.
Plus necessary to do anyway to sanitize
the content.

### Before changes:
<img width="948" alt="Screenshot 2024-02-22 at 14 48 07" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/162ba139-a2e8-48ad-b71d-933e92bba5a0">


### After changes:

<img width="904" alt="Screenshot 2024-02-22 at 14 46 42" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/620b2238-5be2-4b14-8624-7b2e3efdd6ad">
