### PR TITLE
CRM457-1156: Add custom next_hearing_date error messages

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -113,7 +113,12 @@ en:
           attributes:
             next_hearing:
               inclusion: Select yes if you know the date of the next hearing
-            next_hearing_date: *shared_date_errors
+            next_hearing_date: &shared_next_hearing_date_errors
+              blank: Enter a hearing date
+              invalid: Enter a valid hearing date
+              invalid_day: Enter a valid day
+              invalid_month: Enter a valid month
+              invalid_year: Enter a valid year
             plea:
               inclusion: Select the likely or actual plea
             court_type:
@@ -133,7 +138,7 @@ en:
           attributes:
             next_hearing:
               inclusion: Select yes if you know the date of the next hearing
-            next_hearing_date: *shared_date_errors
+            next_hearing_date: *shared_next_hearing_date_errors
         prior_authority/steps/prison_law_form:
           attributes:
             prison_law:

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
       it 'has expected validation errors on the field' do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
-          .to include('Date cannot be blank')
+          .to include('Enter a hearing date')
       end
     end
   end

--- a/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
+++ b/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
         expect(form.errors.messages.values.flatten)
-          .to contain_exactly('Date cannot be blank')
+          .to contain_exactly('Enter a hearing date')
       end
     end
   end

--- a/spec/system/prior_authority/hearing_details_spec.rb
+++ b/spec/system/prior_authority/hearing_details_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Prior authority applications - add hearing details' do
   it 'validates hearing detail fields' do
     click_on 'Save and continue'
     expect(page)
-      .to have_no_content('Date cannot be blank')
+      .to have_no_content('Enter a hearing date')
       .and have_content('Select the likely or actual plea')
       .and have_content('Select the type of court')
   end

--- a/spec/system/prior_authority/next_hearing_spec.rb
+++ b/spec/system/prior_authority/next_hearing_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Prior authority applications (prison law) - add next hearing' do
 
       choose 'Yes'
       click_on 'Save and continue'
-      expect(page).to have_content('Date cannot be blank')
+      expect(page).to have_content('Enter a hearing date')
     end
   end
 end


### PR DESCRIPTION
## Description of change
Add custom next_hearing_date error messages

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1156)

tweaks from QA

### Before changes:
![Screenshot 2024-02-23 at 11 43 02](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/44800547-092c-4943-97a4-44ae2ebdc0c1)



### After changes:

![Screenshot 2024-02-23 at 11 39 31](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/37f1692c-1d15-43c2-8f10-a27d7ee5a394)
