### PR TITLE
CRM457-977: Primary quote QA fixes

### DIFF
--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -71,7 +71,7 @@ module PriorAuthority
         def persist!
           return false unless save_file
 
-          record.update!(attributes.except('id', 'service_type', 'file_upload'))
+          record.update!(attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
         end
 
         def file_is_optional?

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -20,7 +20,11 @@ module PriorAuthority
 
       def service_type_autocomplete
         scope = local_values ? self : application
-        scope.service_type == 'custom' ? scope.custom_service_name : scope.service_type
+        if scope.service_type == 'custom'
+          scope.custom_service_name
+        elsif scope.service_type.present?
+          QuoteServices.new(scope.service_type).translated
+        end
       end
 
       # this should only be used when JS is disabled - otherwise overwritten by service_type_autocomplete_suggestion

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -81,6 +81,13 @@ module PriorAuthority
       def service_rule
         @service_rule ||= ServiceTypeRule.build(service_type)
       end
+
+      def reset_attributes
+        {
+          PER_ITEM => { period: nil, cost_per_hour: nil },
+          PER_HOUR => { items: nil, cost_per_item: nil }
+        }.fetch(cost_type)
+      end
     end
   end
 end

--- a/app/forms/prior_authority/steps/service_cost_form.rb
+++ b/app/forms/prior_authority/steps/service_cost_form.rb
@@ -32,7 +32,7 @@ module PriorAuthority
       private
 
       def persist!
-        record.update!(attributes.except('prior_authority_granted', 'service_type'))
+        record.update!(attributes.except('prior_authority_granted', 'service_type').merge(reset_attributes))
         application.update(prior_authority_granted:)
       end
     end

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -13,7 +13,7 @@ module PriorAuthority
       when QuoteServices::TRANSCRIPTION_RECORDING,
            QuoteServices::TRANSLATION_AND_TRANSCRIPTION
         new(cost_type: :per_item, item: 'minute')
-      when QuoteServices::TRANSLATOR
+      when QuoteServices::TRANSLATION_DOCUMENTS
         new(cost_type: :per_item, item: 'word')
       when QuoteServices::PHOTOCOPYING
         new(cost_type: :per_item, item: 'page')

--- a/app/value_objects/prior_authority/quote_services.rb
+++ b/app/value_objects/prior_authority/quote_services.rb
@@ -99,7 +99,7 @@ module PriorAuthority
       TOXICOLOGIST_REPORT = new(:toxicologist_report),
       TRANSCRIPTION_RECORDING = new(:transcription_recording),
       TRANSLATION_AND_TRANSCRIPTION = new(:translation_and_transcription),
-      TRANSLATOR = new(:translator),
+      TRANSLATION_DOCUMENTS = new(:translation_documents),
       TRAVEL = new(:travel),
       UROLOGIST = new(:urologist),
       VETERINARY_REPORT = new(:veterinary_report),

--- a/app/views/prior_authority/steps/primary_quote_summary/_travel_cost_card.html.erb
+++ b/app/views/prior_authority/steps/primary_quote_summary/_travel_cost_card.html.erb
@@ -16,6 +16,14 @@
   </div>
   <div class="govuk-summary-card__content">
     <% if form.valid? %>
+      <% if form.travel_costs_require_justification? %>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key"><%= t('.why_travel_costs') %></dt>
+            <dd class="govuk-summary-list__value"><%= form.travel_cost_reason %></dd>
+          </div>
+        </dl>
+      <% end %>
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-visually-hidden">
           <%= t('.travel_costs') %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -465,7 +465,7 @@ en:
       toxicologist_report: Toxicologist report
       transcription_recording: Transcription (recording)
       translation_and_transcription: Translation and transcription
-      translator: Translator
+      translation_documents: Translation (documents)
       travel: Travel
       urologist: Urologist
       veterinary_report: Veterinary report

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -141,6 +141,7 @@ en:
           travel_costs: Travel costs
           change: Change
           delete: Delete
+          why_travel_costs: Why travel costs if not detained?
           none_added: No travel costs added
           total: Total
           period: Travel time

--- a/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
       file_upload: file_upload,
       items: '1',
       cost_per_item: '1',
+      period: period,
+      cost_per_hour: cost_per_hour,
+      user_chosen_cost_type: user_chosen_cost_type,
       'travel_time(1)': '',
       'travel_time(2)': '',
       travel_cost_per_hour: travel_cost_per_hour,
@@ -21,6 +24,9 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
     }
   end
 
+  let(:period) { nil }
+  let(:cost_per_hour) { nil }
+  let(:user_chosen_cost_type) { nil }
   let(:travel_cost_per_hour) { '' }
   let(:additional_cost_list) { '' }
   let(:record) { build(:quote, document: nil) }
