### PR TITLE
CRM457-979: Correct back button on CYA/UFN pages

### DIFF
--- a/app/services/decisions/back_decision_tree.rb
+++ b/app/services/decisions/back_decision_tree.rb
@@ -53,7 +53,11 @@ module Decisions
     # ---------------------------------
     from('prior_authority/steps/prison_law').goto(edit: 'prior_authority/applications')
     from('prior_authority/steps/authority_value').goto(edit: 'prior_authority/steps/prison_law')
-    from('prior_authority/steps/ufn').goto(edit: 'prior_authority/steps/authority_value')
+    from('prior_authority/steps/ufn')
+      .when(-> { application.status == PriorAuthorityApplication.statuses[:pre_draft] })
+      .goto(edit: 'prior_authority/steps/authority_value')
+      .goto { overwrite_to_cya }
+
     from('prior_authority/steps/case_contact').goto { overwrite_to_cya }
     from('prior_authority/steps/client_detail').goto { overwrite_to_cya }
 

--- a/app/services/decisions/back_decision_tree.rb
+++ b/app/services/decisions/back_decision_tree.rb
@@ -82,5 +82,8 @@ module Decisions
     from(DecisionTree::PRIOR_AUTHORITY_ALTERNATIVE_QUOTES).goto { overwrite_to_cya }
     from('prior_authority/steps/alternative_quote_details')
       .goto(edit: DecisionTree::PRIOR_AUTHORITY_ALTERNATIVE_QUOTES)
+
+    # check answers
+    from('prior_authority/steps/check_answers').goto(show: 'prior_authority/steps/start_page')
   end
 end

--- a/app/views/prior_authority/steps/ufn/edit.html.erb
+++ b/app/views/prior_authority/steps/ufn/edit.html.erb
@@ -1,5 +1,5 @@
 <% title t('.page_title') %>
-<% decision_step_header if @form_object.record.status == PriorAuthorityApplication.statuses[:pre_draft] %>
+<% decision_step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/prior_authority/authority_value_spec.rb
+++ b/spec/system/prior_authority/authority_value_spec.rb
@@ -1,6 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'Prior authority applications - add case contact' do
+RSpec.describe 'Prior authority applications - add authority value' do
   before do
     visit provider_saml_omniauth_callback_path
     visit prior_authority_root_path
@@ -8,7 +8,7 @@ RSpec.describe 'Prior authority applications - add case contact' do
   end
 
   context 'when application relates to a prison law matter' do
-    it 'set authority threshold to £500' do
+    it 'sets authority threshold to £500' do
       expect(page).to have_content 'Is this a Prison Law matter?'
 
       choose 'Yes'
@@ -26,7 +26,7 @@ RSpec.describe 'Prior authority applications - add case contact' do
   end
 
   context 'when application does not relate to a prison law matter' do
-    it 'set authority threshold to £500' do
+    it 'sets authority threshold to £500' do
       expect(page).to have_content 'Is this a Prison Law matter?'
       choose 'No'
       click_on 'Save and continue'

--- a/spec/system/prior_authority/check_your_answers/submission_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/submission_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'Prior authority applications, check your answers, submission' do
       )
   end
 
+  it 'allows me to go back to the tasklist' do
+    click_on 'Back'
+    expect(page).to have_title('Your application progress')
+  end
+
   it 'allows me to save and come back later' do
     click_on 'Save and come back later'
 

--- a/spec/system/prior_authority/ufn_spec.rb
+++ b/spec/system/prior_authority/ufn_spec.rb
@@ -1,0 +1,54 @@
+require 'system_helper'
+
+RSpec.describe 'Prior authority applications - add Unique file number' do
+  context 'when starting a new application' do
+    before do
+      fill_in_until_step(:ufn)
+    end
+
+    it 'has the expected content' do
+      expect(page).to have_title 'Unique file number'
+      expect(page).to have_content 'What is your unique file number?'
+    end
+
+    it 'allows me to go back to the authority value question' do
+      click_on 'Back'
+      expect(page).to have_title('Authority value')
+    end
+
+    it 'allows me to save and continue' do
+      fill_in 'What is your unique file number?', with: '111111/111'
+      click_on 'Save and continue'
+      expect(page).to have_title 'Your application progress'
+    end
+  end
+
+  context 'when coming from the tasklist' do
+    before do
+      fill_in_until_step(:your_application_progress)
+      click_on 'Unique file number'
+    end
+
+    it 'allows me to go back to the tasklist' do
+      expect(page).to have_title 'Unique file number'
+      click_on 'Back'
+      expect(page).to have_title 'Your application progress'
+    end
+  end
+
+  context 'when coming from the check your answers page' do
+    before do
+      fill_in_until_step(:submit_application)
+      click_on 'Submit application'
+      within('.govuk-summary-card', text: 'Application details') do
+        click_on 'Change'
+      end
+    end
+
+    it 'allows me to go back to the check answers page' do
+      expect(page).to have_title 'Unique file number'
+      click_on 'Back'
+      expect(page).to have_title 'Check your answers'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Fixes from QA feedback on CYA page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-979)

- Correct back button on CYA page, to go to taslklist/start_page
- Correct UFN page back button


> What is your unique file number? - we removed the back button from here as it went ‘Back’ to the initial questions that cannot be amended. However, I think we need it back in for consistency. If it is the CYA loop it would go to the CYA page. If it is from the Task List (My app progress) it would return to the Task List page. If it is the intial create app flow then back to the previous form...
