### PR TITLE
CRM457-1214: Check gatekeeper when displaying start page links

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,9 @@ class HomeController < ApplicationController
   skip_before_action :can_access_service, only: :dev_login
   layout 'submit_a_crime_form'
 
+  def index
+    @gatekeeper = Providers::Gatekeeper.new(current_provider)
+  end
+
   def dev_login; end
 end

--- a/app/services/providers/gatekeeper.rb
+++ b/app/services/providers/gatekeeper.rb
@@ -3,6 +3,7 @@ module Providers
   class Gatekeeper
     ANY_SERVICE = :any
     PAA = :crm4
+    EOL = :crm5
     NSM = :crm7
 
     attr_reader :auth_info

--- a/app/views/home/index.en.html.erb
+++ b/app/views/home/index.en.html.erb
@@ -9,24 +9,29 @@
     <p>
       <%= t('.introduction_html', eforms_link: link_to(t('.eforms'), "https://portal.legalservices.gov.uk/")) %>
     </p>
-    <h2 class="govuk-heading-s">
-      <%= link_to t('.pa_header'), prior_authority_applications_path, class: "govuk-link--no-visited-state", data: { turbo: false } %>
-    </h2>
-    <p>
-      <%= t('.pa_text') %>
-    </p>
-    <h2 class="govuk-heading-s">
-      <%= link_to t('.eol_header'), ENV['EOL_URL'], class: "govuk-link--no-visited-state", data: { turbo: false } %>
-    </h2>
-    <p>
-      <%= t('.eol_text') %>
-    </p>
-    <h2 class="govuk-heading-s">
-      <%= link_to t('.nsm_header'), nsm_start_path, class: "govuk-link--no-visited-state", data: { turbo: false } %>
-    </h2>
-    <p>
-      <%= t('.nsm_text') %>
-    </p>
-
+    <% if @gatekeeper.provider_enrolled?(service: Providers::Gatekeeper::PAA) %>
+      <h2 class="govuk-heading-s">
+        <%= link_to t('.pa_header'), prior_authority_applications_path, class: "govuk-link--no-visited-state", data: { turbo: false } %>
+      </h2>
+      <p>
+        <%= t('.pa_text') %>
+      </p>
+    <% end %>
+    <% if @gatekeeper.provider_enrolled?(service: Providers::Gatekeeper::EOL) %>
+      <h2 class="govuk-heading-s">
+        <%= link_to t('.eol_header'), ENV['EOL_URL'], class: "govuk-link--no-visited-state", data: { turbo: false } %>
+      </h2>
+      <p>
+        <%= t('.eol_text') %>
+      </p>
+    <% end %>
+    <% if @gatekeeper.provider_enrolled?(service: Providers::Gatekeeper::NSM) %>
+      <h2 class="govuk-heading-s">
+        <%= link_to t('.nsm_header'), nsm_start_path, class: "govuk-link--no-visited-state", data: { turbo: false } %>
+      </h2>
+      <p>
+        <%= t('.nsm_text') %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/config/gatekeeper.yml
+++ b/config/gatekeeper.yml
@@ -6,28 +6,29 @@
 #
 localhost:
   office_codes:
-    1A123B: ['crm7', 'crm4']
-    1K022G: ['crm7', 'crm4']
-    AAAAAA: ['crm7', 'crm4']
-    0A719G: ['crm7', 'crm4']
+    1A123B: ['crm7', 'crm4', 'crm5']
+    1K022G: ['crm7', 'crm4', 'crm5']
+    AAAAAA: ['crm7', 'crm4', 'crm5']
+    0A719G: ['crm7', 'crm4', 'crm5']
     AAAAAA: ['crm7']
     BBBBBB: ['crm4']
+    CCCCCC: ['crm5']
 
 development:
   office_codes:
-    1A123B: ['crm7', 'crm4']
-    1K022G: ['crm7', 'crm4']
+    1A123B: ['crm7', 'crm4', 'crm5']
+    1K022G: ['crm7', 'crm4', 'crm5']
     AAAAAA: ['crm7', 'crm4']
-    0A719G: ['crm7', 'crm4']
+    0A719G: ['crm7', 'crm4', 'crm5']
 
 uat:
   office_codes:
-    1A123B: ['crm7', 'crm4']
-    1K022G: ['crm7', 'crm4']
-    AAAAAA: ['crm7', 'crm4']
-    0A719G: ['crm7', 'crm4']
-    0Z981E: ['crm7', 'crm4']
+    1A123B: ['crm7', 'crm4', 'crm5']
+    1K022G: ['crm7', 'crm4', 'crm5']
+    AAAAAA: ['crm7', 'crm4', 'crm5']
+    0A719G: ['crm7', 'crm4', 'crm5']
+    0Z981E: ['crm7', 'crm4', 'crm5']
 
 production:
   office_codes:
-    2N232W: ['crm7', 'crm4'] # dummy user/office
+    2N232W: ['crm7', 'crm4', 'crm5'] # dummy user/office

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -16,13 +16,19 @@ FactoryBot.define do
       base_office_codes { [] }
     end
 
+    trait :eol_access do
+      eol_office_codes { ['CCCCCC'] }
+      base_office_codes { [] }
+    end
+
     transient do
       selected_office_code { office_codes[0] }
       selected_office_codes do
-        [*paa_office_codes, *nsm_office_codes, *base_office_codes]
+        [*paa_office_codes, *nsm_office_codes, *base_office_codes, *eol_office_codes]
       end
       paa_office_codes { [] }
       nsm_office_codes { [] }
+      eol_office_codes { [] }
       base_office_codes { ['1A123B'] }
     end
   end

--- a/spec/system/access_spec.rb
+++ b/spec/system/access_spec.rb
@@ -47,7 +47,22 @@ RSpec.describe 'System Access', type: :system do
       expect(page).to have_current_path(root_path)
     end
 
-    context 'selectes an alternative office code that does not have access' do
+    it 'can view NSM link on home page' do
+      visit root_path
+      expect(page).to have_content "Claim non-standard magistrates' court payments"
+    end
+
+    it 'cannot view PAA link on home page' do
+      visit root_path
+      expect(page).to have_no_content 'Apply for prior authority to incur disbursements'
+    end
+
+    it 'cannot view EOL link on home page' do
+      visit root_path
+      expect(page).to have_no_content 'Apply for extension of upper limits'
+    end
+
+    context 'selects an alternative office code that does not have access' do
       it 'can access NSM' do
         visit nsm_applications_path
         expect(page).to have_content('Your claims')
@@ -75,6 +90,21 @@ RSpec.describe 'System Access', type: :system do
       expect(page).to have_content('Your applications')
     end
 
+    it 'cannot view NSM link on home page' do
+      visit root_path
+      expect(page).to have_no_content "Claim non-standard magistrates' court payments"
+    end
+
+    it 'can view PAA link on home page' do
+      visit root_path
+      expect(page).to have_content 'Apply for prior authority to incur disbursements'
+    end
+
+    it 'cannot view EOL link on home page' do
+      visit root_path
+      expect(page).to have_no_content 'Apply for extension of upper limits'
+    end
+
     context 'selectes an alternative office code that does not have access' do
       it 'can not access NSM' do
         visit nsm_applications_path
@@ -89,8 +119,8 @@ RSpec.describe 'System Access', type: :system do
     end
   end
 
-  context 'user with office codes with access to neither NSM or PAA' do
-    let(:provider) { create(:provider, office_codes: ['CCCCCC']) }
+  context 'user with office codes with access to neither NSM, PAA nor EOL' do
+    let(:provider) { create(:provider, office_codes: ['DDDDD']) }
 
     it 'can not access NSM' do
       visit nsm_applications_path
@@ -116,6 +146,36 @@ RSpec.describe 'System Access', type: :system do
         expect(page).to have_no_content('Your Applications')
         expect(page).to have_current_path(new_provider_session_path)
       end
+    end
+  end
+
+  context 'user with office codes with access to EOL only' do
+    let(:provider) { create(:provider, :eol_access) }
+
+    it 'cannot access NSM' do
+      visit nsm_applications_path
+      expect(page).to have_no_content('Your claims')
+      expect(page).to have_current_path(root_path)
+    end
+
+    it 'cannot access PAA' do
+      visit prior_authority_applications_path
+      expect(page).to have_current_path(root_path)
+    end
+
+    it 'cannot view NSM link on home page' do
+      visit root_path
+      expect(page).to have_no_content "Claim non-standard magistrates' court payments"
+    end
+
+    it 'cannot view PAA link on home page' do
+      visit root_path
+      expect(page).to have_no_content 'Apply for prior authority to incur disbursements'
+    end
+
+    it 'can view EOL link on home page' do
+      visit root_path
+      expect(page).to have_content 'Apply for extension of upper limits'
     end
   end
 end


### PR DESCRIPTION
## Description of change
Only show links on start page if a provider can access them.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1214)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
