### PR TITLE
Stop treating work items as invalid if uplift allowed but not applied

### DIFF
--- a/app/forms/nsm/steps/work_item_form.rb
+++ b/app/forms/nsm/steps/work_item_form.rb
@@ -27,7 +27,7 @@ module Nsm
 
       def apply_uplift
         allow_uplift? &&
-          (@apply_uplift.nil? ? (uplift.present? && uplift.positive?) : @apply_uplift == 'true')
+          (@apply_uplift.nil? ? uplift.to_f.positive? : @apply_uplift == 'true')
       end
 
       def pricing

--- a/app/forms/nsm/steps/work_item_form.rb
+++ b/app/forms/nsm/steps/work_item_form.rb
@@ -27,7 +27,7 @@ module Nsm
 
       def apply_uplift
         allow_uplift? &&
-          (@apply_uplift.nil? ? uplift.present? : @apply_uplift == 'true')
+          (@apply_uplift.nil? ? (uplift.present? && uplift.positive?) : @apply_uplift == 'true')
       end
 
       def pricing

--- a/spec/forms/nsm/steps/work_items_add_form_spec.rb
+++ b/spec/forms/nsm/steps/work_items_add_form_spec.rb
@@ -152,6 +152,12 @@ RSpec.describe Nsm::Steps::WorkItemForm do
           it { expect(subject.apply_uplift).to be_truthy }
         end
 
+        context 'and letters_calls_uplift is zero' do
+          let(:uplift) { 0 }
+
+          it { expect(subject.apply_uplift).to be_falsey }
+        end
+
         context 'and letters_calls_uplift is nil' do
           let(:uplift) { nil }
 


### PR DESCRIPTION
## Description of change
If you save a work item that is eligible for uplift, but don't apply an uplift, it gets saved to the database with a zero uplift. But then the dodgy form logic decides to say that that uplift _has_ been applied - an uplift of zero. And that's now invalid.

This PR changes the form logic so that if a work item is eligible for uplift and what has been saved is zero, it now correctly interprets that as uplift _not_ having been applied, which is a valid state.
