### PR TITLE
CRM457-1193: Add incorrect info review summary

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -7,6 +7,8 @@ module PriorAuthority
       validates :confirm_excluding_vat, acceptance: { accept: true }, allow_nil: false
       validates :confirm_travel_expenditure, acceptance: { accept: true }, allow_nil: false
 
+      validate :application_corrected, if: :needs_correcting?
+
       # Do not save confirmations if "Save and come back later" - commit_draft
       def save!; end
 
@@ -14,6 +16,23 @@ module PriorAuthority
         application.update!(attributes.merge({ status: :submitted }))
         SubmitToAppStore.new.process(submission: application)
         true
+      end
+
+      def application_corrected
+        errors.add(:base, :application_not_corrected) unless application_changed_since_request?
+      end
+
+      def application_changed_since_request?
+        last_updated_at > application.resubmission_requested
+      end
+
+      def last_updated_at
+        LastUpdateFinder.call(application)
+      end
+
+      def needs_correcting?
+        application.sent_back? &&
+          application.incorrect_information_explanation.present?
       end
     end
   end

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -9,7 +9,7 @@ module PriorAuthority
 
       validate :application_corrected, if: :needs_correcting?
 
-      # Do not save confirmations if "Save and come back later" - commit_draft
+      # Do not call persist! if "Save and come back later" - commit_draft
       def save!; end
 
       def persist!

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -30,6 +30,8 @@ class PriorAuthorityApplication < ApplicationRecord
   attribute :firm_account_number, :string
   attribute :created_at, :datetime
   attribute :updated_at, :datetime
+  attribute :confirm_excluding_vat, :boolean
+  attribute :confirm_travel_expenditure, :boolean
 
   enum :status, {
     pre_draft: 'pre_draft',

--- a/app/presenters/tasks/generic.rb
+++ b/app/presenters/tasks/generic.rb
@@ -15,7 +15,8 @@ module Tasks
     end
 
     def can_start?
-      previous_tasks.all? { |task| fulfilled?(task) }
+      previous_tasks.all? { |task| fulfilled?(task) } ||
+        application.status == 'sent_back'
     end
 
     def completed?(rec = record, form = associated_form)

--- a/app/services/prior_authority/last_update_finder.rb
+++ b/app/services/prior_authority/last_update_finder.rb
@@ -1,0 +1,49 @@
+module PriorAuthority
+  class LastUpdateFinder
+    def self.call(application)
+      new(application).call
+    end
+
+    attr_reader :application
+
+    def initialize(application)
+      @application = application
+    end
+
+    def call
+      updates_at.max
+    end
+
+    private
+
+    def updates_at
+      @updates_at ||= [application.updated_at] + updated_associations
+    end
+
+    def updated_associations
+      updated_associations = []
+      associations = PriorAuthorityApplication.reflect_on_all_associations
+
+      associations.each_with_object(updated_associations) do |association, arr|
+        next if excluded?(association.name)
+
+        arr << updated_ats_for(association.name)
+      end
+
+      updated_associations.flatten.compact
+    end
+
+    def updated_ats_for(association_name)
+      if application.send(association_name).respond_to?(:pluck)
+        application.send(association_name).pluck(:updated_at)
+      else
+        application.send(association_name).updated_at
+      end
+    end
+
+    # TODO: CRM457-1192 exclude further_information[_request]s association when it exists
+    def excluded?(association_name)
+      association_name.in?(%i[provider])
+    end
+  end
+end

--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -4,12 +4,22 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+
+    <%= govuk_error_summary(@form_object) %>
+
     <% if @form_object.application.incorrect_information_explanation %>
-      <div class="govuk-inset-text">
-        <strong><%= t('.incorrect_information_heading') %></strong><br>
-        <br>
-        <%= @form_object.application.incorrect_information_explanation %>
-      </div>
+      <% if @form_object.errors.of_kind?(:base, :application_not_corrected) %>
+        <div class="govuk-form-group--error">
+          <p class="govuk-error-message" id="prior-authority-steps-check-answers-form-base-field-error"><%= t('.incorrect_information_heading') %></p>
+          <p class="govuk-body"><%= @form_object.application.incorrect_information_explanation %></p>
+        </div>
+      <% else %>
+        <div class="govuk-inset-text">
+          <strong><%= t('.incorrect_information_heading') %></strong><br>
+          <br>
+          <p class="govuk-body"><%= @form_object.application.incorrect_information_explanation %></p>
+        </div>
+      <% end %>
     <% end %>
 
     <% @report.section_groups.each do |section_group| %>
@@ -30,8 +40,6 @@
     <% end %>
 
     <h2 class="govuk-heading-l"><%= t('.subheading') %></h2>
-
-    <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
       <%= f.govuk_check_boxes_fieldset :confirm_excluding_vat, multiple: false, legend: nil do %>

--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -4,6 +4,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <% if @form_object.application.incorrect_information_explanation %>
+      <div class="govuk-inset-text">
+        <strong><%= t('.incorrect_information_heading') %></strong><br>
+        <br>
+        <%= @form_object.application.incorrect_information_explanation %>
+      </div>
+    <% end %>
+
     <% @report.section_groups.each do |section_group| %>
       <h2 class="govuk-heading-l"><%= section_group[:heading] %></h2>
       <% section_group[:sections].each do |section| %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -71,6 +71,8 @@ en:
               inclusion: Select yes if this case is subject to POCA (Proceeds of Crime Act 2002)?
         prior_authority/steps/check_answers_form:
           attributes:
+            base:
+              application_not_corrected: Your application needs existing information corrected
             confirm_excluding_vat:
               accepted: Select if you confirm that all costs are exclusive of VAT
             confirm_travel_expenditure:

--- a/config/locales/en/prior_authority/check_answers.yml
+++ b/config/locales/en/prior_authority/check_answers.yml
@@ -15,6 +15,7 @@ en:
               is included as additional items in the primary quote, and is not included as part
               of any hourly rate
           heading: Check your answers
+          incorrect_information_heading: Your application needs existing information corrected
           page_title: Check your answers
           sections:
             alternative_quotes:

--- a/db/migrate/20240326074226_drop_confirmations_from_prior_authority_application.rb
+++ b/db/migrate/20240326074226_drop_confirmations_from_prior_authority_application.rb
@@ -1,0 +1,5 @@
+class DropConfirmationsFromPriorAuthorityApplication < ActiveRecord::Migration[7.1]
+  def change
+    remove_columns :prior_authority_applications, :confirm_excluding_vat, :confirm_travel_expenditure
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_141829) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_074226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -193,25 +193,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_22_141829) do
     t.jsonb "navigation_stack", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "reason_why"
