### PR TITLE
Do not inline sidekiq for bin/dev

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -35,3 +35,5 @@ CLAMBY_ENABLED=true
 GOVUK_NOTIFY_API_KEY=not-a-real-key
 
 EOL_URL=https://apply-for-extension-of-upper-limits.dev.form.service.justice.gov.uk/
+
+RUN_SIDEKIQ_IN_TEST_MODE=true

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3001
+web: RUN_SIDEKIQ_IN_TEST_MODE=false bin/rails server -p 3001
 js: yarn build --watch
 css: yarn build:css --watch
 sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,7 +16,7 @@ Sidekiq.default_job_options = { retry: 5 }
 # Perform Sidekiq jobs immediately in development,
 # so you don't have to run a separate process.
 # You'll also benefit from code reloading.
-if Rails.env.development?
+if ENV.fetch('RUN_SIDEKIQ_IN_TEST_MODE', false) == "true"
   require 'sidekiq/testing'
   Sidekiq::Testing.inline!
 end


### PR DESCRIPTION
## Description of change
Do not inline sidekiq for bin/dev

So it behaves as a hosted environments sidekiq worker
as expected and stats are updated.

without this the job will be processed inline with the side
effect that stats on the webui are not updated.
