### PR TITLE
6 is the magic number

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -25,6 +25,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=ministryofjustice/laa-crime-forms-team"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Internal testers routinely hit anomaly scores of 5, whatever that means. Let's set the anomaly score threshold to 6, which is what the caseworker app has.