### PR TITLE
CRM457-1181: Stop using combined name fields

### DIFF
--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -9,7 +9,8 @@ module PriorAuthority
         end
 
         attribute :id, :string
-        attribute :contact_full_name, :string
+        attribute :contact_first_name, :string
+        attribute :contact_last_name, :string
         attribute :organisation, :string
         attribute :postcode, :string
         attribute :travel_time, :time_period
@@ -17,7 +18,8 @@ module PriorAuthority
         attribute :additional_cost_list, :string
         attribute :additional_cost_total, :gbp
 
-        validates :contact_full_name, presence: true
+        validates :contact_first_name, presence: true
+        validates :contact_last_name, presence: true
         validates :organisation, presence: true
         validates :postcode, presence: true, uk_postcode: true
         include DocumentUploadable
@@ -65,6 +67,8 @@ module PriorAuthority
         def document
           record.document || record.build_document
         end
+
+        delegate :contact_full_name, to: :record
 
         private
 

--- a/app/forms/prior_authority/steps/case_contact/solicitor_form.rb
+++ b/app/forms/prior_authority/steps/case_contact/solicitor_form.rb
@@ -2,10 +2,12 @@ module PriorAuthority
   module Steps
     module CaseContact
       class SolicitorForm < ::Steps::BaseFormObject
-        attribute :contact_full_name, :string
+        attribute :contact_first_name, :string
+        attribute :contact_last_name, :string
         attribute :contact_email, :string
 
-        validates :contact_full_name, presence: true, format: { with: /\A[a-z,.'\-]+( +[a-z,.'\-]+)+\z/i }
+        validates :contact_first_name, presence: true
+        validates :contact_last_name, presence: true
         validates :contact_email, presence: true, format: { with: /\A.*@.*\..*\z/ }
 
         private

--- a/app/forms/prior_authority/steps/primary_quote_form.rb
+++ b/app/forms/prior_authority/steps/primary_quote_form.rb
@@ -4,12 +4,14 @@ module PriorAuthority
       def self.attribute_names
         super - %w[service_type custom_service_name file_upload]
       end
-      attribute :contact_full_name, :string
+      attribute :contact_first_name, :string
+      attribute :contact_last_name, :string
       attribute :organisation, :string
       attribute :postcode, :string
 
       validates :service_type_autocomplete, presence: true
-      validates :contact_full_name, presence: true, format: { with: /\A[a-z,.'\-]+( +[a-z,.'\-]+)+\z/i }
+      validates :contact_first_name, presence: true
+      validates :contact_last_name, presence: true
       validates :organisation, presence: true
       validates :postcode, presence: true, uk_postcode: true
       include DocumentUploadable # Include this here so that validations appear in the correct order
@@ -59,6 +61,8 @@ module PriorAuthority
       def draft?
         application.status.in?(%w[pre_draft draft])
       end
+
+      delegate :contact_full_name, to: :record
 
       private
 

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -28,4 +28,8 @@ class Quote < ApplicationRecord
       additional_cost_total
     end
   end
+
+  def contact_full_name
+    "#{contact_first_name} #{contact_last_name}"
+  end
 end

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -3,4 +3,8 @@ class Solicitor < ApplicationRecord
   has_many :nexts, class_name: 'Solicitor', foreign_key: :previous_id, inverse_of: :previous, dependent: nil
 
   scope :latest, -> { left_joins(:nexts).where(nexts_solicitors: { id: nil }) }
+
+  def contact_full_name
+    "#{contact_first_name} #{contact_last_name}"
+  end
 end

--- a/app/presenters/nsm/check_answers/your_details_card.rb
+++ b/app/presenters/nsm/check_answers/your_details_card.rb
@@ -31,8 +31,12 @@ module Nsm
             text: check_missing(firm_details_form.firm_office.vat_registered.to_s.capitalize)
           },
           {
-            head_key: 'solicitor_full_name',
-            text: check_missing(firm_details_form.solicitor.full_name)
+            head_key: 'solicitor_first_name',
+            text: check_missing(firm_details_form.solicitor.first_name)
+          },
+          {
+            head_key: 'solicitor_last_name',
+            text: check_missing(firm_details_form.solicitor.last_name)
           },
           {
             head_key: 'solicitor_reference_number',
@@ -40,11 +44,17 @@ module Nsm
           },
         ]
 
