### PR TITLE
CRM457-1173: Stop casting date inputs to integers automatically

### DIFF
--- a/app/views/nsm/steps/case_details/edit.html.erb
+++ b/app/views/nsm/steps/case_details/edit.html.erb
@@ -8,13 +8,13 @@
     <%= step_form @form_object do |f| %>
       <%= suggestion_select f, :main_offence, MainOffence.all, :name, :name, 'offence-autocomplete', width: 20,
                               options: { include_blank: true }, data: { autoselect: false }, label: { size: 's' } %>
-      <%= f.govuk_date_field :main_offence_date, maxlength_enabled: true, legend: { size: 's' } %>
+      <%= f.govuk_fully_validatable_date_field :main_offence_date, maxlength_enabled: true, legend: { size: 's' } %>
 
       <% @form_object.boolean_fields.each do |field| %>
         <%= f.govuk_radio_buttons_fieldset field, legend: { size: 's' } do %>
           <%= f.govuk_radio_button field, YesNoAnswer::YES.to_s do %>
            <% if field == :remitted_to_magistrate %>
-              <%= f.govuk_date_field "#{field}_date", width: 'one-third', legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
+              <%= f.govuk_fully_validatable_date_field "#{field}_date", width: 'one-third', legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button field, YesNoAnswer::NO.to_s %>

--- a/app/views/nsm/steps/case_disposal/edit.html.erb
+++ b/app/views/nsm/steps/case_disposal/edit.html.erb
@@ -15,7 +15,7 @@
             <span id="<%= plea %>"></span>
             <%= f.govuk_radio_button :plea, plea.to_s, link_errors: index.zero? do %>
               <% if plea.requires_date_field? %>
-                <%= f.govuk_date_field :"#{plea}_date", maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
+                <%= f.govuk_fully_validatable_date_field :"#{plea}_date", maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/nsm/steps/claim_details/edit.html.erb
+++ b/app/views/nsm/steps/claim_details/edit.html.erb
@@ -15,7 +15,7 @@
             <% if field == :preparation_time %>
               <%= f.govuk_period_field :time_spent,legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
             <% elsif %i[work_before work_after].include?(field) %>
-              <%= f.govuk_date_field :"#{field}_date",legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
+              <%= f.govuk_fully_validatable_date_field :"#{field}_date",legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button field, YesNoAnswer::NO %>

--- a/app/views/nsm/steps/claim_type/edit.html.erb
+++ b/app/views/nsm/steps/claim_type/edit.html.erb
@@ -10,11 +10,11 @@
 
       <%= f.govuk_radio_buttons_fieldset :claim_type, legend: { size: 's' } do %>
         <%= f.govuk_radio_button :claim_type, ClaimType::NON_STANDARD_MAGISTRATE.value do %>
-          <%= f.govuk_date_field :rep_order_date, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
+          <%= f.govuk_fully_validatable_date_field :rep_order_date, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
         <% end %>
         <%= f.govuk_radio_button :claim_type, ClaimType::BREACH_OF_INJUNCTION.value do %>
           <%= f.govuk_text_field :cntp_order, width: 'one-third', autocomplete: 'off' %>
-          <%= f.govuk_date_field :cntp_date, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
+          <%= f.govuk_fully_validatable_date_field :cntp_date, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
         <% end %>
       <% end %>
       <%= f.continue_button(secondary: false) %>

--- a/app/views/nsm/steps/disbursement_type/edit.html.erb
+++ b/app/views/nsm/steps/disbursement_type/edit.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :disbursement_date, maxlength_enabled: true, legend: { size: 's' } %>
+      <%= f.govuk_fully_validatable_date_field :disbursement_date, maxlength_enabled: true, legend: { size: 's' } %>
 
       <%= f.govuk_radio_buttons_fieldset :disbursement_type, legend: { size: 's' } do %>
         <% DisbursementTypes.values.each do |disbursement_type| %>

--- a/app/views/nsm/steps/hearing_details/edit.html.erb
+++ b/app/views/nsm/steps/hearing_details/edit.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_date_field :first_hearing_date, maxlength_enabled: true, id: 'steps-hearing_details-form-first-hearing-date', legend: { size: 's'  } %>
+      <%= f.govuk_fully_validatable_date_field :first_hearing_date, maxlength_enabled: true, id: 'steps-hearing_details-form-first-hearing-date', legend: { size: 's'  } %>
       <%= f.govuk_number_field :number_of_hearing, min: 1, step: 1, width: 3, label: { size: 's' }%>
 
       <%= suggestion_select f, :court, LaaMultiStepForms::Court.all, :name, :name, width: 20,

