### PR TITLE
Fix error page config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,5 +164,5 @@ Rails.application.routes.draw do
   end
 
   match '*path', to: 'laa_multi_step_forms/errors#not_found', via: :all, constraints:
-    lambda { |_request| Rails.application.config.consider_all_requests_local }
+    lambda { |_request| !Rails.application.config.consider_all_requests_local }
 end


### PR DESCRIPTION
## Description of change
The app was set up so that in develop/test you got a lovely pretty error message when page was not found, but in production you got the ugly rails default. I'm assuming the intention was the opposite of that.