-        if firm_details_form.solicitor.contact_full_name || firm_details_form.solicitor.contact_email
+        if firm_details_form.solicitor.contact_first_name ||
+           firm_details_form.solicitor.contact_last_name ||
+           firm_details_form.solicitor.contact_email
           data += [
             {
-              head_key: 'contact_full_name',
-              text: check_missing(firm_details_form.solicitor.contact_full_name)
+              head_key: 'contact_first_name',
+              text: check_missing(firm_details_form.solicitor.contact_first_name)
+            },
+            {
+              head_key: 'contact_last_name',
+              text: check_missing(firm_details_form.solicitor.contact_last_name)
             },
             {
               head_key: 'contact_email',

--- a/app/services/submit_to_app_store/nsm_payload_builder.rb
+++ b/app/services/submit_to_app_store/nsm_payload_builder.rb
@@ -23,15 +23,14 @@ class SubmitToAppStore
     private
 
     # rubocop:disable Metrics/AbcSize
-    # NOTE: slice! returns as hash with the other fields
     def data
-      data = claim.as_json.slice!('navigation_stack', 'firm_office_id', 'solicitor_id', 'submitter_id')
+      data = claim.as_json(except: %w[navigation_stack firm_office_id solicitor_id submitter_id])
       data.merge(
         'disbursements' => disbursement_data,
         'work_items' => work_item_data,
         'defendants' => defendant_data,
-        'firm_office' => claim.firm_office.attributes.slice!('id', *DEFAULT_IGNORE),
-        'solicitor' => claim.solicitor.attributes.slice!('id', *DEFAULT_IGNORE),
+        'firm_office' => claim.firm_office.attributes.except('id', *DEFAULT_IGNORE),
+        'solicitor' => claim.solicitor.attributes.except('id', *DEFAULT_IGNORE),
         'submitter' => claim.submitter.attributes.slice('email', 'description'),
         'supporting_evidences' => supporting_evidence,
         'cost_totals' => costs_data,
@@ -41,13 +40,13 @@ class SubmitToAppStore
 
     def costs_data
       claim.cost_totals.map do |cost|
-        cost.as_json.slice!(*DEFAULT_IGNORE)
+        cost.as_json(except: DEFAULT_IGNORE)
       end
     end
 
     def disbursement_data
       claim.disbursements.map do |disbursement|
-        data = disbursement.as_json.slice!(*DEFAULT_IGNORE)
+        data = disbursement.as_json(except: DEFAULT_IGNORE)
         data['disbursement_date'] = data['disbursement_date'].to_s
         data['pricing'] = pricing[disbursement.disbursement_type] || 1.0
         data['vat_rate'] = pricing[:vat]
@@ -60,7 +59,7 @@ class SubmitToAppStore
 
     def work_item_data
       claim.work_items.map do |work_item|
-        data = work_item.as_json.slice!(*DEFAULT_IGNORE)
+        data = work_item.as_json(except: DEFAULT_IGNORE)
         data['completed_on'] = data['completed_on'].to_s
         data['pricing'] = pricing[work_item.work_type]
         data

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -32,7 +32,8 @@ class SubmitToAppStore
         travel_time
         travel_cost_per_hour
         travel_cost_reason
-        contact_full_name
+        contact_first_name
+        contact_last_name
         organisation
         postcode
         primary

--- a/app/services/submit_to_app_store/prior_authority/solicitor_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/solicitor_payload_builder.rb
@@ -7,9 +7,9 @@ class SubmitToAppStore
 
       def payload
         @application.solicitor.as_json(only: %i[
-                                         full_name
                                          reference_number
-                                         contact_full_name
+                                         contact_first_name
+                                         contact_last_name
                                          contact_email
                                        ])
       end

--- a/app/views/nsm/steps/firm_details/edit.html.erb
+++ b/app/views/nsm/steps/firm_details/edit.html.erb
@@ -26,14 +26,16 @@
       <%= f.fields_for :solicitor, as: :firm_details_form do |so| %>
         <%# used govuk_radio_buttons_fieldset instead of govuk_fieldset as it allows hints to be rendered %>
         <%= f.govuk_radio_buttons_fieldset :solicitor_details, legend: { size: 'm', is_page_heading: true } do %>
-          <%= so.govuk_text_field :full_name, width: 20, label: { size: 's' } %>
+          <%= so.govuk_text_field :first_name, width: 20, label: { size: 's' } %>
+          <%= so.govuk_text_field :last_name, width: 20, label: { size: 's' } %>
           <%= so.govuk_text_field :reference_number, width: 10, label: { size: 's' } %>
         <% end %>
 
         <%= so.govuk_radio_buttons_fieldset :alternative_contact_details, legend: { size: 'm' } do %>
           <%= f.fields_for :solicitor, as: :firm_details_form do |so| %>
             <%= so.govuk_radio_button :alternative_contact_details, YesNoAnswer::YES.to_s do %>
-                <%= so.govuk_text_field :contact_full_name, width: 20 %>
+                <%= so.govuk_text_field :contact_first_name, width: 20 %>
+                <%= so.govuk_text_field :contact_last_name, width: 20 %>
                 <%= so.govuk_text_field :contact_email, width: 20 %>
             <% end %>
           <% end %>

--- a/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
@@ -6,17 +6,17 @@
     <%= govuk_error_summary(@form_object) %>
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
-    <p class="govuk-text"><%= t(".hint") %></p>
-    <h2 class="govuk-heading-l"><%= t(".alternative_quote") %></h2>
-    <h3 class="govuk-heading-m"><%= t(".service_details") %></h3>
-
+    <p><%= t(".hint") %></p>
     <%= step_form @form_object, method: @form_object.http_verb, url: @form_object.url do |form| %>
-      <%= form.govuk_text_field :contact_full_name, label: { text: t('.contact_full_name'), size: 's' } %>
+      <h2 class="govuk-heading-l"><%= t(".alternative_quote") %></h2>
+      <h3 class="govuk-heading-m"><%= t(".service_details") %></h3>
+      <%= form.govuk_text_field :contact_first_name, width: 20, label: { text: t('.contact_first_name'), size: 's' } %>
+      <%= form.govuk_text_field :contact_last_name, width: 20, label: { text: t('.contact_last_name'), size: 's' } %>
       <%= form.govuk_text_field :organisation, label: { text: t('.organisation'), size: 's' } %>
-      <%= form.govuk_text_field :postcode, label: { text: t('.postcode'), size: 's' } %>
+      <%= form.govuk_text_field :postcode, width: 10, label: { text: t('.postcode'), size: 's' } %>
 
       <%= form.govuk_file_field :file_upload,
-                                label: { text: t(".file_upload"), size: "m" },
+                                label: { text: t(".file_upload"), size: "s" },
                                 hint: { text: t(".file_upload_hint", size: FileUpload::FileUploader.human_readable_max_file_size) },
                                 accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(',') %>
       <% if @form_object.document_already_uploaded? %>

--- a/app/views/prior_authority/steps/case_contact/edit.html.erb
+++ b/app/views/prior_authority/steps/case_contact/edit.html.erb
@@ -6,17 +6,18 @@
     <%= govuk_error_summary(@form_object) %>
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
-
+    <p><%= t(".explanation") %>
     <%= step_form @form_object do |form| %>
 
       <%= form.fields_for :solicitor, as: :firm_detail_form do |solicitor_object| %>
-        <%= solicitor_object.govuk_text_field :contact_full_name, label: { text: t(".contact_full_name"), size: 'm' } %>
-        <%= solicitor_object.govuk_text_field :contact_email, label: { text: t(".contact_email"), size: 'm' } %>
-      <% end%>
+        <%= solicitor_object.govuk_text_field :contact_first_name, width: 20, label: { text: t(".contact_first_name"), size: 's' } %>
+        <%= solicitor_object.govuk_text_field :contact_last_name, width: 20, label: { text: t(".contact_last_name"), size: 's' } %>
+        <%= solicitor_object.govuk_text_field :contact_email, width: 20, label: { text: t(".contact_email"), size: 's' } %>
+      <% end %>
 
       <%= form.fields_for :firm_office, as: :firm_detail_form do |firm_office_object| %>
-        <%= firm_office_object.govuk_text_field :name, label: { text: t(".firm_name"), size: 'm' } %>
-        <%= firm_office_object.govuk_text_field :account_number, label: { text: t(".firm_account_number"), size: 'm' }, hint: { text: t(".hint") }  %>
+        <%= firm_office_object.govuk_text_field :name, width: 20, label: { text: t(".firm_name"), size: 's' } %>
+        <%= firm_office_object.govuk_text_field :account_number, width: 20, label: { text: t(".firm_account_number"), size: 's' }, hint: { text: t(".hint") }  %>
       <% end %>
 
       <%= form.continue_button %>

--- a/app/views/prior_authority/steps/client_detail/edit.html.erb
+++ b/app/views/prior_authority/steps/client_detail/edit.html.erb
@@ -8,9 +8,9 @@
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
 
     <%= step_form @form_object do |form| %>
-      <%= form.govuk_text_field :first_name, label: { text: t(".first_name"), size: 'm' } %>
-      <%= form.govuk_text_field :last_name, label: { text: t(".last_name"), size: 'm' } %>
-      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t(".date_of_birth") }, hint: { text: t(".date_of_birth_hint") } %>
+      <%= form.govuk_text_field :first_name, width: 20, label: { text: t(".first_name"), size: 's' } %>
+      <%= form.govuk_text_field :last_name, width: 20, label: { text: t(".last_name"), size: 's' } %>
+      <%= form.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t(".date_of_birth"), size: 's' }, hint: { text: t(".date_of_birth_hint") } %>
 
       <%= form.continue_button %>
     <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -16,9 +16,10 @@
         <h2 class="govuk-heading-l"><%= @form_object.service_type_autocomplete %></h2>
       <% end %>
       <h2 class="govuk-heading-m"><%= t(".service_details") %></h2>
-      <%= form.govuk_text_field :contact_full_name, label: { text: t(".contact_full_name"), size: "s" } %>
+      <%= form.govuk_text_field :contact_first_name, width: 20, label: { text: t(".contact_first_name"), size: "s" } %>
+      <%= form.govuk_text_field :contact_last_name, width: 20, label: { text: t(".contact_last_name"), size: "s" } %>
       <%= form.govuk_text_field :organisation, label: { text: t(".organisation"), size: "s" } %>
-      <%= form.govuk_text_field :postcode, label: { text: t(".postcode"), size: "s" } %>
+      <%= form.govuk_text_field :postcode, width: 10, label: { text: t(".postcode"), size: "s" } %>
       <%= form.govuk_file_field :file_upload,
                                 label: { text: t(".file_upload"), size: "m" },
                                 hint: { text: t(".file_upload_hint", size: FileUpload::FileUploader.human_readable_max_file_size) },

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -127,11 +127,10 @@ en:
               inclusion: Select the type of court
         prior_authority/steps/case_contact/solicitor_form:
           attributes: &contact_form
-            contact_full_name:
-              blank: Enter the full name of the contact
-              invalid: |
-                Contact's name must only include letters a to z, and special characters such as hyphens, spaces and apostrophes.
-                The contact's full name must be 2 words or more.
+            contact_first_name:
+              blank: Enter the first name of the contact
+            contact_last_name:
+              blank: Enter the last name of the contact
             contact_email:
               blank: Enter the email address of the contact
               invalid: Enter a valid email address
@@ -162,9 +161,10 @@ en:
           attributes:
             service_type_autocomplete:
               blank: Enter the service required
-            contact_full_name:
-              blank: Enter the contact's full name
-              invalid: Enter a valid full name
+            contact_first_name:
+              blank: Enter the contact's first name
+            contact_last_name:
+              blank: Enter the contact's last name
             organisation:
               blank: Enter the organisation name
             postcode:
@@ -288,19 +288,17 @@ en:
           attributes: *firm_office_form
         nsm/steps/firm_details/solicitor_form:
           summary: &solicitor_form
-            full_name:
-              blank: "Enter the solicitor's full name"
-              invalid: |
-                Solicitor's full name must only include letters a to z, and special characters such as hyphens, spaces and apostrophes.
-                The solicitor's full name must be 2 words or more.
+            first_name:
+              blank: "Enter the solicitor's first name"
+            last_name:
+              blank: "Enter the solicitor's last name"
 
             reference_number:
               blank: "Enter the solicitor's reference number"
-            contact_full_name:
-              blank: "Enter the full name of the alternative contact"
-              invalid: |
-                Contact's name must only include letters a to z, and special characters such as hyphens, spaces and apostrophes.
-                The contact's full name must be 2 words or more.
+            contact_first_name:
+              blank: "Enter the first name of the alternative contact"
+            contact_last_name:
+              blank: "Enter the last name of the alternative contact"
             contact_email:
               blank: "Enter the email address of the alternative contact"
               invalid: "Enter a valid email address"

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -154,9 +154,11 @@ en:
             'yes': 'Yes'
             'no': 'No'
         solicitor_attributes:
-          full_name: Solicitor full name
+          first_name: Solicitor first name
+          last_name: Solicitor last name
           reference_number: Solicitor reference number
-          contact_full_name: Full name of alternative contact
+          contact_first_name: First name of alternative contact
+          contact_last_name: Last name of alternative contact
           contact_email: Email address of alternative contact
           alternative_contact_details_options:
             'yes': 'Yes'

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -26,9 +26,11 @@ en:
               firm_account_number: Firm account number
               firm_address: Firm address
               vat_registered: Firm VAT registered
-              solicitor_full_name: Solicitor full name
+              solicitor_first_name: Solicitor first name
+              solicitor_last_name: Solicitor last name
               solicitor_reference_number: Solicitor reference number
-              contact_full_name: Contact full name
+              contact_first_name: Contact first name
+              contact_last_name: Contact last name
               contact_email: Contact email address
             defendant_summary:
               main_defendant_first_name: Main defendant first name

--- a/config/locales/en/prior_authority/alternative_quotes.yml
+++ b/config/locales/en/prior_authority/alternative_quotes.yml
@@ -20,7 +20,7 @@ en:
           alternative_quote: Alternative quote
           change: Change
           delete: Delete
-          service_details: Service details
+          service_details: Service provider details
           quote_upload: Quote upload
           additional_items: Additional items
           none: None
@@ -42,8 +42,9 @@ en:
           caption: About the request
           hint: You can add up to 3 alternative quotes.
           alternative_quote: Alternative quote
-          service_details: Service details
-          contact_full_name: Contact full name
+          service_details: Service provider details
+          contact_first_name: First name
+          contact_last_name: Last name
           organisation: Organisation
           postcode: Postcode
           file_upload: Upload the quote (optional)
@@ -71,8 +72,10 @@ en:
               blank: Explain why you did not get other quotes
         prior_authority/steps/alternative_quotes/detail_form:
           attributes:
-            contact_full_name:
-              blank: Enter the contact's full name
+            contact_first_name:
+              blank: Enter the contact's first name
+            contact_last_name:
+              blank: Enter the contact's last name
             organisation:
               blank: Enter the organisation name
             postcode:

--- a/config/locales/en/prior_authority/check_answers.yml
+++ b/config/locales/en/prior_authority/check_answers.yml
@@ -52,7 +52,7 @@ en:
               quote_upload: Quote upload
               related_to_post_mortem: Post-mortem
               service_name: Service required
-              service_details: Service details
+              service_details: Service provider details
               travel_cost_reason: Why travel costs are required
             reason_why:
               reason_why: Why prior authority is required

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -8,16 +8,18 @@ en:
           page_title: Authority value
       case_contact:
         edit:
-          caption: 1. Contact details
-          contact_full_name: Full name
+          caption: Contact details
+          contact_first_name: First name
+          contact_last_name: Last name
           contact_email: Email address
           firm_name: Firm name
           firm_account_number: Firm account number
           hint: For example, 1A234B
           page_title: Case contact
+          explanation: We’ll use these contact details if we need to ask you for more information or to tell you the outcome of your application.
       case_detail:
         edit:
-          caption: 2. About the case
+          caption: About the case
           client_detained: Is your client detained?
           client_detained_prison: Where is your client detained?
           client_detained_prison_hint: Enter the name of prison, or select one from the suggestions that appear when you start to enter the name.
@@ -30,7 +32,7 @@ en:
           subject_to_poca: Is this case subject to POCA (Proceeds of Crime Act 2002)?
       client_detail:
         edit:
-          caption: 2. About the case
+          caption: About the case
           first_name: First name
           last_name: Last name
           date_of_birth: Date of birth
@@ -38,7 +40,7 @@ en:
           page_title: Client details
       hearing_detail:
         edit:
-          caption: 2. About the case
+          caption: About the case
           next_hearing: Do you know the date of the next hearing?
           next_hearing_date: Date of next hearing
           next_hearing_date_hint: For example, 27 3 2022
@@ -56,7 +58,7 @@ en:
           page_title: Hearing details
       next_hearing:
         edit:
-          caption: 2. About the case
+          caption: About the case
           next_hearing: Do you know the date of the next hearing?
           next_hearing_date: Date of next hearing
           next_hearing_date_hint: For example, 27 3 2024
@@ -73,12 +75,13 @@ en:
       primary_quote:
         edit:
           page_title: Primary quote
-          caption: 3. About the request
+          caption: About the request
           service_name_hint: |
            Enter the name of the service you require,
            or select one from the suggestions that appear when you start to enter the name.
-          service_details: Service details
-          contact_full_name: Contact full name
+          service_details: Service provider details
+          contact_first_name: First name
+          contact_last_name: Last name
           organisation: Organisation
           postcode: Postcode
           file_upload: Upload the quote
@@ -91,13 +94,13 @@ en:
 
       psychiatric_liaison:
         edit:
-          caption: 2. About the case
+          caption: About the case
           legend: Have you accessed the psychiatric liaison service?
           page_title: Have you accessed the psychiatric liaison service?
           psychiatric_liaison_reason_not: Explain why you did not access this service
       youth_court:
         edit:
-          caption: 2. About the case
+          caption: About the case
           legend: Is this a youth court matter?
           page_title: Is this a youth court matter?
       service_cost:
@@ -131,7 +134,7 @@ en:
           service_costs: Service costs
           change: Change
           service_required: Service required
-          service_details: Service details
+          service_details: Service provider details
           service_quote_upload: Quote upload
           prior_authority_granted: Existing prior authority granted
         service_cost_subtable:
@@ -162,7 +165,7 @@ en:
           total: Total
       reason_why:
         edit:
-          caption: 2. About the request
+          caption: About the request
           page_title: Why is prior authority required?
           reason_why_hint_html: |
             <p>Provide a summary of:</p>
@@ -185,7 +188,7 @@ en:
           supporting_documentation_caption: Attach copies of any supporting documentation. The maximum file size is 70MB. Files must be a DOC, DOCX, XLSX, XLS, RTF, ODT, JPG, BMP, PNG, TIF or PDF.
       travel_detail:
         edit:
-          caption: 3. About the request
+          caption: About the request
           page_title: Travel cost
           explanation: Only include the hourly rate cost. Any other travel expenditure (such as mileage, parking and travel fares) can be added later as additional costs.
           travel_cost_reason: Why are there travel costs if your client is not detained?
@@ -203,7 +206,7 @@ en:
           no_delete: No, do not delete it
       additional_costs:
         edit:
-          caption: 3. About the request
+          caption: About the request
           page_title: You've added %{number} additional %{cost}
           cost: cost
           question: Do you want to add another additional cost?
@@ -224,7 +227,7 @@ en:
           laa_allowed: LAA allowed
       additional_cost_details:
         edit:
-          caption: 3. About the request
+          caption: About the request
           page_title: Additional cost
           name: What is the additional cost for?
           name_hint: Only add one type of cost. Further costs can be added later.

--- a/db/migrate/20240404094407_split_contact_full_names.rb
+++ b/db/migrate/20240404094407_split_contact_full_names.rb
@@ -1,0 +1,18 @@
+class SplitContactFullNames < ActiveRecord::Migration[7.1]
+  def change
+    change_table :quotes, bulk: true do |t|
+      t.remove :contact_full_name, type: :string
+      t.string :contact_first_name, type: :string
+      t.string :contact_last_name, type: :string
+    end
+
+    change_table :solicitors, bulk: true do |t|
+      t.remove :contact_full_name, type: :string
+      t.string :contact_first_name, type: :string
+      t.string :contact_last_name, type: :string
+      t.remove :full_name, type: :string
+      t.string :first_name, type: :string
+      t.string :last_name, type: :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_28_165804) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_04_094407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -256,7 +256,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_165804) do
   end
 
   create_table "quotes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "contact_full_name"
     t.string "organisation"
     t.string "postcode"
     t.boolean "primary", default: false
