### PR TITLE
Crm457 1281/randomise test data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri windows]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
+  gem 'faker'
   gem 'overcommit'
   gem 'pry'
   gem 'rspec-expectations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.3.0)
+      i18n (>= 1.8.11, < 2)
     faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -543,6 +545,7 @@ DEPENDENCIES
   dotenv-rails
   erb_lint
   factory_bot_rails (>= 6.4.3)
+  faker
   govuk_notify_rails (~> 2.2.0)
   hmcts_common_platform!
   httparty

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,8 +1,11 @@
 class ApplicationRecord < ActiveRecord::Base
+  # Needed as Faker loads a number of unrelated locales
+  RENDERED_LOCALES = %i[en].freeze
+
   primary_abstract_class
 
   def translations(value, key, default = value)
-    I18n.available_locales.each_with_object(value:) do |locale, hash|
+    RENDERED_LOCALES.each_with_object(value:) do |locale, hash|
       hash[locale] = value.blank? ? nil : I18n.t("#{key}.#{value}", default:, locale:)
     end
   end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -55,7 +55,6 @@ FactoryBot.define do
     end
 
     trait :case_details do
-      # ufn { '20150612/001' }
       main_offence { MainOffence.all.sample.name }
       main_offence_date { Date.yesterday }
 

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     office_code { '1A123B' }
     laa_reference { 'LAA-n4AohV' }
 
+    transient do
+      date { Date.new(2023, 4, 12) }
+    end
+
     trait :complete do
       firm_details
       main_defendant
@@ -20,16 +24,16 @@ FactoryBot.define do
     end
 
     trait :case_type_magistrates do
-      ufn { '120423/001' }
+      ufn { "#{date.strftime('%d%m%y')}/001" }
       claim_type { 'non_standard_magistrate' }
-      rep_order_date { '2023-01-01' }
+      rep_order_date { date.strftime('%Y-%m-%d') }
     end
 
     trait :case_type_breach do
-      ufn { '120423/002' }
+      ufn { "#{date.strftime('%d%m%y')}/002" }
       claim_type { 'breach_of_injunction' }
-      cntp_order { 'CNTP12345' }
-      cntp_date { '2023-02-01' }
+      cntp_order { "CNTP#{rand(10_000)}" }
+      cntp_date { date.strftime('%Y-%m-%d') }
     end
 
     trait :firm_details do
@@ -51,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :case_details do
-      ufn { '20150612/001' }
+      # ufn { '20150612/001' }
       main_offence { MainOffence.all.sample.name }
       main_offence_date { Date.yesterday }
 
@@ -63,16 +67,16 @@ FactoryBot.define do
 
     trait :with_remittal do
       remitted_to_magistrate { 'yes' }
-      remitted_to_magistrate_date { Date.new(2023, 3, 1) }
+      remitted_to_magistrate_date { date + rand(40) }
     end
 
     trait :hearing_details do
-      first_hearing_date { Date.new(2023, 3, 1) }
+      first_hearing_date { date + rand(40) }
       number_of_hearing { 1 }
       youth_court { 'no' }
       in_area { 'yes' }
       court { 'A Court' }
-      hearing_outcome { 'CP01' }
+      hearing_outcome { OutcomeCode.all.sample.id }
       matter_type { '1' }
     end
 

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -1,23 +1,23 @@
 FactoryBot.define do
   factory :defendant do
     trait :valid do
-      first_name { 'bob' }
-      last_name { 'jim' }
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
       maat { 'AA1' }
       position { 1 }
       main { true }
     end
 
     trait :valid_paa do
-      first_name { 'bob' }
-      last_name { 'jim' }
-      date_of_birth { Date.new(1981, 11, 12) }
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
+      date_of_birth { Faker::Date.birthday(min_age: 18, max_age: 65) }
       maat { 'AA1' }
     end
 
     trait :partial do
-      first_name { 'bob' }
-      last_name { 'jim' }
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
       main { true }
     end
   end

