### PR TITLE
CRM457-1270: Use better status values

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -19,7 +19,7 @@ class Claim < ApplicationRecord
 
   scope :for, ->(provider) { where(office_code: provider.selected_office_code) }
 
-  enum status: { draft: 'draft', submitted: 'completed', granted: 'granted', part_grant: 'part-granted',
+  enum status: { draft: 'draft', submitted: 'submitted', granted: 'granted', part_grant: 'part_grant',
                  review: 'review', further_info: 'further_info', provider_requested: 'provider_requested',
                  rejected: 'rejected' }
 

--- a/db/migrate/20240322122517_standardise_claim_statuses.rb
+++ b/db/migrate/20240322122517_standardise_claim_statuses.rb
@@ -1,0 +1,11 @@
+class StandardiseClaimStatuses < ActiveRecord::Migration[7.1]
+  def up
+    execute("UPDATE claims SET status = 'submitted' WHERE status = 'completed'")
+    execute("UPDATE claims SET status = 'part_grant' WHERE status = 'part-granted'")
+  end
+
+  def down
+    execute("UPDATE claims SET status = 'completed' WHERE status = 'submitted'")
+    execute("UPDATE claims SET status = 'part-granted' WHERE status = 'part_grant'")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_145242) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_22_122517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -193,17 +193,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_145242) do
     t.jsonb "navigation_stack", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "next_hearing"
+    t.text "reason_why"
+    t.date "rep_order_date"
+    t.boolean "client_detained"
+    t.boolean "subject_to_poca"
     t.date "next_hearing_date"
     t.string "plea"
     t.string "court_type"
     t.boolean "youth_court"
     t.boolean "psychiatric_liaison"
     t.string "psychiatric_liaison_reason_not"
-    t.date "rep_order_date"
-    t.boolean "client_detained"
-    t.boolean "subject_to_poca"
-    t.text "reason_why"
+    t.boolean "next_hearing"
     t.boolean "additional_costs_still_to_add"
     t.boolean "prior_authority_granted"
     t.text "no_alternative_quote_reason"

--- a/spec/controllers/nsm/steps/start_page_controller_spec.rb
+++ b/spec/controllers/nsm/steps/start_page_controller_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Nsm::Steps::StartPageController, type: :controller do
       end
     end
 
-    context 'when claim is in a completed state' do
+    context 'when claim is in a submitted state' do
       let(:navigation_stack) { ['/foo'] }
-      let(:status) { 'completed' }
+      let(:status) { 'submitted' }
 
       it 'redirects to the read only view' do
         get :show, params: { id: claim }


### PR DESCRIPTION
## Description of change
Use more sensible name for submitted applications
Use the correct (caseworker-assigned) name for part_grant applications

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1270)
