### PR TITLE
Make fewer requests to the app store

### DIFF
--- a/app/controllers/sync_controller.rb
+++ b/app/controllers/sync_controller.rb
@@ -10,8 +10,7 @@ class SyncController < ApplicationController
   end
 
   def sync_individual
-    record = AppStoreClient.new.get(params[:submission_id])
-    AppStoreUpdateProcessor.call(record, is_full: true)
+    AppStoreUpdateProcessor.call(params[:data].permit!.to_h)
     head :ok
   end
 

--- a/app/services/app_store_update_processor.rb
+++ b/app/services/app_store_update_processor.rb
@@ -1,13 +1,13 @@
 class AppStoreUpdateProcessor
   class << self
-    def call(record, is_full: false)
+    def call(record)
       case record['application_type']
       when 'crm7'
         update_claim(record['application_id'], convert_params(record))
       when 'crm4'
         update_prior_authority_application(record['application_id'],
                                            convert_params(record),
-                                           (record if is_full))
+                                           record)
       end
     end
 
@@ -24,12 +24,12 @@ class AppStoreUpdateProcessor
       claim&.update!(params)
     end
 
-    def update_prior_authority_application(application_id, params, full_record_or_nil)
+    def update_prior_authority_application(application_id, params, record)
       application = PriorAuthorityApplication.find_by(id: application_id)
       return unless application
 
       application.update!(params)
-      PriorAuthority::AssessmentSyncer.call(application, record: full_record_or_nil)
+      PriorAuthority::AssessmentSyncer.call(application, record:)
     end
   end
 end

--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -1,14 +1,14 @@
 module PriorAuthority
   class AssessmentSyncer
-    def self.call(application, record: nil)
+    def self.call(application, record:)
       new(application, record:).call
     end
 
     attr_reader :application, :app_store_record
 
-    def initialize(application, record: nil)
+    def initialize(application, record:)
       @application = application
-      @app_store_record = record || AppStoreClient.new.get(application.id)
+      @app_store_record = record
     end
 
     def call

--- a/spec/requests/sync_spec.rb
+++ b/spec/requests/sync_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe 'Syncs' do
   end
 
   describe 'POST /app_store_webhook' do
-    let(:client) { instance_double(AppStoreClient) }
-    let(:record) { :record }
+    let(:record) { { 'foo' => { 'bar' => %w[baz biz] } } }
 
     context 'when no auth token is provided' do
       it 'rejects all requests' do
@@ -31,16 +30,14 @@ RSpec.describe 'Syncs' do
           allow(AppStoreTokenProvider).to receive(:instance).and_return(token_provider)
           allow(token_provider).to receive(:authentication_configured?).and_return false
 
-          allow(AppStoreClient).to receive(:new).and_return(client)
-          allow(client).to receive(:get).and_return(record)
           allow(AppStoreUpdateProcessor).to receive(:call)
         end
 
         it 'triggers a sync' do
-          post '/app_store_webhook', params: { submission_id: '123' }, headers: { 'Authorization' => 'Bearer ABC' }
+          post '/app_store_webhook', params: { submission_id: '123', data: record },
+headers: { 'Authorization' => 'Bearer ABC' }
           expect(response).to have_http_status(:ok)
-          expect(client).to have_received(:get).with('123')
-          expect(AppStoreUpdateProcessor).to have_received(:call).with(record, is_full: true)
+          expect(AppStoreUpdateProcessor).to have_received(:call).with(record)
         end
       end
     end
@@ -78,16 +75,14 @@ RSpec.describe 'Syncs' do
           allow(JWT::JWK::Set).to receive(:new).with('keys').and_return(jwks)
           allow(JWT).to receive(:decode).with('ABC', nil, true, { algorithms: 'RS256', jwks: jwks }).and_return(decoded)
 
-          allow(AppStoreClient).to receive(:new).and_return(client)
-          allow(client).to receive(:get).and_return(record)
           allow(AppStoreUpdateProcessor).to receive(:call)
         end
 
         it 'triggers a sync' do
-          post '/app_store_webhook', params: { submission_id: '123' }, headers: { 'Authorization' => 'Bearer ABC' }
+          post '/app_store_webhook', params: { submission_id: '123', data: record },
+headers: { 'Authorization' => 'Bearer ABC' }
           expect(response).to have_http_status(:ok)
-          expect(client).to have_received(:get).with('123')
-          expect(AppStoreUpdateProcessor).to have_received(:call).with(record, is_full: true)
+          expect(AppStoreUpdateProcessor).to have_received(:call).with(record)
         end
       end
     end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -251,4 +251,26 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       end
     end
   end
+
+  describe '#get' do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('APP_STORE_TENANT_ID', nil).and_return(nil)
+    end
+
+    let(:id) { 'some-id' }
+    let(:response) { { 'foo' => 'bar' } }
+
+    it 'gets the the requested item' do
+      http_stub = stub_request(:get, "http://localhost:8000/v1/application/#{id}").with(
+        headers: {
+          'Content-Type' => 'application/json',
+          'X-Client-Type' => 'provider'
+        }
+      ).to_return(status: 200, body: response.to_json, headers: {})
+      expect(subject.get(id)).to eq response
+
+      expect(http_stub).to have_been_requested
+    end
+  end
 end

--- a/spec/services/app_store_update_processor_spec.rb
+++ b/spec/services/app_store_update_processor_spec.rb
@@ -19,23 +19,11 @@ RSpec.describe AppStoreUpdateProcessor do
 
     before do
       allow(PriorAuthority::AssessmentSyncer).to receive(:call)
-      described_class.call(response, is_full:)
+      described_class.call(response)
     end
 
-    context 'when response is explicitly flagged as being "full"' do
-      let(:is_full) { true }
-
-      it 'passes the full record on to AssessmentSyncer' do
-        expect(PriorAuthority::AssessmentSyncer).to have_received(:call).with(application, record: response)
-      end
-    end
-
-    context 'when response is not explicitly flagged as being "full"' do
-      let(:is_full) { false }
-
-      it 'does not pass the record on to AssessmentSyncer' do
-        expect(PriorAuthority::AssessmentSyncer).to have_received(:call).with(application, record: nil)
-      end
+    it 'passes the full record on to AssessmentSyncer' do
+      expect(PriorAuthority::AssessmentSyncer).to have_received(:call).with(application, record: response)
     end
   end
 end


### PR DESCRIPTION
- When doing a batch sync, use the full payload that's available from the get-go
- When doing an individual sync, use the data posted by the app store
