### PR TITLE
User local domain for production app store

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -74,7 +74,7 @@ variables:
   environment: production
   portalIDPMetadataFile: config/laa_portal/metadata/prod.xml
   spEntityId: LAA_Portal_CRM7_Prod
-  appStore: https://laa-crime-application-store-prod.apps.live.cloud-platform.service.justice.gov.uk
+  appStore: http://laa-crime-application-store-app.laa-crime-application-store-production.svc.cluster.local
   maxFileUploadBytes: 10485760
   eolUrl: https://apply-for-extension-of-upper-limits.form.service.justice.gov.uk/
   enableSyncTriggerEndpoint: 'false'


### PR DESCRIPTION
## Description of change
Use local app store URL for production app store

[CRM457-1288](https://dsdmoj.atlassian.net/browse/CRM457-1288)

Confirmation of of successful call from to Production app store from Production provider app pod:
<img width="1003" alt="image" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/26544538/b9cb2d50-e6e0-4fd1-8060-2401030f1951">



[CRM457-1288]: https://dsdmoj.atlassian.net/browse/CRM457-1288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