### PR TITLE
Use Local App Store URL - UAT

### DIFF
--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -74,7 +74,7 @@ variables:
   environment: uat
   portalIDPMetadataFile: config/laa_portal/metadata/uat.xml
   spEntityId: LAA_Portal_CRM7_UAT
-  appStore: https://laa-crime-application-store-uat.apps.live.cloud-platform.service.justice.gov.uk
+  appStore: http://laa-crime-application-store-app.laa-crime-application-store-uat.svc.cluster.local
   maxFileUploadBytes: 10485760
   eolUrl: https://apply-for-extension-of-upper-limits.dev.form.service.justice.gov.uk/
   enableSyncTriggerEndpoint: 'false'


### PR DESCRIPTION
## Description of change

 [Update network policies so that Provider application talks to datastore via Cloud Platform rather than via an external url](https://dsdmoj.atlassian.net/browse/CRM457-1288)

## Notes for reviewer

This is just for the UAT env to use the local domain so ingress can be disabled in UAT also for an environment matching production more