@@ -279,17 +278,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_165804) do
     t.decimal "travel_cost_allowed", precision: 10, scale: 2
     t.string "service_adjustment_comment"
     t.string "travel_adjustment_comment"
+    t.string "contact_first_name"
+    t.string "contact_last_name"
     t.index ["prior_authority_application_id"], name: "index_quotes_on_prior_authority_application_id"
   end
 
   create_table "solicitors", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.string "full_name"
     t.string "reference_number"
-    t.string "contact_full_name"
     t.string "contact_email"
     t.uuid "previous_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "contact_first_name"
+    t.string "contact_last_name"
+    t.string "first_name"
+    t.string "last_name"
     t.index ["previous_id"], name: "index_solicitors_on_previous_id"
   end
 

--- a/gems/laa_multi_step_forms/config/locales/errors.yml
+++ b/gems/laa_multi_step_forms/config/locales/errors.yml
@@ -42,11 +42,15 @@ en:
               blank: "Enter a postcode"
         steps/firm_details/solicitor_form:
           attributes:
-            full_name:
-              blank: "Enter the solicitor's full name"
+            first_name:
+              blank: "Enter the solicitor's first name"
+            last_name:
+              blank: "Enter the solicitor's last name"
             reference_number:
               blank: "Enter the solicitor's reference number"