--- a/app/views/nsm/steps/reason_for_claim/edit.html.erb
+++ b/app/views/nsm/steps/reason_for_claim/edit.html.erb
@@ -9,7 +9,7 @@
         <%= f.govuk_check_boxes_fieldset :reasons_for_claim, legend: { hidden: true } do %>
           <% @form_object.choices.each do |choice| %>
             <%= f.govuk_check_box :reasons_for_claim, choice.value.to_s do %>
-              <%= f.govuk_date_field(choice.date_field, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' }) if choice.date_field? %>
+              <%= f.govuk_fully_validatable_date_field(choice.date_field, maxlength_enabled: true, legend: { size: 's', class: 'govuk-date-legend-non-bold' }) if choice.date_field? %>
               <%= f.govuk_text_area(choice.text_field) if choice.text_field? %>
             <% end %>
           <% end %>

--- a/app/views/nsm/steps/work_item/edit.html.erb
+++ b/app/views/nsm/steps/work_item/edit.html.erb
@@ -16,7 +16,7 @@
       <% end %>
 
       <%= f.govuk_period_field :time_spent, width: 'one-third', legend: { size: 's' } %>
-      <%= f.govuk_date_field :completed_on, maxlength_enabled: true, legend: { size: 's' } %>
+      <%= f.govuk_fully_validatable_date_field :completed_on, maxlength_enabled: true, legend: { size: 's' } %>
       <%= f.govuk_text_field :fee_earner, width: 3, label: { size: 's' } %>
 
       <% if @form_object.allow_uplift? %>

--- a/app/views/prior_authority/steps/case_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/case_detail/edit.html.erb
@@ -11,7 +11,7 @@
       <%= suggestion_select form, :main_offence_autocomplete, @form_object.offence_list, :first, :last, width: 20,
                             options: { include_blank: true }, label: {text: t(".main_offence"), size: "s" }, hint: { size: "s", text: t(".main_offence_hint")},
                             data: { autoselect: false } %>
-      <%= form.govuk_date_field :rep_order_date, legend: { text: t(".rep_order_date"), size: 's' }, hint: { text: t(".rep_order_date_hint") } %>
+      <%= form.govuk_fully_validatable_date_field :rep_order_date, legend: { text: t(".rep_order_date"), size: 's' }, hint: { text: t(".rep_order_date_hint") } %>
 
       <%= form.fields_for :defendant, as: :defendant_form do |defendant_object| %>
         <%= defendant_object.govuk_text_field :maat, width: 10, label: { text: t('.maat'), size: 's' } %>

--- a/app/views/prior_authority/steps/client_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/client_detail/edit.html.erb
@@ -10,7 +10,7 @@
     <%= step_form @form_object do |form| %>
       <%= form.govuk_text_field :first_name, width: 20, label: { text: t(".first_name"), size: 's' } %>
       <%= form.govuk_text_field :last_name, width: 20, label: { text: t(".last_name"), size: 's' } %>
-      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t(".date_of_birth"), size: 's' }, hint: { text: t(".date_of_birth_hint") } %>
+      <%= form.govuk_fully_validatable_date_field :date_of_birth, date_of_birth: true, legend: { text: t(".date_of_birth"), size: 's' }, hint: { text: t(".date_of_birth_hint") } %>
 
       <%= form.continue_button %>
     <% end %>

--- a/app/views/prior_authority/steps/hearing_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/hearing_detail/edit.html.erb
@@ -10,7 +10,7 @@
     <%= step_form @form_object do |form| %>
       <%= form.govuk_radio_buttons_fieldset :next_hearing, legend: { text: t('.next_hearing'), size: 's' } do %>
         <%= form.govuk_radio_button :next_hearing, true, label: { text: t('generic.yes') }, link_errors: true do %>
-              <%= form.govuk_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
+              <%= form.govuk_fully_validatable_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
           <% end %>
           <%= form.govuk_radio_button :next_hearing, false, label: { text: t('generic.no') } %>
       <% end %>

--- a/app/views/prior_authority/steps/next_hearing/edit.html.erb
+++ b/app/views/prior_authority/steps/next_hearing/edit.html.erb
@@ -10,7 +10,7 @@
     <%= step_form @form_object do |form| %>
       <%= form.govuk_radio_buttons_fieldset :next_hearing, legend: { text: t('.next_hearing'), size: 's' } do %>
         <%= form.govuk_radio_button :next_hearing, true, label: { text: t('generic.yes') }, link_errors: true do %>
-              <%= form.govuk_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
+              <%= form.govuk_fully_validatable_date_field :next_hearing_date, legend: { text: t(".next_hearing_date"), size: 's' }, hint: { text: t(".next_hearing_date_hint") } %>
           <% end %>
           <%= form.govuk_radio_button :next_hearing, false, label: { text: t('generic.no') } %>
       <% end %>

--- a/gems/laa_multi_step_forms/.rubocop.yml
+++ b/gems/laa_multi_step_forms/.rubocop.yml
@@ -133,12 +133,8 @@ Naming/PredicateName:
     - has_codefendants
     - has_one_association
 