--- a/spec/factories/disbursements.rb
+++ b/spec/factories/disbursements.rb
@@ -2,13 +2,13 @@ FactoryBot.define do
   factory :disbursement do
     # using age as a shorthane  to set the disbursement date
     transient do
-      age { 1 }
+      age { rand(40) }
     end
 
     trait :valid do
       disbursement_date { age.days.ago.to_date }
       disbursement_type { DisbursementTypes.values.reject(&:other?).sample.to_s }
-      miles { 100 }
+      miles { 50 + 200**Random.new.rand(1.0).to_i } # range: 50 -> 250
       total_cost_without_vat do |disb|
         Pricing.for(Claim.new)[disb.disbursement_type] * disb.miles
       end

--- a/spec/factories/disbursements.rb
+++ b/spec/factories/disbursements.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     trait :valid do
       disbursement_date { age.days.ago.to_date }
       disbursement_type { DisbursementTypes.values.reject(&:other?).sample.to_s }
-      miles { 50 + 200**Random.new.rand(1.0).to_i } # range: 50 -> 250
+      miles { 50 + (200**Random.new.rand(1.0).to_i) } # range: 50 -> 250
       total_cost_without_vat do |disb|
         Pricing.for(Claim.new)[disb.disbursement_type] * disb.miles
       end

--- a/spec/factories/work_items.rb
+++ b/spec/factories/work_items.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :work_item do
     trait :valid do
       work_type { WorkTypes.values.sample.to_s }
-      time_spent { 100 }
-      completed_on { Date.yesterday }
-      fee_earner { 'jimbob' }
+      time_spent { 50 + 400**Random.new.rand(1.0).to_i } # range: 50 -> 450
+      completed_on { rand(40).days.ago.to_date }
+      fee_earner { Faker::Name.name }
     end
 
     trait :partial do

--- a/spec/factories/work_items.rb
+++ b/spec/factories/work_items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :work_item do
     trait :valid do
       work_type { WorkTypes.values.sample.to_s }
-      time_spent { 50 + 400**Random.new.rand(1.0).to_i } # range: 50 -> 450
+      time_spent { 50 + (400**Random.new.rand(1.0).to_i) } # range: 50 -> 450
       completed_on { rand(40).days.ago.to_date }
       fee_earner { Faker::Name.name }
     end

--- a/spec/mailers/nsm/submission_mailer_spec.rb
+++ b/spec/mailers/nsm/submission_mailer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Nsm::SubmissionMailer, type: :mailer do
         ).to include(
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '120423/001',
-          main_defendant_name: 'bob jim',
+          main_defendant_name: an_instance_of(String),
           defendant_reference: 'MAAT ID: AA1',
           claim_total: '£20.45',
           date: DateTime.now.to_fs(:stamp),
@@ -47,8 +47,8 @@ RSpec.describe Nsm::SubmissionMailer, type: :mailer do
         ).to include(
           LAA_case_reference: 'LAA-n4AohV',
           UFN: '120423/002',
-          main_defendant_name: 'bob jim',
-          defendant_reference: "Client's CNTP number: CNTP12345",
+          main_defendant_name: an_instance_of(String),
+          defendant_reference: /\AClient's CNTP number: CNTP\d+\z/,
           claim_total: '£20.45',
           date: DateTime.now.to_fs(:stamp),
         )

--- a/spec/mailers/prior_authority/submission_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_mailer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe PriorAuthority::SubmissionMailer, type: :mailer do
       ).to include(
         laa_case_reference: 'LAA-n4AohV',
         ufn: '120423/001',
-        defendant_name: 'bob jim',
+        defendant_name: an_instance_of(String),
         application_total: '£155.00',
         date: DateTime.now.to_fs(:stamp),
       )

--- a/spec/presenters/nsm/check_answers/case_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_details_card_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
 
   describe '#row_data' do
     it 'generates case detail rows with no remittal' do
