### PR TITLE
Add workaround to missing translation issue and fix defendant card

### DIFF
--- a/app/presenters/nsm/check_answers/base.rb
+++ b/app/presenters/nsm/check_answers/base.rb
@@ -8,7 +8,14 @@ module Nsm
 
       def translate_table_key(table, key, **)
         I18n.t("nsm.steps.check_answers.show.sections.#{table}.#{key}", **)
+      # :nocov:
+      rescue I18n::MissingTranslationData => e
+        # TODO: remove as part of CRM457-1183.
+        # This hack is a continuation of the hack on line 34, adjusting it to cope with the fact
+        # that in some environments (notably dev), we raise on missing translation errors
+        e.message
       end
+      # :nocov:
 
       def title(**)
         I18n.t("nsm.steps.check_answers.groups.#{group}.#{section}.title", **)
@@ -26,8 +33,7 @@ module Nsm
 
       def row_content(head_key, text, head_opts = {}, footer: false)
         translated_heading = translate_table_key(section, head_key, **head_opts)
-        # TODO: remove the below line once we understand why it was added as this is a smell
-        # as all keys should have a translation.
+        # TODO: remove the below line once we have implemented CRM457-1183.
         heading = translated_heading.start_with?('Translation missing:') ? head_key : translated_heading
         row = {
           key: {

--- a/app/presenters/nsm/check_answers/defendant_card.rb
+++ b/app/presenters/nsm/check_answers/defendant_card.rb
@@ -22,7 +22,8 @@ module Nsm
       private
 
       def generate_rows(key_prefix, defendant, index)
-        data = [row(key_prefix, :full_name, defendant, index)]
+        data = [row(key_prefix, :first_name, defendant, index),
+                row(key_prefix, :last_name, defendant, index)]
 
         data << row(key_prefix, :maat, defendant, index) if maat_required
 

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -32,9 +32,11 @@ en:
               contact_full_name: Contact full name
               contact_email: Contact email address
             defendant_summary:
-              main_defendant_full_name: Main defendant full name
+              main_defendant_first_name: Main defendant first name
+              main_defendant_last_name: Main defendant last name
               main_defendant_maat: Main defendant MAAT ID
-              additional_defendant_full_name: Additional defendant %{count} full name
+              additional_defendant_first_name: Additional defendant %{count} first name
+              additional_defendant_last_name: Additional defendant %{count} last name
               additional_defendant_maat: Additional defendant %{count} MAAT ID
             case_details:
               main_offence: Main offence name

--- a/spec/presenters/nsm/check_answers/defendant_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/defendant_card_spec.rb
@@ -5,19 +5,33 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
 
   let(:claim) { instance_double(Claim, claim_type:, defendants:) }
   let(:defendants) { [] }
-  let(:main_defendant) { { main: true, full_name: main_defendant_name, maat: main_defendant_maat } }
+  let(:main_defendant) do
+    { main: true,
+     first_name: main_defendant_first_name,
+     last_name: main_defendant_last_name,
+     maat: main_defendant_maat }
+  end
   let(:first_additional_defendant) do
-    { main: false, full_name: first_additional_defendant_name, maat: first_additional_defendant_maat }
+    { main: false,
+     first_name: first_additional_defendant_first_name,
+     last_name: first_additional_defendant_last_name,
+     maat: first_additional_defendant_maat }
   end
   let(:second_additional_defendant) do
-    { main: false, full_name: second_additional_defendant_name, maat: second_additional_defendant_maat }
+    { main: false,
+      first_name: second_additional_defendant_first_name,
+      last_name: second_additional_defendant_last_name,
+      maat: second_additional_defendant_maat }
   end
 
-  let(:main_defendant_name) { 'Tim Roy' }
+  let(:main_defendant_first_name) { 'Tim' }
+  let(:main_defendant_last_name) { 'Roy' }
   let(:main_defendant_maat) { '123ABC' }
-  let(:first_additional_defendant_name) { 'James Brown' }
+  let(:first_additional_defendant_first_name) { 'James' }
+  let(:first_additional_defendant_last_name) { 'Brown' }
   let(:first_additional_defendant_maat) { '456EFG' }
-  let(:second_additional_defendant_name) { 'Timmy Turner' }
+  let(:second_additional_defendant_first_name) { 'Timmy' }
+  let(:second_additional_defendant_last_name) { 'Turner' }
   let(:second_additional_defendant_maat) { '789HIJ' }
 
   let(:claim_type) { ClaimType::NON_STANDARD_MAGISTRATE.to_s }
@@ -43,8 +57,13 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
         expect(subject.row_data).to eq(
           [
             {
-              head_key: 'main_defendant_full_name',
-              text: 'Tim Roy',
+              head_key: 'main_defendant_first_name',
+              text: 'Tim',
+              head_opts: { count: 1 },
+            },
+            {
+              head_key: 'main_defendant_last_name',
+              text: 'Roy',
               head_opts: { count: 1 },
             },
             {
@@ -53,8 +72,13 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
               head_opts: { count: 1 },
             },
             {
-              head_key: 'additional_defendant_full_name',
-              text: 'James Brown',
+              head_key: 'additional_defendant_first_name',
+              text: 'James',
+              head_opts: { count: 1 }
+            },
+            {
+              head_key: 'additional_defendant_last_name',
+              text: 'Brown',
               head_opts: { count: 1 }
             },
             {
@@ -63,8 +87,13 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
               head_opts: { count: 1 }
             },
             {
-              head_key: 'additional_defendant_full_name',
-              text: 'Timmy Turner',
+              head_key: 'additional_defendant_first_name',
+              text: 'Timmy',
+              head_opts: { count: 2 }
+            },
+            {
+              head_key: 'additional_defendant_last_name',
+              text: 'Turner',
               head_opts: { count: 2 }
             },
             {
@@ -84,20 +113,35 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
           expect(subject.row_data).to eq(
             [
               {
-                head_key: 'main_defendant_full_name',
-                text: 'Tim Roy',
+                head_key: 'main_defendant_first_name',
+                text: 'Tim',
                 head_opts: { count: 1 },
               },
               {
-                head_key: 'additional_defendant_full_name',
-                text: 'James Brown',
+                head_key: 'main_defendant_last_name',
+                text: 'Roy',
+                head_opts: { count: 1 },
+              },
+              {
+                head_key: 'additional_defendant_first_name',
+                text: 'James',
                 head_opts: { count: 1 }
               },
               {
-                head_key: 'additional_defendant_full_name',
-                text: 'Timmy Turner',
+                head_key: 'additional_defendant_last_name',
+                text: 'Brown',
+                head_opts: { count: 1 }
+              },
+              {
+                head_key: 'additional_defendant_first_name',
+                text: 'Timmy',
                 head_opts: { count: 2 }
               },
+              {
+                head_key: 'additional_defendant_last_name',
+                text: 'Turner',
+                head_opts: { count: 2 }
+              }
             ]
           )
         end
@@ -107,11 +151,16 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
     context 'no defendants' do
       let(:defendants) { [] }
 
-      it 'generates full name and maat for 1 main defendant' do
+      it 'generates missing info lines' do
         expect(subject.row_data).to eq(
           [
             {
-              head_key: 'main_defendant_full_name',
+              head_key: 'main_defendant_first_name',
+              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>',
+              head_opts: { count: 1 },
+            },
+            {
+              head_key: 'main_defendant_last_name',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>',
               head_opts: { count: 1 },
             },
@@ -132,10 +181,16 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
         expect(subject.row_data).to eq(
           [
             {
-              head_key: 'main_defendant_full_name',
-              text: 'Tim Roy',
+              head_key: 'main_defendant_first_name',
+              text: 'Tim',
               head_opts: { count: 1 },
             },
+            {
+              head_key: 'main_defendant_last_name',
+              text: 'Roy',
+              head_opts: { count: 1 },
+            },
+
             {
               head_key: 'main_defendant_maat',
               text: '123ABC',
@@ -152,10 +207,16 @@ RSpec.describe Nsm::CheckAnswers::DefendantCard do
           expect(subject.row_data).to eq(
             [
               {
-                head_key: 'main_defendant_full_name',
-                text: 'Tim Roy',
+                head_key: 'main_defendant_first_name',
+                text: 'Tim',
                 head_opts: { count: 1 },
               },
+              {
+                head_key: 'main_defendant_last_name',
+                text: 'Roy',
+                head_opts: { count: 1 },
+              },
+
               {
                 head_key: 'main_defendant_maat',
                 text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>',


### PR DESCRIPTION
## Description of change
The 'check answers' screen for NSM was showing 'incomplete' for defendants because the card expected a "full_name" field and the model only had "first_name" and "last_name" (and the test strategy is so heavily dependent on unit tests that mock everything they interact with that this mismatch wasn't shown up). This fixes the card.

For bonus points, it adds a more thorough workaround and documentation for the bug where the check answers screen explodes in dev because things that are not translation keys are being passed round as translation keys.