-            contact_full_name:
-              blank: "Enter a contacts name"
+            contact_first_name:
+              blank: "Enter a contacts first name"
+            contact_last_name:
+              blank: "Enter a contacts last name"
             contact_email:
               blank: "Enter a contacts email"

--- a/spec/factories/quote.rb
+++ b/spec/factories/quote.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :quote do
-    contact_full_name { 'Joe Bloggs' }
+    contact_first_name { 'Joe' }
+    contact_last_name { 'Bloggs' }
     organisation { 'LAA' }
     postcode { 'CR0 1RE' }
     cost_per_hour { 10 }
@@ -12,7 +13,8 @@ FactoryBot.define do
     document factory: %i[quote_document], strategy: :build
 
     trait :blank do
-      contact_full_name { nil }
+      contact_first_name { nil }
+      contact_last_name { nil }
       organisation { nil }
       postcode { nil }
       primary { nil }

--- a/spec/factories/solicitors.rb
+++ b/spec/factories/solicitors.rb
@@ -1,13 +1,15 @@
 FactoryBot.define do
   factory :solicitor do
     trait :valid do
-      full_name { 'Richard Jenkins' }
+      first_name { 'Richard' }
+      last_name { 'Jenkins' }
       reference_number { '111222' }
     end
 
     trait :full do
       valid
-      contact_full_name { 'James Blake' }
+      contact_first_name { 'James' }
+      contact_last_name { 'Blake' }
       contact_email { 'james@email.com' }
     end
   end

--- a/spec/forms/nsm/steps/firm_details/solicitor_form_spec.rb
+++ b/spec/forms/nsm/steps/firm_details/solicitor_form_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
 
   let(:arguments) do
     {
-      full_name:,
+      first_name:,
+      last_name:,
       reference_number:,
-      contact_full_name:,
+      contact_first_name:,
+      contact_last_name:,
       contact_email:,
     }
   end
@@ -16,9 +18,11 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
     instance_double(Claim)
   end
 
-  let(:full_name) { 'Jame Roberts' }
+  let(:first_name) { 'James' }
+  let(:last_name) { 'Roberts' }
   let(:reference_number) { 'ref1' }
-  let(:contact_full_name) { 'JimBob' }
+  let(:contact_first_name) { 'Jim' }
+  let(:contact_last_name) { 'Bob' }
   let(:contact_email) { 'job@bob.com' }
   let(:alternative_contact_details) { 'no' }
 
@@ -29,7 +33,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
       end
     end
 
-    %i[full_name reference_number].each do |field|
+    %i[first_name last_name reference_number].each do |field|
       context "when #{field} is missing" do
         let(field) { nil }
 
@@ -40,7 +44,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
       end
     end
 
-    %i[contact_full_name contact_email].each do |field|
+    %i[contact_first_name contact_last_name contact_email].each do |field|
       context "when #{field} is missing and alternative_contact_details is NO" do
         let(field) { nil }
 
@@ -81,7 +85,8 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
     context 'when passed in as other' do
       let(:alternative_contact_details) { 'other' }
       let(:contact_email) { nil }
-      let(:contact_full_name) { nil }
+      let(:contact_first_name) { nil }
+      let(:contact_last_name) { nil }
 
       it 'determined based on presence of contact email and full anme' do
         expect(form.alternative_contact_details).to eq(YesNoAnswer::NO)
@@ -91,7 +96,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
     context 'when not passed in' do
       let(:alternative_contact_details) { nil }
 
-      context 'when contact_full_name is set' do
+      context 'when contact_first_name is set' do
         let(:contact_email) { nil }
 
         it 'return yes value' do
@@ -100,7 +105,9 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
       end
 
       context 'when contact_email is set' do
-        let(:contact_full_name) { nil }
+        let(:contact_first_name) { nil }
+
+        let(:contact_last_name) { nil }
 
         it 'return yes value' do
           expect(form.alternative_contact_details).to eq(YesNoAnswer::YES)
@@ -109,7 +116,8 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
 
       context 'when neither contact fields are set' do
         let(:contact_email) { nil }