-    t.date "rep_order_date"
-    t.boolean "client_detained"
-    t.boolean "subject_to_poca"
+    t.boolean "next_hearing"
     t.date "next_hearing_date"
     t.string "plea"
     t.string "court_type"
     t.boolean "youth_court"
     t.boolean "psychiatric_liaison"
     t.string "psychiatric_liaison_reason_not"
-    t.boolean "next_hearing"
+    t.date "rep_order_date"
+    t.boolean "client_detained"
+    t.boolean "subject_to_poca"
+    t.text "reason_why"
     t.boolean "additional_costs_still_to_add"
     t.boolean "prior_authority_granted"
     t.text "no_alternative_quote_reason"
     t.boolean "alternative_quotes_still_to_add"
     t.string "service_type"
     t.string "custom_service_name"
-    t.boolean "confirm_excluding_vat"
-    t.boolean "confirm_travel_expenditure"
     t.string "main_offence_id"
     t.string "custom_main_offence_name"
     t.string "prison_id"

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -115,6 +115,7 @@ FactoryBot.define do
       further_information_explanation { 'Please provide more evidence to support the service costs...' }
       incorrect_information_explanation { 'Please correct the following information...' }
       resubmission_deadline { 14.days.from_now }
+      resubmission_requested { DateTime.current }
     end
 
     trait :with_complete_non_prison_law do

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -108,8 +108,13 @@ FactoryBot.define do
       no_alternative_quote_reason { 'a reason' }
       service_type { 'pathologist_report' }
       custom_service_name { nil }
