### PR TITLE
CRM457-992: Add custom item type specific cost error messages

### DIFF
--- a/app/forms/prior_authority/quote_cost_validations.rb
+++ b/app/forms/prior_authority/quote_cost_validations.rb
@@ -10,8 +10,8 @@ module PriorAuthority
                 if: :variable_cost_type?
 
       with_options if: :per_item? do
-        validates :items, presence: true, numericality: { greater_than: 0 }, is_a_number: true
-        validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, is_a_number: true
+        validates :items, item_type_dependant: { pluralize: true }
+        validates :cost_per_item, item_type_dependant: true
       end
 
       with_options if: :per_hour? do

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -1,0 +1,14 @@
+class ItemTypeDependantValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    item_type = item_type_for(record)
+    item_type = item_type.pluralize if options[:pluralize]
+
+    record.errors.add(attribute, :blank, item_type:) if value.blank?
+    record.errors.add(attribute, :not_a_number, item_type:) if value.is_a?(String)
+    record.errors.add(attribute, :greater_than, item_type:) if value.to_i <= 0
+  end
+
+  def item_type_for(record)
+    record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
+  end
+end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -192,13 +192,13 @@ en:
               greater_than: The hourly cost must be more than 0
               not_a_number: The cost per hour must be a number, like 25
             items:
-              blank: Enter the number of items
-              greater_than: The number of items must be more than 0
-              not_a_number: The number of items must be a number, like 25
+              blank: Enter the number of %{item_type}
+              greater_than: The number of %{item_type} must be more than 0
+              not_a_number: The number of %{item_type} must be a number, like 25
             cost_per_item:
-              blank: Enter the cost per item
-              greater_than: The cost per item must be more than 0
-              not_a_number: The cost per item must be a number, like 25
+              blank: Enter the cost per %{item_type}
+              greater_than: The cost per %{item_type} must be more than 0
+              not_a_number: The cost per %{item_type} must be a number, like 25
         prior_authority/steps/travel_detail_form:
           attributes:
             travel_cost_reason:

--- a/config/locales/en/prior_authority/alternative_quotes.yml
+++ b/config/locales/en/prior_authority/alternative_quotes.yml
@@ -88,13 +88,13 @@ en:
               greater_than: The hourly cost must be more than 0
               not_a_number: The hourly cost must be a number, like 25
             items:
-              blank: Enter the number of items
-              greater_than: The number of items must be more than 0
-              not_a_number: The number of items must be a number, like 25
+              blank: Enter the number of %{item_type}
+              greater_than: The number of %{item_type} must be more than 0
+              not_a_number: The number of %{item_type} must be a number, like 25
             cost_per_item:
-              blank: Enter the cost per item
-              greater_than: The cost per item must be more than 0
-              not_a_number: The cost must be a number, like 25
+              blank: Enter the cost per %{item_type}
+              greater_than: The cost per %{item_type} must be more than 0
+              not_a_number: The cost per %{item_type} must be a number, like 25
             travel_time:
               invalid: Travel time must be valid
               blank: To add travel costs you must enter both the time and the hourly cost

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -76,6 +76,11 @@ FactoryBot.define do
       end
     end
 
+    trait :with_primary_quote_per_item do
+      with_primary_quote
+      primary_quote factory: %i[quote primary_per_item], strategy: :build
+    end
+
     trait :with_confirmations do
       confirm_excluding_vat { true }
       confirm_travel_expenditure { true }

--- a/spec/factories/quote.rb
+++ b/spec/factories/quote.rb
@@ -22,6 +22,16 @@ FactoryBot.define do
       primary { true }
     end
 
+    trait :primary_per_item do
+      primary { true }
+      related_to_post_mortem { nil }
+      cost_per_hour { nil }
+      period { nil }
+      cost_per_item { 10 }
+      items { 100 }
+      user_chosen_cost_type { 'per_item' }
+    end
+
     trait :alternative do
       primary { false }
     end

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -155,4 +155,61 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       expect(page).to have_content 'Alternative quotesCompleted'
     end
   end