-        let(:contact_full_name) { nil }
+        let(:contact_first_name) { nil }
+        let(:contact_last_name) { nil }
 
         it 'return no value' do
           expect(form.alternative_contact_details).to eq(YesNoAnswer::NO)
@@ -139,7 +147,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
 
     context 'when application has an existing solicitor' do
       context 'and solicitor details have changed' do
-        let(:solicitor) { Solicitor.new(arguments.merge(full_name: 'Jim Bob')) }
+        let(:solicitor) { Solicitor.new(arguments.merge(first_name: 'Jim', last_name: 'Bob')) }
 
         it 'creates a new solicitor record' do
           expect { subject.save! }.to change(Solicitor, :count).by(1)
@@ -158,7 +166,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
 
     context 'when application has no solictor but one exists for the the reference code' do
       context 'and solicitor details have changed' do
-        before { Solicitor.create!(arguments.merge(full_name: 'Jim Bob')) }
+        before { Solicitor.create!(arguments.merge(first_name: 'Jim', last_name: 'Bob')) }
 
         it 'creates a new solicitor record' do
           expect { subject.save! }.to change(Solicitor, :count).by(1)
@@ -177,7 +185,7 @@ RSpec.describe Nsm::Steps::FirmDetails::SolicitorForm do
       context 'it matches a historic solicitor details' do
         before do
           old_solicitor = travel_to(1.day.ago) { Solicitor.create!(arguments) }
-          Solicitor.create!(arguments.merge(full_name: 'Jim Bob', previous: old_solicitor))
+          Solicitor.create!(arguments.merge(first_name: 'Jim', last_name: 'Bob', previous: old_solicitor))
         end
 
         it 'create a new solicitor record' do

--- a/spec/forms/nsm/steps/firm_details_form_spec.rb
+++ b/spec/forms/nsm/steps/firm_details_form_spec.rb
@@ -80,11 +80,11 @@ RSpec.describe Nsm::Steps::FirmDetailsForm do
 
     context 'solicitor' do
       context 'when solicitor_attributes is passed in' do
-        let(:solicitor_attributes) { { 'full_name' => 'John Bob' } }
+        let(:solicitor_attributes) { { 'first_name' => 'John' } }
 
         it 'used to set values' do
           expect(subject.solicitor).to have_attributes(
-            full_name: 'John Bob',
+            first_name: 'John',
             reference_number: nil,
           )
         end
@@ -94,7 +94,7 @@ RSpec.describe Nsm::Steps::FirmDetailsForm do
 
           it 'ignores existing fields' do
             expect(subject.solicitor).to have_attributes(
-              full_name: 'John Bob',
+              first_name: 'John',
               reference_number: nil,
             )
           end
@@ -107,7 +107,7 @@ RSpec.describe Nsm::Steps::FirmDetailsForm do
 
           it 'populates the values from the DB' do
             expect(subject.solicitor).to have_attributes(
-              full_name: nil,
+              first_name: nil,
               reference_number: 'AAA1',
             )
           end
@@ -116,7 +116,7 @@ RSpec.describe Nsm::Steps::FirmDetailsForm do
         context 'without an existing record in DB' do
           it 'leaves the fields blank' do
             expect(subject.solicitor).to have_attributes(
-              full_name: nil,
+              first_name: nil,
               reference_number: nil,
             )
           end

--- a/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
     {
       record: record,
       application: application,
-      contact_full_name: 'John Smith',
+      contact_first_name: 'John',
+      contact_last_name: 'Smith',
       organisation: 'Acme Ltd',
       postcode: 'SW1 1AA',
       file_upload: file_upload,

--- a/spec/forms/prior_authority/steps/case_contact/solicitor_form_spec.rb
+++ b/spec/forms/prior_authority/steps/case_contact/solicitor_form_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe PriorAuthority::Steps::CaseContact::SolicitorForm do
   let(:arguments) do
     {
       application:,
-      contact_full_name:,
+      contact_first_name:,
+      contact_last_name:,
       contact_email:,
     }
   end
@@ -15,37 +16,40 @@ RSpec.describe PriorAuthority::Steps::CaseContact::SolicitorForm do
     let(:application) { instance_double(PriorAuthorityApplication) }
 
     context 'with valid name and account number' do
-      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:contact_email) { 'joe.bloggs@legalcorp.com' }
 
       it { is_expected.to be_valid }
     end
 
-    context 'with blank contact_full_name' do
-      let(:contact_full_name) { '' }
+    context 'with blank contact_first_name' do
+      let(:contact_first_name) { '' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:contact_email) { 'joe.bloggs@legalcorp.com' }
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:contact_full_name, :blank)).to be(true)
-        expect(form.errors.messages[:contact_full_name]).to include('Enter the full name of the contact')
+        expect(form.errors.of_kind?(:contact_first_name, :blank)).to be(true)
+        expect(form.errors.messages[:contact_first_name]).to include('Enter the first name of the contact')
       end
     end
 
-    context 'with an invalid contact_full_name' do
-      let(:contact_full_name) { 'Joe' }
+    context 'with blank contact_last_name' do
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { '' }
       let(:contact_email) { 'joe.bloggs@legalcorp.com' }
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:contact_full_name, :invalid)).to be(true)
-        expect(form.errors.messages[:contact_full_name])
-          .to include(match("Contact's name must only include letters a to z"))
+        expect(form.errors.of_kind?(:contact_last_name, :blank)).to be(true)
+        expect(form.errors.messages[:contact_last_name]).to include('Enter the last name of the contact')
       end
     end
 
     context 'with blank contact_email' do
-      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:contact_email) { '' }
 
       it 'has a validation error on the field' do
@@ -56,7 +60,8 @@ RSpec.describe PriorAuthority::Steps::CaseContact::SolicitorForm do
     end
 
     context 'with an invalid contact_email' do
-      let(:contact_full_name) { 'Joe' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:contact_email) { 'joe.bloggsatlegalcorp.com' }
 
       it 'has a validation error on the field' do
@@ -73,19 +78,22 @@ RSpec.describe PriorAuthority::Steps::CaseContact::SolicitorForm do
     let(:application) { create(:prior_authority_application) }
 
     context 'with valid solicitor details' do
-      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:contact_email) { 'joe.bloggs@legalcorp.com' }
 
       it 'persists the solicitor details' do
         expect(application.solicitor).to be_nil
         save