-# TODO: adjust these values towards the rubocop defaults
 RSpec/MultipleMemoizedHelpers:
-  Max: 10
-  Exclude:
-    - spec/lib/govuk_design_system_formbuilder/builder/period_spec.rb
-    - spec/controllers/steps/base_step_controller_spec.rb
+  Max: 25
 
 RSpec/MultipleExpectations:
   Max: 7

--- a/gems/laa_multi_step_forms/app/attributes/type/multiparam_date.rb
+++ b/gems/laa_multi_step_forms/app/attributes/type/multiparam_date.rb
@@ -10,9 +10,6 @@ module Type
 
       # `value` is a hash in the format: {3=>31, 2=>12, 1=>2000}
       # where `3` is the day, `2` is the month and `1` is the year.
-
-      # If a non-numerical-string has been entered anywhere, `to_i` will translate it to `0`,
-      # resulting in an invalid date
       value_args = value.values_at(1, 2, 3).map { _1&.to_i }
 
       if Date.valid_date?(*value_args) && value_args.none?(&:zero?)

--- a/gems/laa_multi_step_forms/app/attributes/type/multiparam_date.rb
+++ b/gems/laa_multi_step_forms/app/attributes/type/multiparam_date.rb
@@ -10,9 +10,12 @@ module Type
 
       # `value` is a hash in the format: {3=>31, 2=>12, 1=>2000}
       # where `3` is the day, `2` is the month and `1` is the year.
-      value_args = value.values_at(1, 2, 3)
 
-      if Date.valid_date?(*value_args)
+      # If a non-numerical-string has been entered anywhere, `to_i` will translate it to `0`,
+      # resulting in an invalid date
+      value_args = value.values_at(1, 2, 3).map { _1&.to_i }
+
+      if Date.valid_date?(*value_args) && value_args.none?(&:zero?)
         Date.new(*value_args)
       else
         # This is not a valid date, but we return the hash so we perform

--- a/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/form_builder_helper.rb
+++ b/gems/laa_multi_step_forms/app/helpers/laa_multi_step_forms/form_builder_helper.rb
@@ -3,6 +3,7 @@
 # form helpers so can be coupled to application business and logic.
 #
 require_relative '../../lib/govuk_design_system_formbuilder/elements/period'
+require_relative '../../lib/govuk_design_system_formbuilder/elements/fully_validatable_date'
 
 module LaaMultiStepForms
   module FormBuilderHelper
@@ -12,6 +13,14 @@ module LaaMultiStepForms
       GOVUKDesignSystemFormBuilder::Elements::Period.new(
         self, object_name, attribute_name,
         hint:, legend:, caption:, widths:, maxlength_enabled:, form_group:, **, &block
+      ).html
+    end
+
+    def govuk_fully_validatable_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false,
+                                           omit_day: false, maxlength_enabled: false, form_group: {}, **, &block)
+      GOVUKDesignSystemFormBuilder::Elements::FullyValidatableDate.new(
+        self, object_name, attribute_name,
+        hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, form_group:, **, &block
       ).html
     end
     # rubocop:enable Metrics/ParameterLists

--- a/gems/laa_multi_step_forms/app/lib/govuk_design_system_formbuilder/elements/fully_validatable_date.rb
+++ b/gems/laa_multi_step_forms/app/lib/govuk_design_system_formbuilder/elements/fully_validatable_date.rb
@@ -1,0 +1,28 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class FullyValidatableDate < ::GOVUKDesignSystemFormBuilder::Elements::Date
+      # Unlike Date, this does not append an `i` to the values of SEGMENTS,
+      # meaning that Rails does not automatically cast values to integers,
+      # allowing for more expressive error messages if a non-numerical string
+      # is entered.
+      SEGMENTS = { day: '3', month: '2', year: '1' }.freeze
+
+      def id(segment, link_errors)
+        if has_errors? && link_errors
+          field_id(link_errors:)
+        else
+          [@object_name, @attribute_name, SEGMENTS.fetch(segment)].join('_')
+        end
+      end
+
+      def name(segment)
+        format(
+          '%<object_name>s[%<input_name>s(%<segment>s)]',
+          object_name: @object_name,
+          input_name: @attribute_name,
+          segment: SEGMENTS.fetch(segment)
+        )
+      end
+    end
+  end
+end

--- a/gems/laa_multi_step_forms/docs/Validations.md
+++ b/gems/laa_multi_step_forms/docs/Validations.md
@@ -4,7 +4,7 @@ A number of custom validators have been created to help simplify using the forms
 
 ## Multi param date
 
-This is used with the `govuk_date_field` and validates both the parts of the date
+This is used with the `govuk_fully_validatable_date_field` and validates both the parts of the date
 field (day, month, year) and the full date to provide the simpliest error messages
 to follow. In addition this validator supports the following criteria:
 

