### PR TITLE
CRM457-1200: Add fallback translation for all date validation errors

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -457,3 +457,9 @@ en:
         forbidden_document_type: The selected file must be a DOC, DOCX, XLSX, XLS, RTF, ODT, JPG, BMP, PNG, TIF or PDF
         suspected_malware: File potentially contains malware so cannot be uploaded. Please contact your administrator
         upload_failed: Unable to upload file at this time
+        invalid_day: Enter a valid day
+        invalid_month: Enter a valid month
+        invalid_year: Enter a valid year
+        year_too_early: Date is too far in the past
+        future_not_allowed: Date cannot be in the future
+        before_date_from: End date cannot be before start date

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
           .to include('Enter a hearing date')
       end
     end
+
+    context 'with invalid hearing date when one is expected' do
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing: true,
+          'next_hearing_date(3i)': '14',
+          'next_hearing_date(2i)': '10',
+          'next_hearing_date(1i)': '1066',
+        }
+      end
+
+      it 'has expected validation errors on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.messages.values.flatten)
+          .to include('Date is too far in the past')
+      end
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
## Description of change

Added generic error message fallbacks for all date-specific error fields
 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1200)


