### PR TITLE
CRM457-1188: Move error summary

### DIFF
--- a/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
@@ -10,6 +10,7 @@
                                     text: t('prior_authority.steps.alternative_quotes.deleted'),
                                     success: true) %>
     <% end %>
+    <%= govuk_error_summary(@form_object) %>
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= title_string %></h1>
     <% @form_object.alternative_quotes.each do |alternative_quote| %>
@@ -17,8 +18,6 @@
     <% end %>
 
     <%= step_form @form_object do |form| %>
-
-      <%= govuk_error_summary(@form_object) %>
       <% if @form_object.more_quotes_addable? %>
         <%= form.govuk_collection_radio_buttons(
           :alternative_quotes_still_to_add,


### PR DESCRIPTION
## Description of change
Error summaries typically go above the header, so this makes the alternative quotes screen do that.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1188)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