-      further_information_explanation { 'Some additional information is needed' }
-      incorrect_information_explanation { 'This is incorrect' }
+    end
+
+    trait :with_sent_back_status do
+      status { 'sent_back' }
+      further_information_explanation { 'Please provide more evidence to support the service costs...' }
+      incorrect_information_explanation { 'Please correct the following information...' }
+      resubmission_deadline { 14.days.from_now }
     end
 
     trait :with_complete_non_prison_law do

--- a/spec/factories/supporting_documents.rb
+++ b/spec/factories/supporting_documents.rb
@@ -3,8 +3,6 @@ FactoryBot.define do
     file_name { 'test.png' }
     file_type { 'image/png' }
     file_size { '1234' }
-    created_at { Date.new(2023, 3, 1) }
-    updated_at { Date.new(2023, 3, 1) }
     file_path { 'test_path' }
     documentable_type { 'PriorAuthorityApplication' }
     document_type { 'supporting_document' }

--- a/spec/forms/prior_authority/steps/check_answers_form_spec.rb
+++ b/spec/forms/prior_authority/steps/check_answers_form_spec.rb
@@ -73,30 +73,22 @@ RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
     subject(:save) { form.save! }
 
     let(:application) { create(:prior_authority_application, status: 'draft') }
+    let(:confirm_excluding_vat) { '' }
+    let(:confirm_travel_expenditure) { '' }
 
-    context 'with accepted confirmations' do
-      let(:confirm_excluding_vat) { 'true' }
-      let(:confirm_travel_expenditure) { 'true' }
+    it 'does NOT validate the form' do
+      save
+      expect(form.errors).to be_empty
+    end
 
-      it 'does NOT persist the confirmations' do
-        expect { save }.not_to change { application.reload.attributes }
-          .from(
-            hash_including(
-              'confirm_excluding_vat' => nil,
-              'confirm_travel_expenditure' => nil,
-            )
-          )
-      end
+    it 'does NOT update the status of the application' do
+      expect { save }.not_to change(application, :status).from('draft')
+    end
 
-      it 'does NOT update the status of the application' do
-        expect { save }.not_to change(application, :status).from('draft')
-      end
-
-      it 'does NOT submit the application to the app store' do
-        allow(SubmitToAppStore).to receive(:new)
-        save
-        expect(SubmitToAppStore).not_to have_received(:new)
-      end
+    it 'does NOT submit the application to the app store' do
+      allow(SubmitToAppStore).to receive(:new)
+      save
+      expect(SubmitToAppStore).not_to have_received(:new)
     end
   end
 
@@ -108,22 +100,6 @@ RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
     context 'with accepted confirmations' do
       let(:confirm_excluding_vat) { 'true' }
       let(:confirm_travel_expenditure) { 'true' }
-
-      it 'persists the value' do
-        expect { save }.to change { application.reload.attributes }
-          .from(
-            hash_including(
-              'confirm_excluding_vat' => nil,
-              'confirm_travel_expenditure' => nil,
-            )
-          )
-          .to(
-            hash_including(
-              'confirm_excluding_vat' => true,
-              'confirm_travel_expenditure' => true,
-            )
-          )
-      end
 
       it 'updates the status of the application to submitted' do
         expect { save }.to change(application, :status).from('draft').to('submitted')
@@ -155,14 +131,9 @@ RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
       let(:confirm_excluding_vat) { false }
       let(:confirm_travel_expenditure) { false }
 
-      it 'does not persist the confirmations' do
-        expect { save }.not_to change { application.reload.attributes }
-          .from(
-            hash_including(
-              'confirm_excluding_vat' => nil,
-              'confirm_travel_expenditure' => nil,
-            )
-          )
+      it 'validates the confirmations' do
+        save
+        expect(form.errors.messages).to include(:confirm_excluding_vat, :confirm_travel_expenditure)
       end
 
       it 'does NOT update the status of the application' do
@@ -180,18 +151,19 @@ RSpec.describe PriorAuthority::Steps::CheckAnswersForm do
       let(:confirm_excluding_vat) { nil }
       let(:confirm_travel_expenditure) { nil }
 
