### PR TITLE
Move docker image scan to run in parrallel to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ workflows:
             - rspec-gem-tests
       - scan-docker-image:
           requires:
-            - rspec-tests
+            - build-test-container
 
   build-opened-pr:
     jobs:


### PR DESCRIPTION
## Description of change
Move docker image scan to run in parallel to tests

To reduce the time overhead since the scan takes as long or longer
than the test suite run.

This is inline with [assess pipeline changes](https://github.com/ministryofjustice/laa-assess-crime-forms/pull/354)

## Screenshots of changes (if applicable)

![Screenshot 2024-03-15 at 14 07 40](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/b353c45f-97fd-49bc-990f-1d8a80d6edfc)