-        expect(application.solicitor).to have_attributes(contact_full_name: 'Joe Bloggs',
+        expect(application.solicitor).to have_attributes(contact_first_name: 'Joe',
+                                                         contact_last_name: 'Bloggs',
                                                          contact_email: 'joe.bloggs@legalcorp.com')
       end
     end
 
     context 'with invalid solicitor details' do
-      let(:contact_full_name) { '' }
+      let(:contact_first_name) { '' }
+      let(:contact_last_name) { '' }
       let(:contact_email) { '' }
 
       it 'does not persists to persist the solicitor' do

--- a/spec/forms/prior_authority/steps/case_contact_form_spec.rb
+++ b/spec/forms/prior_authority/steps/case_contact_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PriorAuthority::Steps::CaseContactForm do
     context 'with valid solicitor and firm details' do
       let(:firm_office_attributes) { { 'name' => 'anything', 'account_number' => 'anything' } }
       let(:solicitor_attributes) do
-        { 'contact_full_name' => 'Joe Bloggs', 'contact_email' => 'joe.bloggs@legalcorp.com' }
+        { 'contact_first_name' => 'Joe', 'contact_last_name' => 'Bloggs', 'contact_email' => 'joe.bloggs@legalcorp.com' }
       end
 
       it { is_expected.to be_valid }
@@ -28,17 +28,19 @@ RSpec.describe PriorAuthority::Steps::CaseContactForm do
 
     context 'with invalid solicitor and firm details' do
       let(:firm_office_attributes) { { 'name' => '', 'account_number' => '' } }
-      let(:solicitor_attributes) { { 'contact_full_name' => '', 'contact_email' => '' } }
+      let(:solicitor_attributes) { { 'contact_first_name' => '', 'contact_last_name' => '', 'contact_email' => '' } }
 
       it 'has a validation error on the field' do
         expect(form).not_to be_valid
         expect(form.errors.of_kind?(:'firm_office-attributes.name', :blank)).to be(true)
         expect(form.errors.of_kind?(:'firm_office-attributes.account_number', :blank)).to be(true)
-        expect(form.errors.of_kind?(:'solicitor-attributes.contact_full_name', :blank)).to be(true)
+        expect(form.errors.of_kind?(:'solicitor-attributes.contact_first_name', :blank)).to be(true)
+        expect(form.errors.of_kind?(:'solicitor-attributes.contact_last_name', :blank)).to be(true)
         expect(form.errors.of_kind?(:'solicitor-attributes.contact_email', :blank)).to be(true)
         expect(form.errors.messages.values.flatten).to include('Enter a firm name',
                                                                'Enter an account number',
-                                                               'Enter the full name of the contact',
+                                                               'Enter the first name of the contact',
+                                                               'Enter the last name of the contact',
                                                                'Enter the email address of the contact')
       end
     end
@@ -52,7 +54,7 @@ RSpec.describe PriorAuthority::Steps::CaseContactForm do
     context 'with valid solicitor and firm details' do
       let(:firm_office_attributes) { { 'name' => 'anything', 'account_number' => 'anything' } }
       let(:solicitor_attributes) do
-        { 'contact_full_name' => 'Joe Bloggs', 'contact_email' => 'joe.bloggs@legalcorp.com' }
+        { 'contact_first_name' => 'Joe', 'contact_last_name' => 'Bloggs', 'contact_email' => 'joe.bloggs@legalcorp.com' }
       end
 
       it 'persists the firm details' do
@@ -62,14 +64,15 @@ RSpec.describe PriorAuthority::Steps::CaseContactForm do
 
       it 'persists the solicitor details' do
         expect { save }.to change { application.reload.solicitor }.from(nil).to(be_a(Solicitor))
-        expect(application.solicitor).to have_attributes(contact_full_name: 'Joe Bloggs',
+        expect(application.solicitor).to have_attributes(contact_first_name: 'Joe',
+                                                         contact_last_name: 'Bloggs',
                                                          contact_email: 'joe.bloggs@legalcorp.com')
       end
     end
 
     context 'with invalid solicitor and firm details' do
       let(:firm_office_attributes) { { 'name' => '', 'account_number' => '' } }
-      let(:solicitor_attributes) { { 'contact_full_name' => '', 'contact_email' => '' } }
+      let(:solicitor_attributes) { { 'contact_first_name' => '', 'contact_last_name' => '', 'contact_email' => '' } }
 
       it 'does not persists the solicitor details' do
         expect { save }.not_to change { application.reload.solicitor }.from(nil)

--- a/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
+++ b/spec/forms/prior_authority/steps/primary_quote_form_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
       record:,
       application:,
       service_type_autocomplete_suggestion:,
-      contact_full_name:,
+      contact_first_name:,
+      contact_last_name:,
       organisation:,
       postcode:,
       file_upload:,
@@ -20,7 +21,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
   let(:application) { instance_double(PriorAuthorityApplication, service_type: 'forensics') }
   let(:service_type_autocomplete_suggestion) { 'forensics_expert' }
   let(:file_upload) { nil }
-  let(:contact_full_name) { 'Joe Bloggs' }
+  let(:contact_first_name) { 'Joe' }
+  let(:contact_last_name) { 'Bloggs' }
   let(:organisation) { 'LAA' }
   let(:postcode) { 'CR0 1RE' }
 
@@ -40,19 +42,21 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
 
     context 'with blank quote details' do
       let(:service_type_autocomplete_suggestion) { '' }
-      let(:contact_full_name) { '' }
+      let(:contact_first_name) { '' }
+      let(:contact_last_name) { '' }
       let(:organisation) { '' }
       let(:postcode) { '' }
 
       it 'has a validation errors on blank fields' do
         expect(form).not_to be_valid
         expect(form.errors.of_kind?(:service_type_autocomplete, :blank)).to be(true)
-        expect(form.errors.of_kind?(:contact_full_name, :blank)).to be(true)
+        expect(form.errors.of_kind?(:contact_first_name, :blank)).to be(true)
+        expect(form.errors.of_kind?(:contact_last_name, :blank)).to be(true)
         expect(form.errors.of_kind?(:organisation, :blank)).to be(true)
         expect(form.errors.of_kind?(:postcode, :blank)).to be(true)
         expect(form.errors.messages.values.flatten)
           .to include('Enter the service required',
-                      "Enter the contact's full name",
+                      "Enter the contact's first name",
                       'Enter the organisation name',
                       'Enter the postcode')
       end
@@ -60,17 +64,13 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
 
     context 'with invalid quote details' do
       let(:service_type_autocomplete_suggestion) { 'Forensics Expert' }
-      let(:contact_full_name) { 'Tim' }
-      let(:organisation) { 'LAA' }
       let(:postcode) { 'loren ipsum' }
 
       it 'has a validation errors on blank fields' do
         expect(form).not_to be_valid
-        expect(form.errors.of_kind?(:contact_full_name, :invalid)).to be(true)
         expect(form.errors.of_kind?(:postcode, :invalid)).to be(true)
         expect(form.errors.messages.values.flatten)
-          .to include('Enter a valid full name',
-                      'Enter a real postcode')
+          .to include('Enter a real postcode')
       end
     end
 
@@ -134,7 +134,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
 
     context 'with valid quote details' do
       let(:service_type_autocomplete_suggestion) { 'Forensic scientist' }
-      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:organisation) { 'LAA' }
       let(:postcode) { 'CR0 1RE' }
 
@@ -142,7 +143,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
         expect { save }.to change { record.reload.attributes }
           .from(
             hash_including(
-              'contact_full_name' => nil,
+              'contact_first_name' => nil,
+              'contact_last_name' => nil,
               'organisation' => nil,
               'postcode' => nil,
               'primary' => nil
@@ -150,7 +152,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
           )
           .to(
             hash_including(
-              'contact_full_name' => 'Joe Bloggs',
+              'contact_first_name' => 'Joe',
+              'contact_last_name' => 'Bloggs',
               'organisation' => 'LAA',
               'postcode' => 'CR0 1RE',
               'primary' => true
@@ -176,7 +179,7 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
 
     context 'with incomplete quote details' do
       let(:service_type_autocomplete_suggestion) { 'Forensic scientist' }
-      let(:contact_full_name) { '' }
+      let(:contact_first_name) { '' }
       let(:organisation) { '' }
       let(:postcode) { '' }
 
@@ -184,7 +187,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
         expect { save }.not_to change { record.reload.attributes }
           .from(
             hash_including(
-              'contact_full_name' => nil,
+              'contact_first_name' => nil,
+              'contact_last_name' => nil,
               'organisation' => nil,
               'postcode' => nil,
               'primary' => nil
@@ -251,7 +255,8 @@ RSpec.describe PriorAuthority::Steps::PrimaryQuoteForm do
     end
 
     context 'when the service type is changed' do
-      let(:contact_full_name) { 'Joe Bloggs' }
+      let(:contact_first_name) { 'Joe' }
+      let(:contact_last_name) { 'Bloggs' }
       let(:organisation) { 'LAA' }
       let(:postcode) { 'CR0 1RE' }
       let(:record) { application.primary_quote }

--- a/spec/presenters/nsm/check_answers/your_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/your_details_card_spec.rb
@@ -40,16 +40,24 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'No'
             },
             {
-              head_key: 'solicitor_full_name',
-              text: 'Richard Jenkins'
+              head_key: 'solicitor_first_name',
+              text: 'Richard'
+            },
+            {
+              head_key: 'solicitor_last_name',
+              text: 'Jenkins'
             },
             {
               head_key: 'solicitor_reference_number',
               text: '111222'
             },
             {
-              head_key: 'contact_full_name',
-              text: 'James Blake'
+              head_key: 'contact_first_name',
+              text: 'James'
+            },
+            {
+              head_key: 'contact_last_name',
+              text: 'Blake'
             },
             {
               head_key: 'contact_email',
@@ -83,8 +91,12 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'Yes'
             },
             {
-              head_key: 'solicitor_full_name',
-              text: 'Richard Jenkins'
+              head_key: 'solicitor_first_name',
+              text: 'Richard'
+            },
+            {
+              head_key: 'solicitor_last_name',
+              text: 'Jenkins'
             },
             {
               head_key: 'solicitor_reference_number',
@@ -118,7 +130,11 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {
-              head_key: 'solicitor_full_name',
+              head_key: 'solicitor_first_name',
+              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
+            },
+            {
+              head_key: 'solicitor_last_name',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {
@@ -154,8 +170,12 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'Yes'
             },
             {
-              head_key: 'solicitor_full_name',
-              text: 'Richard Jenkins'
+              head_key: 'solicitor_first_name',
+              text: 'Richard'
+            },
+            {
+              head_key: 'solicitor_last_name',
+              text: 'Jenkins'
             },
             {
               head_key: 'solicitor_reference_number',
@@ -190,8 +210,12 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'Yes'
             },
             {
-              head_key: 'solicitor_full_name',
-              text: 'Richard Jenkins'
+              head_key: 'solicitor_first_name',
+              text: 'Richard'
+            },
+            {
+              head_key: 'solicitor_last_name',
+              text: 'Jenkins'
             },
             {
               head_key: 'solicitor_reference_number',

--- a/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PriorAuthority::CheckAnswers::AlternativeQuotesCard do
   end
 
   describe '#title' do
-    let(:quote) { build_stubbed(:quote, :alternative, contact_full_name: 'Joe Bloggs') }
+    let(:quote) { build_stubbed(:quote, :alternative, contact_first_name: 'Joe', contact_last_name: 'Bloggs') }
 
     it 'shows correct title' do
       expect(card.title).to eq('Alternative quotes')
@@ -31,9 +31,9 @@ RSpec.describe PriorAuthority::CheckAnswers::AlternativeQuotesCard do
     context 'when alternative quotes exist' do
       let(:quotes) do
         [
-          build(:quote, :alternative, contact_full_name: 'Jim Bob',
+          build(:quote, :alternative, contact_first_name: 'Jim', contact_last_name: 'Bob',
                 cost_per_hour: 20, period: 60, travel_cost_per_hour: 30, travel_time: 60),
-          build(:quote, :alternative, contact_full_name: 'John Boy', document: nil,
+          build(:quote, :alternative, contact_first_name: 'John', contact_last_name: 'Boy', document: nil,
                 cost_per_hour: 20, period: 120, travel_cost_per_hour: 30, travel_time: 120),
         ]
       end

--- a/spec/presenters/prior_authority/check_answers/case_contact_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/case_contact_card_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe PriorAuthority::CheckAnswers::CaseContactCard do
       build(:prior_authority_application, firm_office:, solicitor:)
     end
 
-    let(:solicitor) { build(:solicitor, contact_full_name: 'Joe Bloggs', contact_email: 'joe@bloggs.com') }
+    let(:solicitor) do
+      build(:solicitor, contact_first_name: 'Joe', contact_last_name: 'Bloggs', contact_email: 'joe@bloggs.com')
+    end
     let(:firm_office) { build(:firm_office, name: 'Bloggs & Co', account_number: '2B0N2B') }
 
     it 'generates expected rows' do

--- a/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/primary_quote_card_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe PriorAuthority::CheckAnswers::PrimaryQuoteCard do
         build(
           :quote,
           :primary,
-          contact_full_name: 'Jim Bean',
+          contact_first_name: 'Jim',
+          contact_last_name: 'Bean',
           organisation: 'Post-mortems R us',
           postcode: 'SW1A 1AA',
         )

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -115,8 +115,10 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           'signatory_name' => nil,
           'solicitor' => {
             'contact_email' => nil,
-            'contact_full_name' => nil,
-            'full_name' => 'Richard Jenkins',
+            'contact_first_name' => nil,
+            'contact_last_name' => nil,
+            'first_name' => 'Richard',
+            'last_name' => 'Jenkins',
             'previous_id' => nil,
             'reference_number' => '111222'
           },

--- a/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
         },
         solicitor: {
           contact_email: 'james@email.com',
-          contact_full_name: 'James Blake',
-          full_name: 'Richard Jenkins',
+          contact_first_name: 'James',
+          contact_last_name: 'James',
           reference_number: '111222'
         },
         supporting_documents: [
@@ -90,7 +90,8 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
 
     let(:primary_quote) do
       {
-        contact_full_name: 'Joe Bloggs',
+        contact_first_name: 'Joe',
+        contact_last_name: 'Bloggs',
         organisation: 'LAA',
         postcode: 'CR0 1RE',
         primary: true,
@@ -120,7 +121,8 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
 
     let(:alternative_quote) do
       {
-        contact_full_name: 'Joe Bloggs',
+        contact_first_name: 'Joe',
+        contact_last_name: 'Bloggs',
         organisation: 'LAA',
         postcode: 'CR0 1RE',
         primary: false,
@@ -213,8 +215,8 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
           {
             solicitor: {
               contact_email: 'james@email.com',
-              contact_full_name: 'James Rake',
-              full_name: 'Richard Jenkins',
+              contact_first_name: 'James',
+              contact_last_name: 'Rake',
               reference_number: '111222'
             },
           }

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         },
         solicitor: {
           contact_email: 'james@email.com',
-          contact_full_name: 'James Blake',
-          full_name: 'Richard Jenkins',
+          contact_first_name: 'James',
+          contact_last_name: 'Blake',
           reference_number: '111222'
         },
         supporting_documents: [
@@ -75,7 +75,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         ],
         quotes: [
           {
-            contact_full_name: 'Joe Bloggs',
+            contact_first_name: 'Joe',
+            contact_last_name: 'Bloggs',
             organisation: 'LAA',
             postcode: 'CR0 1RE',
             primary: true,
@@ -102,7 +103,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             additional_cost_total: nil,
           },
           {
-            contact_full_name: 'Joe Bloggs',
+            contact_first_name: 'Joe',
+            contact_last_name: 'Bloggs',
             organisation: 'LAA',
             postcode: 'CR0 1RE',
             primary: false,

--- a/spec/system/nsm/firm_details_spec.rb
+++ b/spec/system/nsm/firm_details_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe 'User can fill in firm details', type: :system do
 
     choose 'nsm-steps-firm-details-form-firm-office-attributes-vat-registered-yes-field'
 
-    fill_in 'Solicitor full name', with: 'James Robert'
+    fill_in 'Solicitor first name', with: 'James'
+    fill_in 'Solicitor last name', with: 'Robert'
     fill_in 'Solicitor reference number', with: '2222'
 
     choose 'nsm-steps-firm-details-form-solicitor-attributes-alternative-contact-details-yes-field'
 
-    fill_in 'Full name of alternative contact', with: 'Jim Bob'
+    fill_in 'First name of alternative contact', with: 'Jim'
+    fill_in 'Last name of alternative contact', with: 'Bob'
     fill_in 'Email address of alternative contact', with: 'jim@bob.com'
 
     click_on 'Save and continue'
@@ -43,9 +45,11 @@ RSpec.describe 'User can fill in firm details', type: :system do
     )
 
     expect(claim.solicitor).to have_attributes(
-      full_name: 'James Robert',
+      first_name: 'James',
+      last_name: 'Robert',
       reference_number: '2222',
-      contact_full_name: 'Jim Bob',
+      contact_first_name: 'Jim',
+      contact_last_name: 'Bob',
       contact_email: 'jim@bob.com',
     )
   end

--- a/spec/system/nsm/start_page_spec.rb
+++ b/spec/system/nsm/start_page_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'User can see an application status', type: :system do
   let(:claim) { create(:claim, ufn:, solicitor:, firm_office:, claim_type:, rep_order_date:) }
   let(:ufn) { '120223/001' }
   let(:firm_office) { FirmOffice.create }
-  let(:solicitor) { Solicitor.create(full_name: 'James Robert') }
+  let(:solicitor) { Solicitor.create(first_name: 'James', last_name: 'Robest') }
   let(:claim_type) { ClaimType::NON_STANDARD_MAGISTRATE }
   let(:rep_order_date) { Date.yesterday }
 

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       end
 
       it 'allows me to add an alternative quote' do
-        fill_in 'Contact full name', with: 'Mrs Expert'
+        fill_in 'First name', with: 'Mrs'
+        fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
         choose 'Charged per item'
@@ -48,7 +49,8 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       end
 
       it 'allows me to add a quote with a file' do
-        fill_in 'Contact full name', with: 'Mrs Expert'
+        fill_in 'First name', with: 'Mrs'
+        fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
         choose 'Charged per item'
@@ -62,7 +64,8 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       end
 
       it 'does maths for me' do
-        fill_in 'Contact full name', with: 'Mrs Expert'
+        fill_in 'First name', with: 'Mrs'
+        fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
         choose 'Charged per item'
@@ -79,12 +82,13 @@ RSpec.describe 'Prior authority applications - alternative quote' do
 
       it 'validates' do
         click_on 'Save and continue'
-        expect(page).to have_content "Enter the contact's full name"
+        expect(page).to have_content "Enter the contact's first name"
       end
 
       context 'When I have added a quote' do
         before do
-          fill_in 'Contact full name', with: 'Mrs Expert'
+          fill_in 'First name', with: 'Mrs'
+          fill_in 'Last name', with: 'Expert'
           fill_in 'Organisation', with: 'ExpertiseCo'
           fill_in 'Postcode', with: 'SW1 1AA'
           choose 'Charged per item'
@@ -96,7 +100,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         it 'allows me to edit a quote' do
           click_on 'Change'
 
-          fill_in 'Contact full name', with: 'Mr Expert'
+          fill_in 'First name', with: 'Mr'
           click_on 'Save and continue'
 
           expect(page).to have_content "You've added 1 alternative quote"

--- a/spec/system/prior_authority/case_contact_spec.rb
+++ b/spec/system/prior_authority/case_contact_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe 'Prior authority applications - add case contact' do
     expect(page).to have_content 'Case contactNot started'
 
     click_on 'Case contact'
-    fill_in 'Full name', with: 'John Doe'
+    fill_in 'First name', with: 'John'
+    fill_in 'Last name', with: 'Doe'
     fill_in 'Email address', with: 'john@does.com'
     fill_in 'Firm name', with: 'LegalCorp Ltd'
     fill_in 'Firm account number', with: 'A12345'
@@ -24,7 +25,7 @@ RSpec.describe 'Prior authority applications - add case contact' do
     click_on 'Case contact'
     click_on 'Save and continue'
 
-    expect(page).to have_content 'Enter the full name of the contact'
+    expect(page).to have_content 'Enter the first name of the contact'
   end
 
   it 'allows save and come back later' do
@@ -44,7 +45,7 @@ RSpec.describe 'Prior authority applications - add case contact' do
 
     it 'allows contact detail updating' do
       click_on 'Case contact'
-      fill_in 'Full name', with: 'Jane Doe'
+      fill_in 'First name', with: 'Jane'
       click_on 'Save and continue'
 
       expect(page).to have_content 'Case contactCompleted'

--- a/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/no_prison_law_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'Prior authority applications, no prison law - check your answers
     within('.govuk-summary-card', text: 'Primary quote') do
       expect(page)
         .to have_css('.govuk-summary-card__content', text: 'Service requiredMeteorologist')
-        .and have_css('.govuk-summary-card__content', text: 'Service detailsJoe BloggsLAA, CR0 1RE')
+        .and have_css('.govuk-summary-card__content', text: 'Service provider detailsJoe BloggsLAA, CR0 1RE')
         .and have_css('.govuk-summary-card__content', text: 'Quote uploadtest.png')
         .and have_css('.govuk-summary-card__content', text: 'Existing prior authority grantedYes')
         .and have_css('.govuk-summary-card__content', text: /Why travel costs are required.*Client lives in Wales/)

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
       expect(page).to have_title 'Primary quote'
 
       fill_in 'Service required', with: 'Custom Forensics'
-      fill_in 'Contact full name', with: 'Joe Bloggs'
+      fill_in 'First name', with: 'Joe'
+      fill_in 'Last name', with: 'Bloggs'
       fill_in 'Organisation', with: 'LAA'
       fill_in 'Postcode', with: 'CR0 1RE'
       page.attach_file(file_fixture('test.png')) do
@@ -46,7 +47,8 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
 
     click_on 'Save and continue'
     expect(page).to have_content 'Enter the service required'
-    expect(page).to have_content "Enter the contact's full name"
+    expect(page).to have_content "Enter the contact's first name"
+    expect(page).to have_content "Enter the contact's last name"
     expect(page).to have_content 'Enter the organisation name'
     expect(page).to have_content 'Enter the postcode'
   end

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -93,7 +93,8 @@ module PriorAuthority
     end
 
     def fill_in_case_contact
-      fill_in 'Full name', with: 'John Doe'
+      fill_in 'First name', with: 'John'
+      fill_in 'Last name', with: 'Doe'
       fill_in 'Email address', with: 'john@does.com'
       fill_in 'Firm name', with: 'LegalCorp Ltd'
       fill_in 'Firm account number', with: 'A12345'
@@ -172,7 +173,8 @@ module PriorAuthority
       # be hidden
       select service_type, from: 'Service required'
 
-      fill_in 'Contact full name', with: 'Joe Bloggs'
+      fill_in 'First name', with: 'Joe'
+      fill_in 'Last name', with: 'Bloggs'
       fill_in 'Organisation', with: 'LAA'
       fill_in 'Postcode', with: 'CR0 1RE'
 
@@ -215,7 +217,8 @@ module PriorAuthority
     end
 
     def fill_in_alternative_quote
-      fill_in 'Contact full name', with: 'Jim Bob'
+      fill_in 'First name', with: 'Jim'
+      fill_in 'Last name', with: 'Bob'
       fill_in 'Organisation', with: 'Experts Inc.'
       fill_in 'Postcode', with: 'SW1A 1AA'
 


### PR DESCRIPTION
## Description of change
- Split full_name fields to first_name and last_name fields
- Due to shared models, it was easier to update NSM at the same time than leave it to tidy up later
- I also tweaked the UI field widths, label texts and header sizes to match the designs for the affected screens

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1181)