@@ -94,6 +100,25 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
         subject.save
         expect(subject.errors[:additional_cost_total]).to include(
           'To add additional costs you must enter both a list of the additional costs and the total cost'
+        )
+      end
+    end
+
+    context 'when redundant fields are entered' do
+      let(:period) { 180 }
+      let(:cost_per_hour) { '35' }
+      let(:items) { '3' }
+      let(:cost_per_item) { '20' }
+      let(:user_chosen_cost_type) { 'per_hour' }
+      let(:application) { create(:prior_authority_application, service_type: 'custom') }
+      let(:record) { build(:quote, document: nil, prior_authority_application: application) }
+      let(:file_upload) { nil }
+
+      it 'clears them out' do
+        subject.save
+        expect(record.reload).to have_attributes(
+          items: nil,
+          cost_per_item: nil
         )
       end
     end

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -249,6 +249,64 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
         end
       end
     end
+
+    context 'when the service type is changed' do
+      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:organisation) { 'LAA' }
+      let(:postcode) { 'CR0 1RE' }
+      let(:record) { application.primary_quote }
+      let(:service_type_autocomplete_suggestion) { 'Photocopying' }
+
+      context 'when changed to one with a different item type' do
+        let(:application) do
+          create(:prior_authority_application,
+                 service_type: 'transcription_recording',
+                 quotes: [
+                   build(:quote, :primary, items: 3, cost_per_item: 1.23),
+                   build(:quote, :alternative, items: 3, cost_per_item: 1.25)
+                 ])
+        end
+
+        let(:service_type_autocomplete_suggestion) { 'Photocopying' }
+
+        before { save }
+
+        it 'clears out old item data for all quotes' do
+          expect(application.reload.primary_quote).to have_attributes(
+            items: nil,
+            cost_per_item: nil
+          )
+        end
+
+        it 'removes alternative quotes entirely' do
+          expect(application.alternative_quotes.count).to eq 0
+        end
+      end
+
+      context 'when changed to one with a different cost basis type' do
+        let(:application) do
+          create(:prior_authority_application,
+                 service_type: 'pathologist_report',
+                 quotes: [
+                   build(:quote, :primary, period: 30, cost_per_hour: 1.23),
+                   build(:quote, :alternative, period: 60, cost_per_hour: 1.25)
+                 ])
+        end
+
+        before { save }
+
+        it 'clears out old item data for all quotes' do
+          expect(application.reload.primary_quote).to have_attributes(
+            items: nil,
+            cost_per_item: nil
+          )
+        end
+
+        it 'removes alternative quotes entirely' do
+          expect(application.alternative_quotes.count).to eq 0
+        end
+      end
+    end
   end
 
   describe 'variable assignment order' do

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -269,17 +269,16 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
 
         let(:service_type_autocomplete_suggestion) { 'Photocopying' }
 
-        before { save }
-
-        it 'clears out old item data for all quotes' do
-          expect(application.reload.primary_quote).to have_attributes(
-            items: nil,
-            cost_per_item: nil
+        it 'clears out old item data for primary quote' do
+          expect { save }.to change { application.reload.primary_quote.attributes }.from(
+            hash_including('items' => 3, 'cost_per_item' => 1.23)
+          ).to(
+            hash_including('items' => nil, 'cost_per_item' => nil)
           )
         end
 
         it 'removes alternative quotes entirely' do
-          expect(application.alternative_quotes.count).to eq 0
+          expect { save }.to change(application.alternative_quotes, :count).from(1).to(0)
         end
       end
 
@@ -293,17 +292,16 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
                  ])
         end
 
-        before { save }
-
-        it 'clears out old item data for all quotes' do
-          expect(application.reload.primary_quote).to have_attributes(
-            items: nil,
-            cost_per_item: nil
+        it 'clears out old item data for primary quote' do
+          expect { save }.to change { application.reload.primary_quote.attributes }.from(
+            hash_including('period' => 30, 'cost_per_hour' => 1.23)
+          ).to(
+            hash_including('period' => nil, 'cost_per_hour' => nil)
           )
         end
 
         it 'removes alternative quotes entirely' do
-          expect(application.alternative_quotes.count).to eq 0
+          expect { save }.to change(application.alternative_quotes, :count).from(1).to(0)
         end
       end
     end

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe 'Prior authority applications - add service costs' do
     end
   end
 
-  context 'when the service is Translator' do
-    let(:service_type) { 'Translator' }
+  context 'when the service is Translation (documents)' do
+    let(:service_type) { 'Translation (documents)' }
 
     it 'asks a question about words' do
       expect(page).to have_content 'What is the cost per word?'


### PR DESCRIPTION
## Description of change
When the service type changes, we don't want irrelevant previously-entered values to stick around. So we do more resetting of attributes on quote cost forms and the primary quote form

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-977)
