### PR TITLE
CRM457-992: Change format period inline with prototype designs

### DIFF
--- a/gems/laa_multi_step_forms/Gemfile.lock
+++ b/gems/laa_multi_step_forms/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
   specs:
     laa_multi_step_forms (0.1.0)
       devise (~> 4.8)
-      govuk-components
+      govuk-components (>= 5.0.0)
       govuk_design_system_formbuilder (>= 4.0, < 5.3)
       hmcts_common_platform
       omniauth-rails_csrf_protection (~> 1.0.1)

--- a/gems/laa_multi_step_forms/config/locales/en/helpers.yml
+++ b/gems/laa_multi_step_forms/config/locales/en/helpers.yml
@@ -24,9 +24,9 @@ en:
       update_calculation_no_article: Update calculation
     time_period: &period
       hours:
-        one: '%{count} Hour '
-        other: '%{count} Hours '
+        one: '%{count} hour '
+        other: '%{count} hours '
       minutes:
-        one: '%{count} Min'
-        other: '%{count} Mins'
+        one: '%{count} minute'
+        other: '%{count} minutes'
     missing_data: Incomplete

--- a/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
+++ b/gems/laa_multi_step_forms/spec/helpers/application_helper_spec.rb
@@ -105,8 +105,9 @@ RSpec.describe LaaMultiStepForms::ApplicationHelper, type: :helper do
 
     context 'when period is not nil' do
       it 'formats the value in hours and minutes' do
-        expect(helper.format_period(62)).to eq('1 Hour 2 Mins')
-        expect(helper.format_period(1)).to eq('0 Hours 1 Min')
+        expect(helper.format_period(62)).to eq('1 hour 2 minutes')
+        expect(helper.format_period(1)).to eq('0 hours 1 minute')
+        expect(helper.format_period(120)).to eq('2 hours 0 minutes')
       end
     end
   end

--- a/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             },
             {
               head_key: 'time_spent',
-              text: '2 Hours 1 Min'
+              text: '2 hours 1 minute'
             },
             {
               head_key: 'work_before',


### PR DESCRIPTION
## Description of change
Change format period inline with prototype/designs

[link to ticket](https://dsdmoj.atlassian.net/browse/CRM457-1204)
[came out of ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)
[and ticket](https://dsdmoj.atlassian.net/browse/CRM457-1115)

Came out of conversation with content and design who decided
that a consistent approach across NSM and PA on both caseworker
and provider app is preferred and should be

- full word for hours and minutes, lower case
- no leading zeros

### Before changes:
![Screenshot 2024-02-29 at 17 43 07](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/7a53e25e-bc30-4491-9438-688a8ebb34a2)


### After changes:

![Screenshot 2024-02-29 at 17 41 54](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/08c0e1fa-8e8d-4665-9342-416cd26ab69d)

