### PR TITLE
CRM457-1239: Show expired applications (and fix date format)

### DIFF
--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -2,7 +2,7 @@ module PriorAuthority
   class ApplicationsController < ApplicationController
     before_action :set_default_table_sort_options
     before_action :load_drafts, only: %i[index draft]
-    before_action :load_assessed, only: %i[index assessed]
+    before_action :load_reviewed, only: %i[index reviewed]
     before_action :load_submitted, only: %i[index submitted]
     layout 'prior_authority'
 
@@ -39,7 +39,7 @@ module PriorAuthority
       render layout: nil
     end
 
-    def assessed
+    def reviewed
       render layout: nil
     end
 
@@ -57,8 +57,8 @@ module PriorAuthority
       @draft_pagy, @draft_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).draft)
     end
 
-    def load_assessed
-      @assessed_pagy, @assessed_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).assessed)
+    def load_reviewed
+      @reviewed_pagy, @reviewed_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).reviewed)
     end
 
     def load_submitted

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
     when 'draft'
       :draft
     else
-      :assessed
+      :reviewed
     end
   end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -5,6 +5,8 @@ module TagHelper
     auto_grant: 'govuk-tag--green',
     part_grant: 'govuk-tag--blue',
     rejected: 'govuk-tag--red',
+    expired: 'govuk-tag--red',
+    sent_back: 'govuk-tag--yellow',
   }.freeze
 
   def prior_authority_tag_colour(status)

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -44,7 +44,7 @@ class PriorAuthorityApplication < ApplicationRecord
     expired: 'expired'
   }
 
-  scope :assessed, -> { where(status: %i[granted part_grant rejected auto_grant]) }
+  scope :reviewed, -> { where(status: %i[granted part_grant rejected auto_grant sent_back expired]) }
 
   scope :for, ->(provider) { where(office_code: provider.selected_office_code) }
 

--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -64,7 +64,9 @@ module PriorAuthority
         info_correct_required = data['updates_needed'].include? 'incorrect_information'
         application.update(
           further_information_explanation: further_info_required ? data['further_information_explanation'] : nil,
-          incorrect_information_explanation: info_correct_required ? data['incorrect_information_explanation'] : nil
+          incorrect_information_explanation: info_correct_required ? data['incorrect_information_explanation'] : nil,
+          resubmission_deadline: data['resubmission_deadline'],
+          resubmission_requested: DateTime.current
         )
       end
 

--- a/app/views/prior_authority/applications/assessed.html.erb
+++ b/app/views/prior_authority/applications/assessed.html.erb
@@ -1,3 +1,0 @@
-<turbo-frame id="assessed_applications">
-  <%= render 'prior_authority/applications/frame_contents/assessed', model: @assessed_model, pagy: @assessed_pagy %>
-</turbo-frame>

--- a/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
@@ -1,7 +1,7 @@
 <% if model.none? %>
-  <p><%= t('prior_authority.applications.tabs.no_assessed') %></p>
+  <p><%= t('prior_authority.applications.tabs.no_reviewed') %></p>
 <% else %>
-  <h2 class="govuk-heading-m"><%= t('prior_authority.applications.tabs.assessed') %></h2>
+  <h2 class="govuk-heading-m"><%= t('prior_authority.applications.tabs.reviewed') %></h2>
   <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_submitted">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
@@ -9,7 +9,7 @@
           <%= table_header(key,
                           'prior_authority.applications.tabs.header',
                            index,
-                           assessed_prior_authority_applications_path,
+                           reviewed_prior_authority_applications_path,
                            @sort_by,
                            @sort_direction) %>
         <% end %>

--- a/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
@@ -2,7 +2,7 @@
   <p><%= t('prior_authority.applications.tabs.no_reviewed') %></p>
 <% else %>
   <h2 class="govuk-heading-m"><%= t('prior_authority.applications.tabs.reviewed') %></h2>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_submitted">
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_reviewed">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <% ['ufn', 'client', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>

--- a/app/views/prior_authority/applications/index.html.erb
+++ b/app/views/prior_authority/applications/index.html.erb
@@ -25,9 +25,9 @@
     <div class="govuk-grid-column-full">
 
       <%= govuk_tabs(title: t(".page_title"), classes: ['reload-visible-turboframes'], html_attributes: { data: { selector: '.govuk-tabs__tab' }}) do |c| %>
