### PR TITLE
CRM457-1229: VAT calculations

### DIFF
--- a/app/lib/cost_calculator.rb
+++ b/app/lib/cost_calculator.rb
@@ -21,16 +21,16 @@ module CostCalculator
     end
 
     def work_item_total(item, pricing, vat)
-      rounded_cost = (item.time_spent.to_f / 60) * pricing[item.work_type] * (1 + (item[:uplift].to_f / 100)).round(2)
-      return (rounded_cost * (1 + pricing.vat)).floor(2) if vat
+      total = (item.time_spent.to_f / 60) * pricing[item.work_type] * (1 + (item[:uplift].to_f / 100))
+      return (total * (1 + pricing.vat)) if vat
 
-      rounded_cost
+      total
     end
 
     def disbursements_total(vat, object)
       pricing = Pricing.for(object)
       if vat
-        disbursements_total_cost_with_vat(object, pricing).round(2)
+        disbursements_total_cost_with_vat(object, pricing)
       else
         disbursements(object).sum(&:total_cost_without_vat).round(2)
       end
@@ -39,7 +39,7 @@ module CostCalculator
     def disbursements_total_cost_with_vat(object, pricing)
       disbursements(object).sum do |i|
         vat_multiplier = i.apply_vat == 'true' ? pricing.vat : 0
-        (i.total_cost_without_vat * (1 + vat_multiplier)).floor(2)
+        (i.total_cost_without_vat * (1 + vat_multiplier)).round(2)
       end
     end
 


### PR DESCRIPTION
## Description of change
Change VAT calculation logic to match clarified requirements

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1229)

## Notes for reviewer
I've followed the changes as listed in the ticket - removing a `round` and a `floor` in individual work item pricing calculations, changing a `floor` to a `round` in disbursement VAT calculations, and finally removing a redundant `round` in disbursement total summing.
