### PR TITLE
CRM457-1303: Mark persist as having succeeded

### DIFF
--- a/app/forms/nsm/steps/solicitor_declaration_form.rb
+++ b/app/forms/nsm/steps/solicitor_declaration_form.rb
@@ -12,6 +12,7 @@ module Nsm
           build_costs
           application.update!(attributes)
           SubmitToAppStore.new.process(submission: application)
+          true
         end
       end
 


### PR DESCRIPTION
## Description of change
In production, SubmitToAppStore happens async, so the user is never notified of any errors. And there is no UI to notify users of any errors. But in any mode where sidekiq is run inline, any errors in SubmitToAppStore cause it to return a `nil`, meaning the SolicitorDeclarationForm acts as though `persist` has failed, so you can never get _past_ the solicitor declaration form. This is neither helpful not true to production. So this PR makes sure that, since we don't have a sensible user journey if `persist` fails, we don't send users down that journey. (It also means that for E2E tests we can actually _reach_ the final screen despite not having a valid GovUK Notify API key).

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1303)