-        <% c.with_tab(label: t(".tabs.assessed")) do %>
-          <%= turbo_frame_tag 'assessed_applications', src: assessed_prior_authority_applications_path, loading: :lazy do %>
-            <%= render 'prior_authority/applications/frame_contents/assessed', model: @assessed_model, pagy: @assessed_pagy %>
+        <% c.with_tab(label: t(".tabs.reviewed")) do %>
+          <%= turbo_frame_tag 'reviewed_applications', src: reviewed_prior_authority_applications_path, loading: :lazy do %>
+            <%= render 'prior_authority/applications/frame_contents/reviewed', model: @reviewed_model, pagy: @reviewed_pagy %>
           <% end %>
         <% end %>
         <% c.with_tab(label: t(".tabs.submitted")) do %>

--- a/app/views/prior_authority/applications/response_summaries/_assessed.html.erb
+++ b/app/views/prior_authority/applications/response_summaries/_assessed.html.erb
@@ -1,0 +1,22 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%= t("prior_authority.applications.show.laa_response") %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <p><%= @application.assessment_comment %></p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% if @application.primary_quote.service_adjustment_comment.present? %>
+        <li><%= link_to t('prior_authority.applications.show.review_service_cost_adjustments'), '#service-cost' %></li>
+      <% end %>
+      <% if @application.primary_quote.travel_adjustment_comment.present? %>
+        <li><%= link_to t('prior_authority.applications.show.review_travel_cost_adjustments'), '#travel-cost' %></li>
+      <% end %>
+      <% if @application.additional_costs.any? { _1.adjustment_comment.present? } %>
+        <li><%= link_to t('prior_authority.applications.show.review_additional_cost_adjustments'), '#additional-cost-0' %></li>
+      <% end %>
+    </ul>
+    <% if !@application.granted? %>
+      <%= govuk_button_link_to(t('prior_authority.applications.show.appeal'), '#') %>
+    <% end %>
+  </dd>
+</div>

--- a/app/views/prior_authority/applications/response_summaries/_expired.html.erb
+++ b/app/views/prior_authority/applications/response_summaries/_expired.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    <%= t("prior_authority.applications.show.laa_response") %>
+  </dt>
+  <dd class="govuk-summary-list__value">
+    <% t('prior_authority.applications.show.expiry_explanations',
+          requested: @application.resubmission_requested.to_fs(:stamp),
+          deadline: @application.resubmission_deadline.to_fs(:stamp)).each do |paragraph| %>
+      <p><%= paragraph %></p>
+    <% end %>
+  </dt>
+</div>

--- a/app/views/prior_authority/applications/reviewed.html.erb
+++ b/app/views/prior_authority/applications/reviewed.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="reviewed_applications">
+  <%= render 'prior_authority/applications/frame_contents/reviewed', model: @reviewed_model, pagy: @reviewed_pagy %>
+</turbo-frame>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -24,41 +24,10 @@
                 <%= render "prior_authority/applications/state_summaries/#{@application.status}" %>
             </dd>
           </div>
-          <% if @application.status.in?(['part_grant', 'rejected']) || @application.assessment_comment.present? %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= t(".laa_response") %>
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <p><%= @application.assessment_comment %></p>
-                <ul class="govuk-list govuk-list--bullet">
-                  <% if @application.primary_quote.service_adjustment_comment.present? %>
-                    <li><%= link_to t('.review_service_cost_adjustments'), '#service-cost' %></li>
-                  <% end %>
-                  <% if @application.primary_quote.travel_adjustment_comment.present? %>
-                    <li><%= link_to t('.review_travel_cost_adjustments'), '#travel-cost' %></li>
-                  <% end %>
-                  <% if @application.additional_costs.any? { _1.adjustment_comment.present? } %>
-                    <li><%= link_to t('.review_additional_cost_adjustments'), '#additional-cost-0' %></li>
-                  <% end %>
-                </ul>
-                <% if @application.status != 'granted' %>
-                  <%= govuk_button_link_to(t('.appeal'), '#') %>
-                <% end %>
-              </dd>
-            </div>
+          <% if @application.assessment_comment.present? %>
+            <%= render "prior_authority/applications/response_summaries/assessed" %>
           <% elsif @application.expired? %>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                <%= t(".laa_response") %>
-              </dt>
-              <dd class="govuk-summary-list__value">
-                  <% t('.expiry_explanations',
-                       requested: @application.resubmission_requested.to_fs(:stamp),
-                       deadline: @application.resubmission_deadline.to_fs(:stamp)).each do |paragraph| %>
-                    <p><%= paragraph %></p>
-                  <% end %>
-              </dt>
+            <%= render "prior_authority/applications/response_summaries/expired" %>
           <% end %>
         </dl>
       </div>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -47,6 +47,18 @@
                 <% end %>
               </dd>
             </div>
