### PR TITLE
CRM457-1102: Correct recipient for submitted notification

### DIFF
--- a/app/mailers/prior_authority/submission_mailer.rb
+++ b/app/mailers/prior_authority/submission_mailer.rb
@@ -19,7 +19,7 @@ module PriorAuthority
     private
 
     def email_recipient
-      @application.provider.email
+      @application.solicitor.contact_email
     end
 
     def case_reference

--- a/spec/mailers/prior_authority/submission_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_mailer_spec.rb
@@ -5,8 +5,14 @@ require 'rails_helper'
 RSpec.describe PriorAuthority::SubmissionMailer, type: :mailer do
   let(:feedback_template) { 'd07d03fd-65d0-45e4-8d49-d4ee41efad35' }
   let(:application) do
-    create(:prior_authority_application, :with_defendant, :with_created_primary_quote, :with_created_alternative_quote,
-           :with_ufn)
+    create(
+      :prior_authority_application,
+      :with_firm_and_solicitor,
+      :with_defendant,
+      :with_created_primary_quote,
+      :with_created_alternative_quote,
+      :with_ufn
+    )
   end
 
   describe '#notify' do
@@ -16,8 +22,8 @@ RSpec.describe PriorAuthority::SubmissionMailer, type: :mailer do
       expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
     end
 
-    it 'sets the recipient from config' do
-      expect(mail.to).to eq(['provider@example.com'])
+    it 'sets the recipient to solicitors contact email' do
+      expect(mail.to).to eq(['james@email.com'])
     end
 
     it 'sets the template' do


### PR DESCRIPTION

## Description of change
Correct recipient for submitted notification

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1102)

Although a provider will be associated with an application
they also specify a case contact per application. This contact
should be used for notification purposes related to the case.