-      it 'does not persist the confirmations' do
-        expect { save }.not_to change { application.reload.attributes }
-          .from(
-            hash_including(
-              'confirm_excluding_vat' => nil,
-              'confirm_travel_expenditure' => nil,
-            )
-          )
+      it 'validates the confirmations' do
+        save
+        expect(form.errors.messages).to include(:confirm_excluding_vat, :confirm_travel_expenditure)
       end
 
       it 'does NOT update the status of the application' do
         expect { save }.not_to change(application, :status).from('draft')
+      end
+
+      it 'does NOT submit the application to the app store' do
+        allow(SubmitToAppStore).to receive(:new)
+        save
+        expect(SubmitToAppStore).not_to have_received(:new)
       end
     end
   end

--- a/spec/services/prior_authority/last_update_finder_spec.rb
+++ b/spec/services/prior_authority/last_update_finder_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::LastUpdateFinder do
+  describe '.call' do
+    subject(:finder) { described_class.call(application) }
+
+    let(:application) do
+      travel_to(sent_back_datetime) do
+        create(:prior_authority_application,
+               :with_all_tasks_completed,
+               :with_firm_and_solicitor,
+               :with_alternative_quotes,
+               :with_sent_back_status)
+      end
+    end
+
+    let(:sent_back_datetime) { 2.days.ago.change({ hour: 11, minute: 0 }) }
+    let(:updated_datetime) { 0.days.ago.change({ hour: 10, minute: 0 }) }
+
+    before do
+      application
+    end
+
+    context 'when not updated' do
+      it 'returns the date application was sent back' do
+        expect(finder).to eql(sent_back_datetime)
+      end
+    end
+
+    context 'when provider updated' do
+      before do
+        travel_to(updated_datetime) do
+          application.provider.update!(email: 'someone-else@provider.com')
+        end
+      end
+
+      it 'excludes provider updated date' do
+        expect(finder).to eql(sent_back_datetime)
+      end
+    end
+
+    context 'when firm_office updated' do
+      before do
+        travel_to(updated_datetime) do
+          application.firm_office.update!(account_number: '2BON2B')
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 6, minute: 0 }) }
+
+      it 'returns the date of the update of the firm_office' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with changed application details' do
+      before do
+        travel_to(updated_datetime) do
+          application.update!(subject_to_poca: true)
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 10, minute: 0 }) }
+
+      it 'returns the date of the update of the application' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with changed solicitor details' do
+      before do
+        travel_to(updated_datetime) do
+          application.solicitor.update!(contact_email: 'billy-bob@pga-law.com')
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 8, minute: 0 }) }
+
+      it 'returns the date of the update of the solicitor' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with changed defendant details' do
+      before do
+        travel_to(updated_datetime) do
+          application.defendant.update!(date_of_birth: Date.new(2001, 1, 1))
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 7, minute: 30 }) }
+
+      it 'returns the date of the update of the defendant' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with changed primary quote details' do
+      before do
+        travel_to(updated_datetime) do
+          application.primary_quote.update!(postcode: 'SW1A 2AA')
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 9, minute: 0 }) }
+
+      it 'returns the date of the update of the primary quote' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with changed alternative quote details' do
+      before do
+        travel_to(updated_datetime) do
+          application.alternative_quotes.first.update!(organisation: 'Some other company')
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 12, minute: 0 }) }
+
+      it 'returns the date of the update of the alternative quote' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with additional alternative quote' do
+      before do
+        travel_to(updated_datetime) do
+          application.alternative_quotes << build(:quote, :alternative)
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 14, minute: 0 }) }
+
+      it 'returns the date the additional alternative quote was created/updated' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+
+    context 'with additional supporting document' do
+      before do
+        travel_to(updated_datetime) do
+          application.supporting_documents << build(:supporting_document)
+        end
+      end
+
+      let(:updated_datetime) { 0.days.ago.change({ hour: 12, minute: 0 }) }
+
+      it 'returns the date the additional supporting document was created/updated' do
+        expect(finder).to eql(updated_datetime)
+      end
+    end
+  end
+end

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -153,13 +153,13 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
               'document_type' => 'supporting_evidence',
               'documentable_id' => an_instance_of(String),
               'documentable_type' => 'Claim',