+          <% elsif @application.expired? %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= t(".laa_response") %>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                  <% t('.expiry_explanations',
+                       requested: @application.resubmission_requested.to_fs(:stamp),
+                       deadline: @application.resubmission_deadline.to_fs(:stamp)).each do |paragraph| %>
+                    <p><%= paragraph %>
+                  <% end %>
+              </dt>
           <% end %>
         </dl>
       </div>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -56,7 +56,7 @@
                   <% t('.expiry_explanations',
                        requested: @application.resubmission_requested.to_fs(:stamp),
                        deadline: @application.resubmission_deadline.to_fs(:stamp)).each do |paragraph| %>
-                    <p><%= paragraph %>
+                    <p><%= paragraph %></p>
                   <% end %>
               </dt>
           <% end %>

--- a/app/views/prior_authority/applications/state_summaries/_expired.html.erb
+++ b/app/views/prior_authority/applications/state_summaries/_expired.html.erb
@@ -1,0 +1,4 @@
+<p><strong class="govuk-tag <%= prior_authority_tag_colour(:rejected) %>"><%= t(".status") %></strong></p>
+<p><%= @application.app_store_updated_at.to_fs(:stamp) %></p>
+<br>
+<p><%= t('prior_authority.applications.show.amount_requested', amount: @primary_quote_summary.formatted_total_cost) %></p>

--- a/app/views/prior_authority/applications/state_summaries/_expired.html.erb
+++ b/app/views/prior_authority/applications/state_summaries/_expired.html.erb
@@ -1,4 +1,4 @@
-<p><strong class="govuk-tag <%= prior_authority_tag_colour(:rejected) %>"><%= t(".status") %></strong></p>
+<p><strong class="govuk-tag <%= prior_authority_tag_colour(:expired) %>"><%= t(".status") %></strong></p>
 <p><%= @application.app_store_updated_at.to_fs(:stamp) %></p>
 <br>
 <p><%= t('prior_authority.applications.show.amount_requested', amount: @primary_quote_summary.formatted_total_cost) %></p>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -3,5 +3,5 @@
 # instead of
 # `my_date.strftime('%d %B %Y')`
 #
-Date::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY
-Time::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY
+Date::DATE_FORMATS[:stamp] = '%-d %B %Y' # DD MONTH YYYY
+Time::DATE_FORMATS[:stamp] = '%-d %B %Y' # DD MONTH YYYY

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -16,14 +16,14 @@ en:
         tabs:
           drafts: Drafts
           submitted: Submitted
-          assessed: Assessed
+          reviewed: Reviewed
       tabs:
         drafts: Drafts
         submitted: Submitted
-        assessed: Assessed
+        reviewed: Reviewed
         no_drafts: You do not have any draft applications.
-        no_submitted: You do not have any applications waiting to be assessed.
-        no_assessed: You do not have any applications that have been assessed.
+        no_submitted: You do not have any applications waiting to be reviewed.
+        no_reviewed: You do not have any applications that have been reviewed.
         application: application
         header:
           ufn: UFN
@@ -37,6 +37,8 @@ en:
           auto_grant: Granted
           part_grant: Part granted
           rejected: Rejected
+          sent_back: Update needed
+          expired: Expired
         delete: Delete
       confirm_delete:
         page_title: Are you sure you want to delete this draft application?
@@ -64,6 +66,10 @@ en:
         review_service_cost_adjustments: Review service cost adjustments
         review_travel_cost_adjustments: Review travel cost adjustments
         review_additional_cost_adjustments: Review additional cost adjustments
+        expiry_explanations:
+          - On %{requested} we asked you to update your application before we could complete the assessment. This was due by %{deadline}.
+          - As this update was not made by the required date this application has been automatically closed.
+          - If you make a new application you should include the requested update.
       state_summaries:
         submitted:
           status: Submitted
@@ -74,6 +80,8 @@ en:
           status: Rejected
         part_grant:
           status: Part granted
+        expired:
+          status: Expired
     steps:
       start_page:
         show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
       collection do
         get :draft
         get :submitted
-        get :assessed
+        get :reviewed
       end
       member do
         get 'offboard'

