### PR TITLE
CRM457-1193: Change assessed tab to reviewed tab

### DIFF
--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -2,7 +2,7 @@ module PriorAuthority
   class ApplicationsController < ApplicationController
     before_action :set_default_table_sort_options
     before_action :load_drafts, only: %i[index draft]
-    before_action :load_assessed, only: %i[index assessed]
+    before_action :load_reviewed, only: %i[index reviewed]
     before_action :load_submitted, only: %i[index submitted]
     layout 'prior_authority'
 
@@ -39,7 +39,7 @@ module PriorAuthority
       render layout: nil
     end
 
-    def assessed
+    def reviewed
       render layout: nil
     end
 
@@ -57,8 +57,8 @@ module PriorAuthority
       @draft_pagy, @draft_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).draft)
     end
 
-    def load_assessed
-      @assessed_pagy, @assessed_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).assessed)
+    def load_reviewed
+      @reviewed_pagy, @reviewed_model = order_and_paginate(PriorAuthorityApplication.for(current_provider).reviewed)
     end
 
     def load_submitted

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,7 @@ module ApplicationHelper
     when 'draft'
       :draft
     else
-      :assessed
+      :reviewed
     end
   end
 end

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -5,6 +5,7 @@ module TagHelper
     auto_grant: 'govuk-tag--green',
     part_grant: 'govuk-tag--blue',
     rejected: 'govuk-tag--red',
+    sent_back: 'govuk-tag--yellow',
   }.freeze
 
   def prior_authority_tag_colour(status)

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -44,7 +44,7 @@ class PriorAuthorityApplication < ApplicationRecord
     expired: 'expired'
   }
 
-  scope :assessed, -> { where(status: %i[granted part_grant rejected auto_grant]) }
+  scope :reviewed, -> { where(status: %i[granted part_grant rejected auto_grant sent_back]) }
 
   scope :for, ->(provider) { where(office_code: provider.selected_office_code) }
 

--- a/app/views/prior_authority/applications/assessed.html.erb
+++ b/app/views/prior_authority/applications/assessed.html.erb
@@ -1,3 +1,0 @@
-<turbo-frame id="assessed_applications">
-  <%= render 'prior_authority/applications/frame_contents/assessed', model: @assessed_model, pagy: @assessed_pagy %>
-</turbo-frame>

--- a/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
+++ b/app/views/prior_authority/applications/frame_contents/_reviewed.html.erb
@@ -1,15 +1,15 @@
 <% if model.none? %>
-  <p><%= t('prior_authority.applications.tabs.no_assessed') %></p>
+  <p><%= t('prior_authority.applications.tabs.no_reviewed') %></p>
 <% else %>