+
+  context 'when i have a item type specific primary quote' do
+    let(:application) do
+      create(:prior_authority_application, :with_primary_quote_per_item, service_type:)
+    end
+
+    before do
+      click_on 'Alternative quotes'
+      choose 'Yes'
+      click_on 'Save and continue'
+    end
+
+    context 'with Translation (documents) service' do
+      let(:service_type) { 'translation_documents' }
+
+      it 'asks a question about words' do
+        expect(page).to have_content 'What is the cost per word?'
+      end
+
+      it 'validates appropriately with partial data' do
+        click_on 'Save and continue'
+        expect(page)
+          .to have_content('Enter the number of words')
+          .and have_content('Enter the cost per word')
+      end
+    end
+
+    context 'with Photocopying service' do
+      let(:service_type) { 'photocopying' }
+
+      it 'asks a question about pages' do
+        expect(page).to have_content 'What is the cost per page?'
+      end
+
+      it 'validates appropriately with partial data' do
+        click_on 'Save and continue'
+        expect(page)
+          .to have_content('Enter the number of pages')
+          .and have_content('Enter the cost per page')
+      end
+    end
+
+    context 'with Translation and transcription service' do
+      let(:service_type) { 'translation_and_transcription' }
+
+      it 'asks a question about minutes' do
+        expect(page).to have_content 'What is the cost per minute?'
+      end
+
+      it 'validates appropriately with partial data' do
+        click_on 'Save and continue'
+        expect(page)
+          .to have_content('Enter the number of minutes')
+          .and have_content('Enter the cost per minute')
+      end
+    end
+  end
 end

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe 'Prior authority applications - add service costs' do
     it 'asks a question about minutes' do
       expect(page).to have_content 'What is the cost per minute?'
     end
+
+    it 'validates appropriately with partial data' do
+      click_on 'Save and continue'
+      expect(page)
+        .to have_content('Enter the number of minutes')
+        .and have_content('Enter the cost per minute')
+    end
   end
 
   context 'when the service is Translation (documents)' do
@@ -40,13 +47,27 @@ RSpec.describe 'Prior authority applications - add service costs' do
     it 'asks a question about words' do
       expect(page).to have_content 'What is the cost per word?'
     end
+
+    it 'validates appropriately with partial data' do
+      click_on 'Save and continue'
+      expect(page)
+        .to have_content('Enter the number of words')
+        .and have_content('Enter the cost per word')
+    end
   end
 
   context 'when the service is Photocopying' do
     let(:service_type) { 'Photocopying' }
 
-    it 'asks a question about words' do
+    it 'asks a question about pages' do
       expect(page).to have_content 'What is the cost per page?'
+    end
+
+    it 'validates appropriately with partial data' do
+      click_on 'Save and continue'
+      expect(page)
+        .to have_content('Enter the number of pages')
+        .and have_content('Enter the cost per page')
     end
   end
 

--- a/spec/validators/item_type_dependant_validator_spec.rb
+++ b/spec/validators/item_type_dependant_validator_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe ItemTypeDependantValidator do
+  subject(:instance) { klass.new(items:, cost_per_item:) }
+
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, 'temp')
+      end
+
+      attribute :items
+      attribute :cost_per_item, :gbp
+
+      validates :items, item_type_dependant: { pluralize: true }
+      validates :cost_per_item, item_type_dependant: true
+    end
+  end
+
+  context 'when attribute is a positive number' do
+    let(:items) { 1 }
+    let(:cost_per_item) { 100 }
+
+    it 'form object is valid' do
+      expect(instance).to be_valid
+    end
+  end
+
+  context 'when attribute is nil' do
+    let(:items) { nil }
+    let(:cost_per_item) { nil }
+
+    it 'adds blank error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :blank)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :blank)).to be(true)
+    end
+
+    it 'adds item_type option to error object' do
+      instance.validate
+      expect(instance.errors.map(&:options)).to all(include(:item_type))
+    end
+  end
+
+  context 'when attribute is a string' do
+    let(:items) { 'one' }
+    let(:cost_per_item) { '100 hundred' }
+
+    it 'adds not_a_number error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :not_a_number)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :not_a_number)).to be(true)
+    end
+  end
+
+  context 'when attribute is less zero or less' do
+    let(:items) { 0 }
+    let(:cost_per_item) { 0 }
+
+    it 'adds greater_than error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :greater_than)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
+    end
+  end
+
+  context 'when model has an item_type attribute' do
+    subject(:instance) { klass.new(items:, cost_per_item:, item_type:) }
+
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, 'temp')
+        end
+
+        attribute :item_type, :string
+
+        attribute :items
+        attribute :cost_per_item, :gbp
+
+        validates :items, item_type_dependant: { pluralize: true }
+        validates :cost_per_item, item_type_dependant: true
+      end
+    end
+
+    context 'when attribute is nil' do
+      let(:items) { nil }
+      let(:cost_per_item) { nil }
+      let(:item_type) { 'word' }
+
+      it 'include item type option from model, pluralizing if option set' do
+        instance.validate
+        expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
+        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('word')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add item cost error messages

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)

Inline designs/content for error messages and QA feedback. This can/ should also be applied to provider

Reference:
see [assess PR](https://github.com/ministryofjustice/laa-assess-crime-forms/pull/347) 