--- a/db/migrate/20240322141829_add_resubmission_dates_to_prior_authority_application.rb
+++ b/db/migrate/20240322141829_add_resubmission_dates_to_prior_authority_application.rb
@@ -1,0 +1,6 @@
+class AddResubmissionDatesToPriorAuthorityApplication < ActiveRecord::Migration[7.1]
+  def change
+    add_column :prior_authority_applications, :resubmission_requested, :datetime
+    add_column :prior_authority_applications, :resubmission_deadline, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_122517) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_22_141829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -220,6 +220,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_122517) do
     t.string "assessment_comment"
     t.string "further_information_explanation"
     t.string "incorrect_information_explanation"
+    t.datetime "resubmission_requested"
+    t.datetime "resubmission_deadline"
     t.index ["firm_office_id"], name: "index_prior_authority_applications_on_firm_office_id"
     t.index ["provider_id"], name: "index_prior_authority_applications_on_provider_id"
     t.index ["solicitor_id"], name: "index_prior_authority_applications_on_solicitor_id"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,8 +57,21 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#relevant_prior_authority_list_anchor' do
-    let(:application) { build(:prior_authority_application, status: 'draft') }
+    let(:application) { build(:prior_authority_application) }
 
-    it { expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:draft) }
+    it 'returns draft for draft status' do
+      allow(application).to receive(:status).and_return('draft')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:draft)
+    end
+
+    it 'returns submitted for submitted status' do
+      allow(application).to receive(:status).and_return('submitted')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:submitted)
+    end
+
+    it 'returns reviewed for all statuses other than draft or submitted' do
+      allow(application).to receive(:status).and_return('whatever')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:reviewed)
+    end
   end
 end

--- a/spec/presenters/nsm/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/application_status_card_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
             },
             {
               head_key: 'Date Submitted',
-              text: '01 December 2023'
+              text: '1 December 2023'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/case_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_details_card_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
           },
           {
             head_key: 'main_offence_date',
-            text: '01 January 2023'
+            text: '1 January 2023'
           },
           {
             head_key: 'assigned_counsel',
@@ -57,7 +57,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'main_offence_date',
-              text: '01 January 2023'
+              text: '1 January 2023'
             },
             {
               head_key: 'assigned_counsel',
@@ -77,7 +77,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'remitted_to_magistrate_date',
-              text: '01 March 2023'
+              text: '1 March 2023'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/case_disposal_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_disposal_card_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDisposalCard do
           },
           {
             head_key: 'arrest_warrant_date',
-            text: '01 March 2023'
+            text: '1 March 2023'
           }
         ]
       )
@@ -85,7 +85,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDisposalCard do
           },
           {
             head_key: 'cracked_trial_date',
-            text: '01 March 2023'
+            text: '1 March 2023'
           }
         ]
       )

--- a/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             },
             {
               head_key: 'work_before_date',
-              text: '01 December 2020'
+              text: '1 December 2020'
             },
             {
               head_key: 'work_after',
@@ -54,7 +54,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             },
             {
               head_key: 'work_after_date',
-              text: '01 January 2020'
+              text: '1 January 2020'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/claim_justification_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_justification_card_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimJustificationCard do
             },
             {
               head_key: 'representation_order_withdrawn_date',
-              text: '01 August 2023'
+              text: '1 August 2023'
             },
             {
               head_key: 'reason_for_claim_other_details',

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'rep_order_date',
-              text: '01 January 2023'
+              text: '1 January 2023'
             }
           ]
         )
@@ -67,7 +67,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'cntp_rep_order',
-              text: '01 February 2023'
+              text: '1 February 2023'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
         [
           {
             head_key: 'hearing_date',
-            text: '01 March 2023'
+            text: '1 March 2023'
           },
           {
             head_key: 'number_of_hearing',

--- a/spec/presenters/prior_authority/check_answers/client_detail_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/client_detail_card_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PriorAuthority::CheckAnswers::ClientDetailCard do
           },
           {
             head_key: 'date_of_birth',
-            text: '01 January 2001'
+            text: '1 January 2001'
           },
         ]
       )

--- a/spec/system/prior_authority/application_lists_spec.rb
+++ b/spec/system/prior_authority/application_lists_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Prior authority application lists' do
       expect(page).to have_content 'BBBBB'
     end
 
-    within '#assessed' do
+    within '#reviewed' do
       expect(page).to have_content 'CCCCC'
     end
 