-      expect(subject.row_data).to eq(
+      expect(subject.row_data).to match(
         [
           {
             head_key: 'main_offence',
@@ -23,7 +23,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
           },
           {
             head_key: 'main_offence_date',
-            text: '1 January 2023'
+            text: /\A\d{1,2} \w+ \d{4}\z/
           },
           {
             head_key: 'assigned_counsel',
@@ -49,7 +49,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
       let(:claim) { build(:claim, :case_details, :with_remittal, main_offence:, main_offence_date:) }
 
       it 'generates case detail rows with remittal' do
-        expect(subject.row_data).to eq(
+        expect(subject.row_data).to match(
           [
             {
               head_key: 'main_offence',
@@ -57,7 +57,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'main_offence_date',
-              text: '1 January 2023'
+              text: /\A\d{1,2} \w+ \d{4}\z/
             },
             {
               head_key: 'assigned_counsel',
@@ -77,7 +77,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'remitted_to_magistrate_date',
-              text: '1 March 2023'
+              text: /\A\d{1,2} \w+ \d{4}\z/
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/case_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_details_card_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
           },
           {
             head_key: 'main_offence_date',
-            text: /\A\d{1,2} \w+ \d{4}\z/
+            text: '1 January 2023'
           },
           {
             head_key: 'assigned_counsel',
@@ -46,7 +46,10 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
     end
 
     context 'when remitted to magistrate is yes' do
-      let(:claim) { build(:claim, :case_details, :with_remittal, main_offence:, main_offence_date:) }
+      let(:claim) do
+        build(:claim, :case_details, :with_remittal, main_offence:, main_offence_date:, remitted_to_magistrate_date:)
+      end
+      let(:remitted_to_magistrate_date) { Date.new(2023, 6, 30) }
 
       it 'generates case detail rows with remittal' do
         expect(subject.row_data).to match(
@@ -57,7 +60,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'main_offence_date',
-              text: /\A\d{1,2} \w+ \d{4}\z/
+            text: '1 January 2023'
             },
             {
               head_key: 'assigned_counsel',
@@ -77,7 +80,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'remitted_to_magistrate_date',
-              text: /\A\d{1,2} \w+ \d{4}\z/
+              text: '30 June 2023'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/case_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_details_card_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Nsm::CheckAnswers::CaseDetailsCard do
             },
             {
               head_key: 'main_offence_date',
-            text: '1 January 2023'
+              text: '1 January 2023'
             },
             {
               head_key: 'assigned_counsel',

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
 
   describe '#row_data' do
     context 'with non standard magistrates claim' do
-      let(:claim) { build(:claim, :case_type_magistrates) }
+      let(:claim) { build(:claim, :case_type_magistrates, rep_order_date:) }
+      let(:rep_order_date) { Date.new(2024, 3, 1) }
 
       it 'generates magistrates rows' do
         expect(subject.row_data).to match(
@@ -30,7 +31,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'rep_order_date',
-              text: /\A\d{1,2} \w+ \d{4}\z/
+              text: '1 March 2024'
             }
           ]
         )
@@ -47,7 +48,8 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
     end
 
     context 'with breach of injunction claim' do
-      let(:claim) { build(:claim, :case_type_breach) }
+      let(:claim) { build(:claim, :case_type_breach, cntp_date:) }
+      let(:cntp_date) { Date.new(2024, 2, 10) }
 
       it 'generates magistrates rows' do
         expect(subject.row_data).to match(
@@ -67,7 +69,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'cntp_rep_order',
-              text: /\A\d{1,2} \w+ \d{4}\z/
+              text: '10 February 2024'
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
       let(:claim) { build(:claim, :case_type_magistrates) }
 
       it 'generates magistrates rows' do
-        expect(subject.row_data).to eq(
+        expect(subject.row_data).to match(
           [
             {
               head_key: 'file_ufn',
@@ -30,7 +30,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'rep_order_date',
-              text: '1 January 2023'
+              text: /\A\d{1,2} \w+ \d{4}\z/
             }
           ]
         )
@@ -50,7 +50,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
       let(:claim) { build(:claim, :case_type_breach) }
 
       it 'generates magistrates rows' do
-        expect(subject.row_data).to eq(
+        expect(subject.row_data).to match(
           [
             {
               head_key: 'file_ufn',
@@ -63,11 +63,11 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             },
             {
               head_key: 'cntp_number',
-              text: 'CNTP12345'
+              text: /\ACNTP\d+\z/
             },
             {
               head_key: 'cntp_rep_order',
-              text: '1 February 2023'
+              text: /\A\d{1,2} \w+ \d{4}\z/
             }
           ]
         )

--- a/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
   subject { described_class.new(claim) }
 
-  let(:claim) { build(:claim, :hearing_details) }
+  let(:claim) { build(:claim, :hearing_details, first_hearing_date:) }
+  let(:first_hearing_date) { Date.new(2023, 12, 14) }
 
   describe '#initialize' do
     it 'creates the data instance' do
@@ -24,7 +25,7 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
         [
           {
             head_key: 'hearing_date',
-            text: /\A\d{1,2} \w+ \d{4}\z/
+            text: '14 December 2023'
           },
           {
             head_key: 'number_of_hearing',

--- a/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
 
   describe '#row_data' do
     it 'generates hearing details rows' do
-      expect(subject.row_data).to eq(
+      expect(subject.row_data).to match(
         [
           {
             head_key: 'hearing_date',
-            text: '1 March 2023'
+            text: /\A\d{1,2} \w+ \d{4}\z/
           },
           {
             head_key: 'number_of_hearing',
@@ -44,7 +44,7 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
           },
           {
             head_key: 'hearing_outcome',
-            text: 'Arrest warrant issued/adjourned indefinitely'
+            text: an_instance_of(String)
           },
           {
             head_key: 'matter_type',

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           [{
             'apply_vat' => 'true',
             'details' => 'Details',
-            'disbursement_date' => '2023-08-16',
+            'disbursement_date' => /\A\d{4}-\d{2}-\d{2}\z/,
             'disbursement_type' => { en: an_instance_of(String), value: disbursement.disbursement_type },
             'id' => disbursement.id,
-            'miles' => '100.0',
+            'miles' => disbursement.miles.to_s,
             'other_type' => { en: nil, value: nil },
             'pricing' => pricing[disbursement.disbursement_type],
             'prior_authority' => nil,
@@ -136,11 +136,11 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           'work_before_date' => nil,
           'work_items' =>
           [{
-            'completed_on' => '2023-08-16',
-            'fee_earner' => 'jimbob',
+            'completed_on' => /\A\d{4}-\d{2}-\d{2}\z/,
+            'fee_earner' => an_instance_of(String),
             'id' => work_item.id,
             'pricing' => pricing[work_item.work_type],
-            'time_spent' => 100,
+            'time_spent' => an_instance_of(Integer),
             'uplift' => nil,
             'work_type' => { en: an_instance_of(String), value: work_item.work_type },
           }],

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -9,14 +9,11 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
   let(:disbursement) { claim.disbursements.first }
   let(:work_item) { claim.work_items.first }
   let(:cost_total) { claim.cost_totals.first }
-  let(:tester) { double(:tester, process: true) }
   let(:pricing) { Pricing.for(claim) }
 
   it 'generates and send the data message for a claim' do
     travel_to(Time.zone.local(2023, 8, 17, 12, 13, 14)) do
-      tester.process(subject.payload)
-
-      expect(tester).to have_received(:process).with(
+      check_json(subject.payload).matches(
         application: {
           'agent_instructed' => 'no',
           'adjusted_total' => nil,
@@ -34,8 +31,8 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           'created_at' => '2023-08-17T12:13:14.000Z',
           'defence_statement' => nil,
           'defendants' => [{
-            'first_name' => 'bob',
-            'last_name' => 'jim',
+            'first_name' => an_instance_of(String),
+            'last_name' => an_instance_of(String),
             'id' => defendant.id,
             'maat' => 'AA1',
             'main' => true,
@@ -68,12 +65,12 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
             'town' => 'Lawyer Town',
             'vat_registered' => 'yes'
           },
-          'first_hearing_date' => '2023-03-01',
+          'first_hearing_date' => /\A\d{4}-\d{2}-\d{2}\z/,
           'gender' => { en: 'Male', value: 'm' },
           'has_disbursements' => nil,
           'hearing_outcome' => {
-            value: 'CP01',
-            en: 'Arrest warrant issued/adjourned indefinitely'
+            value: /\ACP\d{2}\z/,
+            en: an_instance_of(String)
           },
           'id' => claim.id,
           'in_area' => 'yes',
@@ -84,7 +81,7 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
             { 'count' => 3, 'pricing' => 4.09, 'type' => { en: 'Calls', value: 'calls' }, 'uplift' => nil }
           ],
           'main_offence' => claim.main_offence,
-          'main_offence_date' => '2023-08-16',
+          'main_offence_date' => /\A\d{4}-\d{2}-\d{2}\z/,
           'matter_type' => {
             value: '1',
             en: 'Offences against the person'
@@ -112,7 +109,7 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           ],
           'remitted_to_magistrate' => 'no',
           'remitted_to_magistrate_date' => nil,
-          'rep_order_date' => '2023-01-01',
+          'rep_order_date' => /\A\d{4}-\d{2}-\d{2}\z/,
           'representation_order_withdrawn_date' => nil,
           'send_by_post' => nil,
           'signatory_name' => nil,

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
 
   let(:expected_output) do
     {
-      application: {
+      application: hash_including(
         prison_law: true,
         ufn: '120423/123',
         laa_reference: 'LAA-n4AohV',
@@ -32,12 +32,12 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         no_alternative_quote_reason: 'a reason',
         confirm_excluding_vat: true,
         confirm_travel_expenditure: true,
-        defendant: {
-          first_name: 'bob',
-          last_name: 'jim',
+        defendant: hash_including(
+          first_name: an_instance_of(String),
+          last_name: an_instance_of(String),
           maat: 'AA1',
-          date_of_birth: '1981-11-12'
-        },
+          date_of_birth: /\A\d{4}-\d{2}-\d{2}\z/
+        ),
         firm_office: {
           account_number: '123ABC',
           address_line_1: '2 Laywer Suite',
@@ -124,7 +124,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
           }
         ],
         additional_costs: []
-      },
+      ),
       application_id: application.id,
       application_state: 'submitted',
       application_type: 'crm4',
@@ -143,6 +143,6 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
   end
 
   it 'generates the payload for an application' do
-    expect(subject.payload.with_indifferent_access).to eq(expected_output.with_indifferent_access)
+    check_json(subject.payload.deep_symbolize_keys).matches(expected_output)
   end
 end

--- a/spec/support/json_checker.rb
+++ b/spec/support/json_checker.rb
@@ -1,5 +1,8 @@
-# TODO: convert this to a matcher instead - if possible
+# Using this allows for easier diff checking as the `have_received` matcher puts individual line diff
+# instead of just the entire blob. This greatly speeds up the fixing process when something has been
+# changed
 module JsonChecker
+  # TODO: convert this to a matcher instead - if possible
   def check_json(payload)
     Checker.new(self, payload)
   end

--- a/spec/support/json_checker.rb
+++ b/spec/support/json_checker.rb
@@ -1,0 +1,23 @@
+# TODO: convert this to a matcher instead - if possible
+module JsonChecker
+  def check_json(payload)
+    Checker.new(self, payload)
+  end
+
+  class Checker
+    attr_reader :rspec, :payload
+
+    def initialize(rspec, payload)
+      @rspec = rspec
+      @payload = payload
+    end
+
+    def matches(json)
+      tester = rspec.double(:tester, process: true)
+      tester.process(payload)
+      rspec.expect(tester).to rspec.have_received(:process).with(json)
+    end
+  end
+end
+
+RSpec.configuration.include JsonChecker


### PR DESCRIPTION
## Description of change
Split this to a separate PR to merge quicker

Randomise the data that is produced for the tests, this will allow reuse of the Factories to create the performance testing data

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1281)
