### PR TITLE
DO NOT MERGE: Amend dockerfile to try and run dummy data rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'bootsnap', '~> 1.18.3', require: false
 gem 'clamby', '~> 1.6'
 gem 'cssbundling-rails'
 gem 'factory_bot_rails', '>= 6.4.3'
+gem 'faker'
 gem 'govuk_notify_rails', '~> 2.2.0'
 gem 'httparty'
 gem 'jsbundling-rails'
@@ -34,7 +35,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri windows]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
-  gem 'faker'
+  # gem 'faker'
   gem 'overcommit'
   gem 'pry'
   gem 'rspec-expectations'


### PR DESCRIPTION
## Description of change

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)

## Notes for reviewer

This is a test branch to see if I can get the dummy data rake running in the end2end tests. Some of the settings in this dockerfile are preventing me installing the right gems needed to run the rake.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
