### PR TITLE
CRM457-979: Make check answers look more like the prototype

### DIFF
--- a/app/presenters/prior_authority/check_answers/base.rb
+++ b/app/presenters/prior_authority/check_answers/base.rb
@@ -49,7 +49,6 @@ module PriorAuthority
         {
           key: {
             text: heading,
-            classes: 'govuk-summary-list__value-width-50'
           },
           value: {
             text:

--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -2,7 +2,7 @@
 <% decision_step_header %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
     <% @report.section_groups.each do |section_group| %>
       <h2 class="govuk-heading-l"><%= section_group[:heading] %></h2>


### PR DESCRIPTION
## Description of change
These discrepancies are also affecting CRM457-1158 (in progress: readonly view of submitted applications)
 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

## Screenshots of changes (if applicable)

### Before changes:
<img width="1168" alt="Screenshot 2024-02-23 at 09 40 55" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/113888736/67302e3c-292d-4762-883b-019ef4fbb227">

### After changes:
<img width="1044" alt="Screenshot 2024-02-23 at 09 40 33" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/113888736/6c1de58a-2f37-4cba-8095-1d08a2e2ae0e">

