### PR TITLE
Crm457 1287 update azure authentication

### DIFF
--- a/app/services/app_store_token_provider.rb
+++ b/app/services/app_store_token_provider.rb
@@ -39,7 +39,7 @@ class AppStoreTokenProvider
   end
 
   def app_store_client_id
-      ENV.fetch('APP_STORE_CLIENT_ID', nil)
+    ENV.fetch('APP_STORE_CLIENT_ID', nil)
   end
 
   def tenant_id

--- a/app/services/app_store_token_provider.rb
+++ b/app/services/app_store_token_provider.rb
@@ -31,11 +31,15 @@ class AppStoreTokenProvider
   private
 
   def new_access_token
-    oauth_client.client_credentials.get_token(scope: "api://#{client_id}/.default")
+    oauth_client.client_credentials.get_token(scope: "api://#{app_store_client_id}/.default")
   end
 
   def client_id
-    ENV.fetch('APP_STORE_CLIENT_ID', nil)
+    ENV.fetch('PROVIDER_CLIENT_ID', nil)
+  end
+
+  def app_store_client_id
+      ENV.fetch('APP_STORE_CLIENT_ID', nil)
   end
 
   def tenant_id
@@ -43,6 +47,6 @@ class AppStoreTokenProvider
   end
 
   def client_secret
-    ENV.fetch('APP_STORE_CLIENT_SECRET', nil)
+    ENV.fetch('PROVIDER_CLIENT_SECRET', nil)
   end
 end

--- a/docs/development-e2e-setup.md
+++ b/docs/development-e2e-setup.md
@@ -8,12 +8,13 @@ For provider app submission you will need to ensure you have the following env v
 
 ```sh
 # App store credentials (for authenticating to a local app store currently)
-# TODO: Oauth may be removed from local/development app store in the future
+# It is possible to develop locally without using Oauth in which case you should not declare APP_STORE_TENANT_ID.
+PROVIDER_CLIENT_ID=not-a-real-key
+PROVIDER_CLIENT_SECRET=not-a-real-key
 APP_STORE_CLIENT_ID=not-a-real-key
-APP_STORE_CLIENT_SECRET=not-a-real-key
 APP_STORE_TENANT_ID=not-a-real-key
 ```
-Ask a dev where these can be retrieved, and do not use production versions
+Ask a dev where these can be retrieved, and **do not use production versions**
 
 To receive emails to you own email address, or avoid errors on submission, you should supply the following ENV VAR
 ```sh

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -161,11 +161,16 @@ spec:
                 secretKeyRef:
                   name: app-store-auth
                   key: app_client_id
-            - name: APP_STORE_CLIENT_SECRET
+            - name: PROVIDER_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: app-store-auth
-                  key: app_client_secret
+                  key: provider_client_id
+            - name: PROVIDER_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-store-auth
+                  key: provider_client_secret
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -179,11 +179,16 @@ spec:
                 secretKeyRef:
                   name: app-store-auth
                   key: app_client_id
-            - name: APP_STORE_CLIENT_SECRET
+            - name: PROVIDER_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: app-store-auth
-                  key: app_client_secret
+                  key: provider_client_id
+            - name: PROVIDER_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: app-store-auth
+                  key: provider_client_secret
             - name: SIDEKIQ_WEB_UI_USERNAME
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
##

 [CRM457-1287](https://dsdmoj.atlassian.net/browse/CRM457-1287)

Previously the provider application was using credentials and secrets from the app store azure registration to verify it's identity with the app store.

It _should_ have been using it's own client registration. As can be seen in the [example documentation](https://intility.github.io/fastapi-azure-auth/usage-and-faq/calling_your_apis_from_python#single--and-multi-tenant), the scope uses a different client_id. 

Doing it this way will also allow us to use different roles for provider and caseworker once they have been implemented by Azure.

https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade
 
Two new azure registrations has been created for the provider application. 
`laa-crime-forms-provider-datastore-access [pre-production]` and `laa-crime-forms-provider-datastore-access [production]`

Client secrets are created in pre-production azure registration for the dev and uat environments and in the production azure environment for prod.


## Notes for reviewer

For this code to work - the `app-store-auth` secret needs to be updated in kubernetes to include the new keys.
That has been done - the old keys currently exist and should be deleted when this has been merged.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
You can check this works by adding in the correct environment variables to your env.local files and submitting an application. You should create your own secret in the azure registration.


[CRM457-1287]: https://dsdmoj.atlassian.net/browse/CRM457-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