### PR TITLE
CRM457-750: Add validation to uplift 'Update calculation' buttons

### DIFF
--- a/app/controllers/concerns/add_another_methods.rb
+++ b/app/controllers/concerns/add_another_methods.rb
@@ -43,10 +43,6 @@ module AddAnotherMethods
     @record = object_collection.find(params[:id])
   end
 
-  def reload
-    render :edit
-  end
-
   # :nocov:
   def build_form_object
     raise 'Implement in subclass'

--- a/app/controllers/prior_authority/steps/travel_detail_controller.rb
+++ b/app/controllers/prior_authority/steps/travel_detail_controller.rb
@@ -12,10 +12,6 @@ module PriorAuthority
         update_and_advance(TravelDetailForm, as:, after_commit_redirect_path:, record:)
       end
 
-      def reload
-        render :edit
-      end
-
       private
 
       def record

--- a/app/forms/nsm/steps/letters_calls_form.rb
+++ b/app/forms/nsm/steps/letters_calls_form.rb
@@ -12,10 +12,10 @@ module Nsm
       validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
       validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
       validates :letters_uplift, presence: true,
-        numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+        numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
         if: :apply_letters_uplift
       validates :calls_uplift, presence: true,
-        numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+        numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
         if: :apply_calls_uplift
 
       def allow_uplift?

--- a/app/forms/nsm/steps/work_item_form.rb
+++ b/app/forms/nsm/steps/work_item_form.rb
@@ -18,7 +18,7 @@ module Nsm
               multiparam_date: { allow_past: true, allow_future: false }
       validates :fee_earner, presence: true
       validates :uplift, presence: true,
-              numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+              numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
               if: :apply_uplift
 
       def allow_uplift?

--- a/app/views/nsm/steps/letters_calls/edit.html.erb
+++ b/app/views/nsm/steps/letters_calls/edit.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       <% end %>
 
-      <%= f.refresh_button %>
+      <%= f.reload_button %>
 
       <%= govuk_table(rows: @form_object.calculation_rows, caption: t('.calculation')) %>
 

--- a/app/views/nsm/steps/work_item/edit.html.erb
+++ b/app/views/nsm/steps/work_item/edit.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       <% end %>
 
-      <%= f.refresh_button %>
+      <%= f.reload_button %>
 
       <%= govuk_table(rows: @form_object.calculation_rows, caption: t('.calculation')) %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -412,6 +412,8 @@ en:
               blank: Type of work must be choosen
             uplift:
               blank: Uplift amount must be set
+              less_than_or_equal_to: You can only apply an uplift from 1 to 100
+              greater_than_or_equal_to: You can only apply an uplift from 1 to 100
         nsm/steps/letters_calls_form:
           attributes:
             letters:
@@ -420,8 +422,12 @@ en:
               blank: Set the number of calls
             letters_uplift:
               blank: Letters uplift percentage must be set
+              less_than_or_equal_to: You can only apply an uplift from 1 to 100
+              greater_than_or_equal_to: You can only apply an uplift from 1 to 100
             calls_uplift:
               blank: Calls uplift percentage must be set
+              less_than_or_equal_to: You can only apply an uplift from 1 to 100
+              greater_than_or_equal_to: You can only apply an uplift from 1 to 100
         nsm/steps/disbursement_type_form:
           attributes:
             disbursement_date: *shared_date_errors

--- a/gems/laa_multi_step_forms/Gemfile.lock
+++ b/gems/laa_multi_step_forms/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
     laa_multi_step_forms (0.1.0)
       devise (~> 4.8)
       govuk-components (>= 5.0.0)
-      govuk_design_system_formbuilder (>= 4.0, < 5.3)
+      govuk_design_system_formbuilder (>= 4.0, < 5.4)
       hmcts_common_platform
       omniauth-rails_csrf_protection (~> 1.0.1)
       omniauth-saml (~> 2.1.0)

--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -16,12 +16,12 @@ module Steps
     def update
       raise 'implement this action, if needed, in subclasses'
     end
+    # :nocov:
 
     def reload
       @form_object.valid?
       render :edit
     end
-    # :nocov:
 
     private
 

--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -18,7 +18,8 @@ module Steps
     end
 
     def reload
-      raise 'implement this action, if needed, in subclasses'
+      @form_object.valid?
+      render :edit
     end
     # :nocov:
 

