### PR TITLE
CRM457-1327: Allow bypassing sync authentication to enable e2e tests

### DIFF
--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -52,19 +52,18 @@ class AppStoreClient
 
   def options(message = nil)
     options = message ? { body: message.to_json } : {}
+    options.merge(headers:)
+  end
 
+  def headers
     if AppStoreTokenProvider.instance.authentication_configured?
-      options.merge(
-        headers: {
-          authorization: "Bearer #{AppStoreTokenProvider.instance.bearer_token}"
-        }
-      )
+      {
+        authorization: "Bearer #{AppStoreTokenProvider.instance.bearer_token}"
+      }
     else
-      options.merge(
-        headers: {
-          'X-Client-Type': 'provider'
-        }
-      )
+      {
+        'X-Client-Type': 'provider'
+      }
     end
   end
 

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -53,15 +53,19 @@ class AppStoreClient
   def options(message = nil)
     options = message ? { body: message.to_json } : {}
 
-    return options unless AppStoreTokenProvider.instance.authentication_configured?
-
-    token = AppStoreTokenProvider.instance.bearer_token
-
-    options.merge(
-      headers: {
-        authorization: "Bearer #{token}"
-      }
-    )
+    if AppStoreTokenProvider.instance.authentication_configured?
+      options.merge(
+        headers: {
+          authorization: "Bearer #{AppStoreTokenProvider.instance.bearer_token}"
+        }
+      )
+    else
+      options.merge(
+        headers: {
+          'X-Client-Type': 'provider'
+        }
+      )
+    end
   end
 
   def host

--- a/app/services/app_store_token_authenticator.rb
+++ b/app/services/app_store_token_authenticator.rb
@@ -1,6 +1,8 @@
 class AppStoreTokenAuthenticator
   class << self
     def call(headers)
+      return true unless AppStoreTokenProvider.instance.authentication_configured?
+
       jwt = headers['Authorization'].gsub(/^Bearer /, '')
       data = parse(jwt)
       valid?(data)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,5 +81,5 @@ Rails.application.configure do
   config.logstasher.logger_path = 'log/logstasher_development.log'
   config.logstasher.log_level = Logger::INFO
   config.logstasher.suppress_app_log = false
-  config.logstasher.source = 'laa-claim-no-standard-magistrates-fee-backed-dev'
+  config.logstasher.source = 'laa-submit-crime-forms-dev'
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,7 @@
+# If this is set to a positive number, Puma will launch in cluster mode.
+# Note that on Mac you may need to also have env var `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`
+workers ENV.fetch("WORKERS", 0)
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
 
         it 'gets the claims without headers' do
           expect(described_class).to receive(:get)
-            .with('http://some.url/v1/applications?since=1&count=2')
+            .with('http://some.url/v1/applications?since=1&count=2', { headers: { 'X-Client-Type': 'provider' } })
 
           subject.get_all(since: 1, count: 2)
         end
@@ -105,7 +105,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         it 'posts the message without headers' do
           expect(described_class).to receive(:put)
             .with("http://some.url/v1/application/#{application_id}",
-                  body: message.to_json)
+                  body: message.to_json,
+                  headers: { 'X-Client-Type': 'provider' })
 
           subject.put(message)
         end
@@ -175,7 +176,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         it 'posts the message without headers' do
           expect(described_class).to receive(:post)
             .with('http://some.url/v1/application/',
-                  body: message.to_json)
+                  body: message.to_json,
+                  headers: { 'X-Client-Type': 'provider' })
 
           subject.post(message)
         end


### PR DESCRIPTION
## Description of change
- It's ok if we're in a non-auth environment if the app store webhook URL doesn't have a bearer token
- If we don't provide a bearer token, use a fallback header to tell the app store our role
- Allow launching the app in puma cluster mode so that if needed we can have multiple workers to avoid logjams where a request triggers a synchronous webhook callback that can't be processed.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1327)
