### PR TITLE
Use pgrep to probe sidekiq for liveness/readiness

### DIFF
--- a/bin/sidekiq_health_check
+++ b/bin/sidekiq_health_check
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+module Worker
+  def self.healthcheck
+    abort 'sidekiq not found' unless system('pgrep -f sidekiq')
+  end
+end
+
+Worker.healthcheck

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -49,17 +49,15 @@ spec:
               containerPort: {{ .Values.service.workerPort }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
-              port: {{ .Values.service.workerPort }}
-            initialDelaySeconds: 20
-            periodSeconds: 30
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 60
+            periodSeconds: 5
           readinessProbe:
-            httpGet:
-              path: /
-              port: {{ .Values.service.workerPort }}
-            initialDelaySeconds: 20
-            periodSeconds: 30
+            exec:
+              command: ['bin/sidekiq_health_check']
+            initialDelaySeconds: 60
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
## Description of change
Use pgrep to probe sidekiq for liveness/readiness

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1248)

We should really be testing if sidekiq is available for liveness and readiness, rather
than any root path available on the worker (which may just be the sidekiq webUI root path 🤷) 