### PR TITLE
Add container `securityContext` to all containers

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -37,6 +37,13 @@ spec:
             - bundle
             - exec
             - sidekiq
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ "ALL" ]
           ports:
             - name: http
               containerPort: {{ .Values.service.workerPort }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
             requests:
               cpu: 10m
               memory: 1Gi
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ "ALL" ]
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -66,6 +73,13 @@ spec:
             preStop:
               exec:
                 command: ["sh", "-c", "sleep 30"] # Workaround for occasional lost requests - see https://github.com/puma/puma/blob/master/docs/kubernetes.md#running-puma-in-kubernetes
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ "ALL" ]
           env:
           {{ if .Values.redis.enabled }}
             - name: REDIS_PROTOCOL


### PR DESCRIPTION
## Description of change
Add container `securityContext` to all containers

To handle deployment warnings:
```
W0226 09:28:18.411693     351 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "laa-claim-non-standard-magistrate-fee-backend-worker" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "laa-claim-non-standard-magistrate-fee-backend-worker" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "laa-claim-non-standard-magistrate-fee-backend-worker" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "laa-claim-non-standard-magistrate-fee-backend-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0226 09:28:18.703983     351 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (containers "clamav", "laa-claim-non-standard-magistrate-fee-backend" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "clamav", "laa-claim-non-standard-magistrate-fee-backend" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "clamav", "laa-claim-non-standard-magistrate-fee-backend" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "clamav", "laa-claim-non-standard-magistrate-fee-backend" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
Release "laa-claim-non-standard-magistrate-fee" has been upgraded. Happy Helming!
```
