### PR TITLE
CRM457-993: Remove convenience attributes from PA payload

### DIFF
--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -26,7 +26,7 @@ class SubmitToAppStore
         defendant:,
         quotes:,
         additional_costs:,
-      ).merge(convenience_attributes)
+      )
     end
 
     def direct_attributes
@@ -59,13 +59,6 @@ class SubmitToAppStore
 
     def additional_costs
       PriorAuthority::AdditionalCostPayloadBuilder.new(application).payload
-    end
-
-    def convenience_attributes
-      {
-        firm_name: application.firm_office.name,
-        client_name: application.defendant.full_name
-      }
     end
 
     DIRECT_ATTRIBUTES = %i[

--- a/spec/forms/prior_authority/steps/check_answers_form_spec.rb
+++ b/spec/forms/prior_authority/steps/check_answers_form_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
     end
   end
 
-  describe '#save ("Accept and send")' do
+  describe '#save ("Accept and send")', :stub_oauth_token do
     subject(:save) { form.save }
 
     let(:application) { create(:prior_authority_application, status: 'draft') }

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         office_code: '1A123B',
         service_type: 'pathologist_report',
         custom_service_name: nil,
-        firm_name: 'Firm A',
-        client_name: 'bob jim',
         prior_authority_granted: false,
         no_alternative_quote_reason: 'a reason',
         confirm_excluding_vat: true,


### PR DESCRIPTION
## Description of change
Remove convenience attributes firm_name and client_name from PA payload

[Related to ticket](https://dsdmoj.atlassian.net/browse/CRM457-993)

The client name and firm_name are already available in the payload
nested under defendant and firm_office respecctively. The caseworker app
can locate and use them there. removing them from the payload creates
a single flexible source of truth for these details.

## Notes for reviewer
This came out of [PR for related applications in Assess](https://github.com/ministryofjustice/laa-assess-crime-forms/pull/341) and was
agreed on by patrick and joel as a way forward.