### PR TITLE
CRM457-1147: Change dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,30 +3,37 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: wednesday
     time: "03:00"
     timezone: Europe/London
   groups:
-    aws-gems:
+    bundler:
       patterns:
-        - "aws-*"
+        - "*"
   open-pull-requests-limit: 10
-  reviewers:
-    - "ministryofjustice/crm7team"
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
+    day: wednesday
     time: "03:00"
     timezone: Europe/London
   groups:
     npm-babel:
       patterns:
-        - "*babel*"
-    npm-jest:
-      patterns:
-        - "jest*"
+        - "*"
   open-pull-requests-limit: 10
-  reviewers:
-    - "ministryofjustice/crm7team"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: wednesday
+    time: "03:00"
+    timezone: Europe/London
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+  open-pull-requests-limit: 10
 


### PR DESCRIPTION
## Description of change
- Updates come in weekly
- They're fully grouped (we're going to try this, and whenever there's a broken or high-risk update we'll manually pull that out separately. If we end up doing that more times than not, we'll default to _not_ grouping)

## Link to relevant ticket

[CRM457-1147](https://dsdmoj.atlassian.net/browse/CRM457-1147)

[CRM457-1147]: https://dsdmoj.atlassian.net/browse/CRM457-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