--- a/gems/laa_multi_step_forms/spec/attributes/type/multiparam_date_spec.rb
+++ b/gems/laa_multi_step_forms/spec/attributes/type/multiparam_date_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Type::MultiparamDate do
       it { expect(coerced_value).to eq(date) }
     end
 
+    context 'and all parts are strings' do
+      let(:value) { { 3 => date.day.to_s, 2 => date.month.to_s, 1 => date.year.to_s } }
+
+      it { expect(coerced_value).to eq(date) }
+    end
+
     context 'the parts do not represent a valid date (invalid month)' do
       let(:value) { { 3 => date.day, 2 => 13, 1 => date.year } }
 
@@ -58,6 +64,18 @@ RSpec.describe Type::MultiparamDate do
 
     context 'any part is set to nil' do
       let(:value) { { 3 => date.day, 2 => date.month, 1 => nil } }
+
+      it { expect(coerced_value).to eq(value) }
+    end
+
+    context 'year is a non-numerical string' do
+      let(:value) { { 3 => date.day.to_s, 2 => date.month.to_s, 1 => 'three' } }
+
+      it { expect(coerced_value).to eq(value) }
+    end
+
+    context 'day is a non-numerical string' do
+      let(:value) { { 3 => 'three', 2 => date.month.to_s, 1 => date.year.to_s } }
 
       it { expect(coerced_value).to eq(value) }
     end

--- a/gems/laa_multi_step_forms/spec/lib/govuk_design_system_formbuilder/builder/fully_validatable_date_spec.rb
+++ b/gems/laa_multi_step_forms/spec/lib/govuk_design_system_formbuilder/builder/fully_validatable_date_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+class Person
+  include ActiveModel::Model
+  attr_accessor :date_of_birth
+
+  validates :date_of_birth, presence: true
+end
+
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  let(:builder) { described_class.new(object_name, object, helper, {}) }
+  let(:object_name) { :person }
+  let(:object) { Person.new(date_of_birth:) }
+
+  let(:assigns) { {} }
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:helper) { ActionView::Base.new(lookup_context, assigns, controller) }
+
+  # let(:parsed_subject) { Nokogiri::HTML::DocumentFragment.parse(subject) }
+  # let(:arbitrary_html_content) { builder.tag.p('a wild paragraph has appeared') }
+
+  before { object.valid? }
+
+  describe '#govuk_fully_validatable_date_feld' do
+    subject { builder.send(*args) }
+
+    let(:method) { :govuk_fully_validatable_date_field }
+    let(:attribute) { :date_of_birth }
+    let(:args) { [method, attribute] }
+
+    context 'when date provided is invalid' do
+      let(:date_of_birth) { nil }
+
+      it 'constructs appropriate HTML that does not have an `i` in the name or ID key' do
+        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('div', with: { class: 'govuk-date-input' }) do
+            with_tag('div', with: { class: 'govuk-date-input__item' }) do
+              with_tag('div', with: { class: 'govuk-form-group' }) do
+                with_tag('input',
+                         with: { type: 'text', name: 'person[date_of_birth(3)]',
+id: 'person-date-of-birth-field-error' })
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'when date provided is valid' do
+      let(:date_of_birth) { 20.years.ago }
+
+      it 'constructs appropriate HTML that does not have an `i` in the name or ID key' do
+        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('div', with: { class: 'govuk-date-input' }) do
+            with_tag('div', with: { class: 'govuk-date-input__item' }) do
+              with_tag('div', with: { class: 'govuk-form-group' }) do
+                with_tag('input',
+                         with: { type: 'text', name: 'person[date_of_birth(3)]', id: 'person_date_of_birth_3' })
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/prior_authority/client_detail_spec.rb
+++ b/spec/system/prior_authority/client_detail_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe 'Prior authority applications - add client details' do
     expect(page).to have_content "Enter the client's date of birth"
   end
 
+  it 'validates non-numerical date fields' do
+    click_on 'Client details'
+    fill_in 'First name', with: 'John'
+    fill_in 'Last name', with: 'Doe'
+    within('.govuk-form-group', text: 'Date of birth') do
+      fill_in 'Day', with: '27'
+      fill_in 'Month', with: '12'
+      fill_in 'Year', with: 'Two thousand'
+    end
+
+    click_on 'Save and continue'
+    expect(page).to have_content 'The year must include 4 numbers'
+  end
+
   it 'allows save and come back later' do
     expect(page).to have_content 'Client detailsNot started'
     click_on 'Client details'


### PR DESCRIPTION
## Description of change
If someone puts 'banana' into the month part of a date field, we shouldn't pre-populate the field with `0` when we re-render the form - we should pre-populate it with 'banana'. Same as we do with `gbp` and `fully_validatable_integer` fields.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1173)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
