### PR TITLE
CRM457-1033: Remove feedback URL from submission mailer

### DIFF
--- a/app/mailers/nsm/submission_mailer.rb
+++ b/app/mailers/nsm/submission_mailer.rb
@@ -12,7 +12,6 @@ module Nsm
         defendant_reference: defendant_reference_string,
         claim_total: claim_total,
         date: submission_date,
-        feedback_url: feedback_url
       )
       mail(to: email_recipient)
     end
@@ -64,10 +63,6 @@ module Nsm
 
     def submission_date
       DateTime.now.to_fs(:stamp)
-    end
-
-    def feedback_url
-      Rails.configuration.x.contact.feedback_url
     end
   end
 end

--- a/app/mailers/prior_authority/submission_mailer.rb
+++ b/app/mailers/prior_authority/submission_mailer.rb
@@ -11,7 +11,6 @@ module PriorAuthority
         defendant_name: @application.defendant.full_name,
         application_total: application_total,
         date: submission_date,
-        feedback_url: feedback_url
       )
       mail(to: email_recipient)
     end
@@ -36,10 +35,6 @@ module PriorAuthority
 
     def submission_date
       DateTime.now.to_fs(:stamp)
-    end
-
-    def feedback_url
-      Rails.configuration.x.contact.feedback_url
     end
   end
 end

--- a/spec/mailers/nsm/submission_mailer_spec.rb
+++ b/spec/mailers/nsm/submission_mailer_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Nsm::SubmissionMailer, type: :mailer do
           defendant_reference: 'MAAT ID: AA1',
           claim_total: '£20.45',
           date: DateTime.now.to_fs(:stamp),
-          feedback_url: 'tbc'
         )
       end
     end
@@ -52,7 +51,6 @@ RSpec.describe Nsm::SubmissionMailer, type: :mailer do
           defendant_reference: "Client's CNTP number: CNTP12345",
           claim_total: '£20.45',
           date: DateTime.now.to_fs(:stamp),
-          feedback_url: 'tbc'
         )
       end
     end

--- a/spec/mailers/prior_authority/submission_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_mailer_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe PriorAuthority::SubmissionMailer, type: :mailer do
         defendant_name: 'bob jim',
         application_total: '£155.00',
         date: DateTime.now.to_fs(:stamp),
-        feedback_url: 'tbc'
       )
     end
   end


### PR DESCRIPTION
## Description of change
Remove feedback URL from submission mailer

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1033)

Inline with UCD discussion it was decided to remove feedback
links from notification emails sent by the service.

The template has been edited on notify and no longer uses it.