-              'created_at' => '2023-03-01T00:00:00.000Z',
+              'created_at' => '2023-08-17T12:13:14.000Z',
                'file_name' => 'test.png',
                'file_path' => 'test_path',
                'file_size' => 1234,
                'file_type' => 'image/png',
                'id' => an_instance_of(String),
-               'updated_at' => '2023-03-01T00:00:00.000Z'
+               'updated_at' => '2023-08-17T12:13:14.000Z'
             }],
           'cost_totals' =>
           [

--- a/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
@@ -1,0 +1,18 @@
+require 'system_helper'
+
+RSpec.describe 'Prior authority applications, no prison law - check your answers' do
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit prior_authority_steps_check_answers_path(application)
+  end
+
+  let(:application) do
+    create(:prior_authority_application, :full, :with_sent_back_status)
+  end
+
+  it 'shows the incorrect information details from the caseworker' do
+    expect(page)
+      .to have_content('Your application needs existing information corrected', count: 1)
+      .and have_content('Please correct the following information...', count: 1)
+  end
+end

--- a/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe 'Prior authority applications, sent back - check your answers' do
                                text: 'Your application needs existing information corrected')
     end
   end
+
+  it 'submits when changes made since it was sent back by caseworker', :stub_oauth_token do
+    application.defendant.update!(first_name: 'Billy')
+
+    check 'I confirm that all costs are exclusive of VAT'
+    check 'I confirm that any travel expenditure (such as mileage, ' \
+          'parking and travel fares) is included as additional items ' \
+          'in the primary quote, and is not included as part of any hourly rate'
+    click_on 'Accept and send'
+
+    expect(page)
+      .to have_title('Application complete')
+      .and have_content('What happens next')
+  end
 end

--- a/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/sent_back_spec.rb
@@ -1,18 +1,40 @@
 require 'system_helper'
 
-RSpec.describe 'Prior authority applications, no prison law - check your answers' do
+RSpec.describe 'Prior authority applications, sent back - check your answers' do
   before do
     visit provider_saml_omniauth_callback_path
     visit prior_authority_steps_check_answers_path(application)
   end
 
   let(:application) do
-    create(:prior_authority_application, :full, :with_sent_back_status)
+    travel_to(sent_back_datetime) do
+      create(:prior_authority_application, :full, :with_sent_back_status)
+    end
   end
 
-  it 'shows the incorrect information details from the caseworker' do
+  let(:sent_back_datetime) { 2.days.ago.change({ hour: 11, minute: 0 }) }
+
+  it 'shows the "incorrect information" details from the caseworker' do
     expect(page)
       .to have_content('Your application needs existing information corrected', count: 1)
       .and have_content('Please correct the following information...', count: 1)
+  end
+
+  it 'renders a custom govuk error when no changes made since it was sent back by caseworker' do
+    check 'I confirm that all costs are exclusive of VAT'
+    check 'I confirm that any travel expenditure (such as mileage, ' \
+          'parking and travel fares) is included as additional items ' \
+          'in the primary quote, and is not included as part of any hourly rate'
+    click_on 'Accept and send'
+
+    within('.govuk-error-summary') do
+      expect(page).to have_link('Your application needs existing information corrected',
+                                href: '#prior-authority-steps-check-answers-form-base-field-error')
+    end
+
+    within('.govuk-form-group--error') do
+      expect(page).to have_css('#prior-authority-steps-check-answers-form-base-field-error.govuk-error-message',
+                               text: 'Your application needs existing information corrected')
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Add incorrect info text and error to check your answers

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1193)

Display the incorrect info comments for sent back statuses and error if no
changes made to the application before submission.

## Notes for reviewer

This also removes the persisted confirmations table columns in favour of virtual attributes
because they would otherwise need resetting as part of the assessment sync for sent back
events. Their removal makes this redundant and handles similar possible situations for
other status changes requiring resubmission.

## Screenshots of changes (if applicable)

**Text**
![Screenshot 2024-03-26 at 09 35 13](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/bcd8c29f-26ee-4b12-8526-f65c5027eff1)

**Error**
![Screenshot 2024-03-26 at 09 35 07](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/5b515b5a-a8c4-4738-8bc1-5f10b13bf513)