--- a/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
+++ b/gems/laa_multi_step_forms/spec/controllers/steps/base_step_controller_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe DummyStepController, type: :controller do
     end
 
     context 'when reloading (without save)' do
-      let(:form) { instance_double(Steps::BaseFormObject, application:, record:) }
+      let(:form) { instance_double(Steps::BaseFormObject, application: application, record: record, valid?: true) }
       let(:record) { application }
       let(:params) { { id: application.id, test_model: { first: 1, second: 2 }, reload: true } }
 

--- a/gems/laa_multi_step_forms/spec/dummy/app/controllers/dummy_step_controller.rb
+++ b/gems/laa_multi_step_forms/spec/dummy/app/controllers/dummy_step_controller.rb
@@ -25,10 +25,6 @@ class DummyStepController < ::Steps::BaseStepController
     true
   end
 
-  def reload
-    head(:ok)
-  end
-
   def decision_tree_class
     DummyStepImplementation.decision_tree_class || super
   end

--- a/spec/forms/nsm/steps/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/steps/letters_calls_form_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
   let(:letters) { 1 }
   let(:calls) { 1 }
   let(:apply_letters_uplift) { 'true' }
-  let(:letters_uplift) { 0 }
+  let(:letters_uplift) { 1 }
   let(:apply_calls_uplift) { 'true' }
-  let(:calls_uplift) { 0 }
+  let(:calls_uplift) { 1 }
   let(:date) { nil }
   let(:reasons_for_claim) { [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s] }
 
@@ -111,7 +111,7 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         context 'is zero' do
           let(:letters_uplift) { 0 }
 
-          it { expect(subject).to be_valid }
+          it { expect(subject).not_to be_valid }
         end
 
         context 'is positive' do
@@ -179,7 +179,7 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         context 'is zero' do
           let(:calls_uplift) { 0 }
 
-          it { expect(subject).to be_valid }
+          it { expect(subject).not_to be_valid }
         end
 
         context 'is positive' do
@@ -386,6 +386,8 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
   describe '#total_cost' do
     let(:letters) { 2 }
     let(:calls) { 3 }
+    let(:apply_calls_uplift) { 'false' }
+    let(:apply_letters_uplift) { 'false' }
 
     context 'letters is 0' do
       let(:letters) { 0 }

--- a/spec/forms/nsm/steps/work_items_add_form_spec.rb
+++ b/spec/forms/nsm/steps/work_items_add_form_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Nsm::Steps::WorkItemForm do
         context 'is zero' do
           let(:uplift) { 0 }
 
-          it { expect(subject).to be_valid }
+          it { expect(subject).not_to be_valid }
         end
 
         context 'is positive' do

--- a/spec/system/nsm/letters_calls_spec.rb
+++ b/spec/system/nsm/letters_calls_spec.rb
@@ -43,13 +43,6 @@ RSpec.describe 'User can fill in claim type details', type: :system do
 
     click_on 'Update the calculation'
 
-    expect(claim.reload).to have_attributes(
-      letters: 1,
-      calls: 2,
-      letters_uplift: nil,
-      calls_uplift: nil,
-    )
-
     within '.govuk-table__body' do
       expect(page.text).to eq('Letters£4.09Phone calls£8.18')
     end

--- a/spec/system/nsm/work_items_spec.rb
+++ b/spec/system/nsm/work_items_spec.rb
@@ -121,12 +121,6 @@ RSpec.describe 'User can manage work items', type: :system do
   it 'can calculate the result without creating duplicate records' do
     visit edit_nsm_steps_work_item_path(claim.id, work_item_id: Nsm::StartPage::NEW_RECORD)
 
-    expect { click_on 'Update the calculation' }.to change(WorkItem, :count).by(1)
-    work_item_path = edit_nsm_steps_work_item_path(claim.id, work_item_id: WorkItem.last.id)
-
-    expect(page).to have_current_path(work_item_path)
-
-    # Second click just updates the record
     expect { click_on 'Update the calculation' }.not_to change(WorkItem, :count)
   end
 


### PR DESCRIPTION
## Description of change
- Switch from a 'save_and_refresh' to a 'reload' on click on 'Update calculation' for pages with uplift values
- Change the 'reload' behaviour to validate the form so that when the page is re-rendered it displays any validation errors (but will still update the calculation if it can)
- Add the missing error messaging
- Adjust the minimum uplift threshold from 0 to 1 to match the error messaging

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-750)

