### PR TITLE
Automate deployment to prod for main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,20 +431,8 @@ workflows:
           context: laa-submit-crime-forms-dev
           requires:
             - build-to-ecr
-      - hold-uat:
-          type: approval
-          requires:
-            - build-to-ecr
-          filters:
-            branches:
-              only:
-                - main
       - deploy-uat:
           context: laa-submit-crime-forms-uat
-          requires:
-            - hold-uat
-      - hold-prod:
-          type: approval
           requires:
             - build-to-ecr
           filters:
@@ -454,7 +442,7 @@ workflows:
       - deploy-prod:
           context: laa-submit-crime-forms-production
           requires:
-            - hold-prod
+            - deploy-uat
           filters:
             branches:
               only:


### PR DESCRIPTION

## Description of change
Automate deployment to prod for main

Until we go to private beta, and perhaps even after that,
we might as well deploy to UAT and then production automatically.

This will:
- expose any deployment issues immediatley on a per merge basis
- not incur overhead of devs remebering to deploy