--- a/spec/system/prior_authority/application_lists_spec.rb
+++ b/spec/system/prior_authority/application_lists_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe 'Prior authority application lists' do
            status: 'submitted',
            updated_at: 1.day.ago)
     create(:prior_authority_application, laa_reference: 'LAA-BBBBB', status: 'submitted', updated_at: 2.days.ago)
-    create(:prior_authority_application, laa_reference: 'LAA-CCCCC', status: 'granted', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC1', status: 'granted', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC2', status: 'sent_back', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC3', status: 'part_grant', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC4', status: 'rejected', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC5', status: 'auto_grant', updated_at: 3.days.ago)
     create(:prior_authority_application, laa_reference: 'LAA-DDDDD', status: 'draft', updated_at: 4.days.ago)
     create(:prior_authority_application, laa_reference: 'LAA-EEEEE', status: 'draft', office_code: 'OTHER')
 
@@ -24,7 +28,12 @@ RSpec.describe 'Prior authority application lists' do
     end
 
     within '#reviewed' do
-      expect(page).to have_content 'CCCCC'
+      expect(page)
+        .to have_content('CCCC1')
+        .and have_content('CCCC2')
+        .and have_content('CCCC3')
+        .and have_content('CCCC4')
+        .and have_content('CCCC5')
     end
 
     within '#drafts' do

--- a/spec/system/prior_authority/view_assessed_applications_spec.rb
+++ b/spec/system/prior_authority/view_assessed_applications_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'View reviewed applications' do
+  let(:arbitrary_fixed_date) { DateTime.new(2024, 3, 22, 15, 23, 11) }
+
   before do
+    travel_to arbitrary_fixed_date
     visit provider_saml_omniauth_callback_path
     application
     visit prior_authority_applications_path

--- a/spec/system/prior_authority/view_assessed_applications_spec.rb
+++ b/spec/system/prior_authority/view_assessed_applications_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe 'View reviewed applications' do
       create(:prior_authority_application,
              :full,
              status: 'part_grant',
+             assessment_comment: 'Too much',
              app_store_updated_at: 1.day.ago,
              quotes: [quote],
              additional_costs: [additional_cost])
@@ -105,10 +106,10 @@ RSpec.describe 'View reviewed applications' do
     end
 
     it 'shows expiry details' do
-      expect(page).to have_content 'Expired'
-      expect(page).to have_content '£155.00 requested'
-      expect(page).to have_content 'On 8 March 2024 we asked you to update your application'
-      expect(page).to have_content 'This was due by 21 March 2024'
+      expect(page).to have_content('Expired')
+        .and have_content('£155.00 requested')
+        .and have_content('On 8 March 2024 we asked you to update your application')
+        .and have_content('This was due by 21 March 2024')
     end
   end
 end

--- a/spec/system/prior_authority/view_assessed_applications_spec.rb
+++ b/spec/system/prior_authority/view_assessed_applications_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'View assessed applications' do
+RSpec.describe 'View reviewed applications' do
   before do
     visit provider_saml_omniauth_callback_path
     application
@@ -88,6 +88,24 @@ RSpec.describe 'View assessed applications' do
     it 'shows additional cost adjustments' do
       expect(page).to have_content 'Nearly right'
       expect(page).to have_content '£20.00 £119.00'
+    end
+  end
+
+  context 'when application is expired' do
+    let(:application) do
+      create(:prior_authority_application,
+             :full,
+             status: 'expired',
+             app_store_updated_at: 1.day.ago,
+             resubmission_requested: 14.days.ago,
+             resubmission_deadline: 1.day.ago)
+    end
+
+    it 'shows expiry details' do
+      expect(page).to have_content 'Expired'
+      expect(page).to have_content '£155.00 requested'
+      expect(page).to have_content 'On 8 March 2024 we asked you to update your application'
+      expect(page).to have_content 'This was due by 21 March 2024'
     end
   end
 end


### PR DESCRIPTION
## Description of change
Pull timings of resubmission window from payload
Sort out application show page for expired applications
Rename 'Assessed' to 'Reviewed' and include expired applications
Update date format to match designs (no leading zero on day)

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1239)

## Notes for reviewe

## Screenshots of changes

<img width="717" alt="Screenshot 2024-03-22 at 14 55 17" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/113888736/7f7dc156-5e37-4911-99fa-5c2104eb820c">

---

<img width="1111" alt="Screenshot 2024-03-22 at 14 55 10" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/113888736/f28c4edb-c9aa-4d98-b8e9-ead441be14bb">
