### PR TITLE
CRM457-1012: Fix payload structure

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -13,7 +13,7 @@ module PriorAuthority
       def save!; end
 
       def persist!
-        application.update!(attributes.merge({ status: :submitted }))
+        application.update!(attributes.merge({ status: new_status }))
         SubmitToAppStore.new.process(submission: application)
         true
       end
@@ -33,6 +33,10 @@ module PriorAuthority
       def needs_correcting?
         application.sent_back? &&
           application.incorrect_information_explanation.present?
+      end
+
+      def new_status
+        application.sent_back? ? :provider_updated : :submitted
       end
     end
   end

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -8,7 +8,7 @@ class SubmitToAppStore
       content = data
       { application_id: application.id,
         json_schema_version: 1,
-        application_state: 'submitted',
+        application_state: application.status,
         application: content,
         application_type: 'crm4',
         application_risk: 'N/A',
@@ -28,7 +28,7 @@ class SubmitToAppStore
         defendant:,
         quotes:,
         additional_costs:,
-        further_informations:,
+        further_information:,
       )
     end
 
@@ -64,7 +64,7 @@ class SubmitToAppStore
       PriorAuthority::AdditionalCostPayloadBuilder.new(application).payload
     end
 
-    def further_informations
+    def further_information
       PriorAuthority::FurtherInformationsPayloadBuilder.new(application).payload
     end
 

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         prison_law: true,
         ufn: '120423/123',
         laa_reference: 'LAA-n4AohV',
-        status: 'pre_draft',
+        status: 'submitted',
         reason_why: 'something',
         main_offence_id: 'something',
         custom_main_offence_name: nil,
@@ -126,7 +126,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
           }
         ],
         additional_costs: [],
-        further_informations: [
+        further_information: [
           {
             caseworker_id: '87e88ac6-d89a-4180-80d4-e03285023fb0',
             documents: [
@@ -160,7 +160,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
     }
   end
   let(:provider) { create(:provider) }
-  let(:application) { create(:prior_authority_application, :full, :with_confirmations) }
+  let(:application) { create(:prior_authority_application, :full, :with_confirmations, status: :submitted) }
   let(:fixed_arbitrary_date) { Date.new(2024, 1, 15) }
 
   before do


### PR DESCRIPTION
## Description of change
- Ensure we don't mark `provider_updated` submissions as `submitted`
- Remove a rogue `s` from a payload key

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1012)