-  <h2 class="govuk-heading-m"><%= t('prior_authority.applications.tabs.assessed') %></h2>
-  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_submitted">
+  <h2 class="govuk-heading-m"><%= t('prior_authority.applications.tabs.reviewed') %></h2>
+  <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="tab_reviewed">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <% ['ufn', 'client', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>
           <%= table_header(key,
                           'prior_authority.applications.tabs.header',
                            index,
-                           assessed_prior_authority_applications_path,
+                           reviewed_prior_authority_applications_path,
                            @sort_by,
                            @sort_direction) %>
         <% end %>

--- a/app/views/prior_authority/applications/index.html.erb
+++ b/app/views/prior_authority/applications/index.html.erb
@@ -25,9 +25,9 @@
     <div class="govuk-grid-column-full">
 
       <%= govuk_tabs(title: t(".page_title"), classes: ['reload-visible-turboframes'], html_attributes: { data: { selector: '.govuk-tabs__tab' }}) do |c| %>
-        <% c.with_tab(label: t(".tabs.assessed")) do %>
-          <%= turbo_frame_tag 'assessed_applications', src: assessed_prior_authority_applications_path, loading: :lazy do %>
-            <%= render 'prior_authority/applications/frame_contents/assessed', model: @assessed_model, pagy: @assessed_pagy %>
+        <% c.with_tab(label: t(".tabs.reviewed")) do %>
+          <%= turbo_frame_tag 'reviewed_applications', src: reviewed_prior_authority_applications_path, loading: :lazy do %>
+            <%= render 'prior_authority/applications/frame_contents/reviewed', model: @reviewed_model, pagy: @reviewed_pagy %>
           <% end %>
         <% end %>
         <% c.with_tab(label: t(".tabs.submitted")) do %>

--- a/app/views/prior_authority/applications/reviewed.html.erb
+++ b/app/views/prior_authority/applications/reviewed.html.erb
@@ -1,0 +1,3 @@
+<turbo-frame id="reviewed_applications">
+  <%= render 'prior_authority/applications/frame_contents/reviewed', model: @reviewed_model, pagy: @reviewed_pagy %>
+</turbo-frame>

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -16,14 +16,14 @@ en:
         tabs:
           drafts: Drafts
           submitted: Submitted
-          assessed: Assessed
+          reviewed: Reviewed
       tabs:
         drafts: Drafts
         submitted: Submitted
-        assessed: Assessed
+        reviewed: Reviewed
         no_drafts: You do not have any draft applications.
-        no_submitted: You do not have any applications waiting to be assessed.
-        no_assessed: You do not have any applications that have been assessed.
+        no_submitted: You do not have any applications waiting to be reviewed.
+        no_reviewed: You do not have any applications that have been reviewed.
         application: application
         header:
           ufn: UFN
@@ -37,6 +37,7 @@ en:
           auto_grant: Granted
           part_grant: Part granted
           rejected: Rejected
+          sent_back: Update needed
         delete: Delete
       confirm_delete:
         page_title: Are you sure you want to delete this draft application?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
       collection do
         get :draft
         get :submitted
-        get :assessed
+        get :reviewed
       end
       member do
         get 'offboard'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,8 +57,21 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe '#relevant_prior_authority_list_anchor' do
-    let(:application) { build(:prior_authority_application, status: 'draft') }
+    let(:application) { build(:prior_authority_application) }
 
-    it { expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:draft) }
+    it 'returns draft for draft status' do
+      allow(application).to receive(:status).and_return('draft')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:draft)
+    end
+
+    it 'returns submitted for submitted status' do
+      allow(application).to receive(:status).and_return('submitted')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:submitted)
+    end
+
+    it 'returns reviewed for all statuses other than draft or submitted' do
+      allow(application).to receive(:status).and_return('whatever')
+      expect(helper.relevant_prior_authority_list_anchor(application)).to eq(:reviewed)
+    end
   end
 end

--- a/spec/system/prior_authority/application_lists_spec.rb
+++ b/spec/system/prior_authority/application_lists_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe 'Prior authority application lists' do
            status: 'submitted',
            updated_at: 1.day.ago)
     create(:prior_authority_application, laa_reference: 'LAA-BBBBB', status: 'submitted', updated_at: 2.days.ago)
-    create(:prior_authority_application, laa_reference: 'LAA-CCCCC', status: 'granted', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC1', status: 'granted', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC2', status: 'sent_back', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC3', status: 'part_grant', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC4', status: 'rejected', updated_at: 3.days.ago)
+    create(:prior_authority_application, laa_reference: 'LAA-CCCC5', status: 'auto_grant', updated_at: 3.days.ago)
     create(:prior_authority_application, laa_reference: 'LAA-DDDDD', status: 'draft', updated_at: 4.days.ago)
     create(:prior_authority_application, laa_reference: 'LAA-EEEEE', status: 'draft', office_code: 'OTHER')
 
@@ -19,12 +23,18 @@ RSpec.describe 'Prior authority application lists' do
 
   it 'only shows right applications in the right tabs' do
     within '#submitted' do
-      expect(page).to have_content 'AAAAA'
-      expect(page).to have_content 'BBBBB'
+      expect(page)
+        .to have_content('AAAAA')
+        .and have_content('BBBBB')
     end
 
-    within '#assessed' do
-      expect(page).to have_content 'CCCCC'
+    within '#reviewed' do
+      expect(page)
+        .to have_content('CCCC1')
+        .and have_content('CCCC2')
+        .and have_content('CCCC3')
+        .and have_content('CCCC4')
+        .and have_content('CCCC5')
     end
 
     within '#drafts' do


### PR DESCRIPTION
## Description of change
Change assessed tab to reviewed tab

[Came out of work on](https://dsdmoj.atlassian.net/browse/CRM457-1193)

Rename tab in line with designs and include applications
with a status of sent_back.

### After changes:
![Screenshot 2024-03-25 at 10 13 29](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/5005987e-4edf-4f9a-9caf-93df4a1e06d2)


