### PR TITLE
Add envars needed for local integration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -30,6 +30,23 @@ INCLUDE_ACCESSIBILITY_SPECS=false
 MAX_UPLOAD_SIZE_BYTES=10485760
 CLAMBY_ENABLED=true
 
+# App store credentials for testing against local app store
+#
+# - commenting out APP_STORE_TENANT_ID will prevent attempts to authenticate to configured app store.
+#   Note that the configured app store will require AUTHAUTHENTICATION_REQUIRED=false too in this case.
+#
+# - uncomment all and add secret values from k8s to autheticate
+#   Note that the configured app store must NOT have AUTHAUTHENTICATION_REQUIRED=false in this case.
+#
+# PROVIDER_CLIENT_ID=not-a-real-key
+# PROVIDER_CLIENT_SECRET=not-a-real-key
+# APP_STORE_CLIENT_ID=not-a-real-key
+# APP_STORE_TENANT_ID=not-a-real-key
+
+# ingress and protocol for webhook subscription to app store - must match local apps's rails server
+HOSTS=localhost:3001
+PROTOCOL=http
+
 # Can generate your own test key here or use dev key here to send to team members emails
 # see https://www.notifications.service.gov.uk/
 GOVUK_NOTIFY_API_KEY=not-a-real-key

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: RUN_SIDEKIQ_IN_TEST_MODE=false bin/rails server -p 3001
 js: yarn build --watch
 css: yarn build:css --watch
-sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq
+sidekiq: RUN_SIDEKIQ_IN_TEST_MODE=false DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq


### PR DESCRIPTION
## Description of change
Add envars needed for local integration

This is one way of replicating a production like
integration of assess with app store inline with pub/sub
change.
