### PR TITLE
BUG: Fix field missing from payload

### DIFF
--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -74,7 +74,7 @@ class SubmitToAppStore
       ufn
       laa_reference
       status
-      rep_order_data
+      rep_order_date
       reason_why
       main_offence
       client_detained

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         client_detained_prison: 'something',
         subject_to_poca: true,
         next_hearing_date: '2024-01-16',
+        rep_order_date: nil,
         plea: 'something',
         court_type: 'central_criminal_court',
         youth_court: true,


### PR DESCRIPTION
## Description of change
A typo meant we weren't sending the optional 'rep_order_date' field to the app store
