### PR TITLE
CRM457-1432: Validate next hearing date to NOT be in past

### DIFF
--- a/app/forms/prior_authority/steps/hearing_detail_form.rb
+++ b/app/forms/prior_authority/steps/hearing_detail_form.rb
@@ -9,7 +9,7 @@ module PriorAuthority
       validates :next_hearing, inclusion: { in: [true, false] }
       validates :next_hearing_date,
                 presence: true,
-                multiparam_date: { allow_past: true, allow_future: true },
+                multiparam_date: { allow_past: false, allow_future: true },
                 if: :next_hearing
 
       validates :plea, inclusion: { in: PleaOptions.values }

--- a/app/forms/prior_authority/steps/hearing_detail_form.rb
+++ b/app/forms/prior_authority/steps/hearing_detail_form.rb
@@ -10,7 +10,7 @@ module PriorAuthority
       validates :next_hearing_date,
                 presence: true,
                 multiparam_date: { allow_past: false, allow_future: true },
-                if: :next_hearing
+                if: :validate_next_hearing_date?
 
       validates :plea, inclusion: { in: PleaOptions.values }
       validates :court_type, inclusion: { in: CourtTypeOptions.values }
@@ -24,6 +24,10 @@ module PriorAuthority
       end
 
       private
+
+      def validate_next_hearing_date?
+        next_hearing && (next_hearing_date.nil? || attribute_changed?(:next_hearing_date))
+      end
 
       def persist!
         application.update!(attributes_with_resets)

--- a/app/forms/prior_authority/steps/next_hearing_form.rb
+++ b/app/forms/prior_authority/steps/next_hearing_form.rb
@@ -7,7 +7,7 @@ module PriorAuthority
       validates :next_hearing, inclusion: { in: [true, false] }
       validates :next_hearing_date,
                 presence: true,
-                multiparam_date: { allow_past: true, allow_future: true },
+                multiparam_date: { allow_past: false, allow_future: true },
                 if: :next_hearing
 
       private

--- a/app/forms/prior_authority/steps/next_hearing_form.rb
+++ b/app/forms/prior_authority/steps/next_hearing_form.rb
@@ -8,9 +8,13 @@ module PriorAuthority
       validates :next_hearing_date,
                 presence: true,
                 multiparam_date: { allow_past: false, allow_future: true },
-                if: :next_hearing
+                if: :validate_next_hearing_date?
 
       private
+
+      def validate_next_hearing_date?
+        next_hearing && (next_hearing_date.nil? || attribute_changed?(:next_hearing_date))
+      end
 
       def persist!
         application.update!(attributes_to_reset)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -116,6 +116,7 @@ en:
               invalid_day: Enter a valid day
               invalid_month: Enter a valid month
               invalid_year: Enter a valid year
+              past_not_allowed: The next hearing date cannot be in the past
             plea:
               inclusion: Select the likely or actual plea
             court_type:
@@ -136,7 +137,6 @@ en:
               inclusion: Select yes if you know the date of the next hearing
             next_hearing_date:
               <<: *shared_next_hearing_date_errors
-              past_not_allowed: The next hearing date cannot be in the past
         prior_authority/steps/prison_law_form:
           attributes:
             prison_law:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -134,7 +134,9 @@ en:
           attributes:
             next_hearing:
               inclusion: Select yes if you know the date of the next hearing
-            next_hearing_date: *shared_next_hearing_date_errors
+            next_hearing_date:
+              <<: *shared_next_hearing_date_errors
+              past_not_allowed: The next hearing date cannot be in the past
         prior_authority/steps/prison_law_form:
           attributes:
             prison_law:

--- a/gems/laa_multi_step_forms/app/forms/steps/base_form_object.rb
+++ b/gems/laa_multi_step_forms/app/forms/steps/base_form_object.rb
@@ -43,6 +43,10 @@ module Steps
       !record.slice(*attribute_names).eql?(attributes)
     end
 
+    def attribute_changed?(attribute)
+      self[attribute] != record.public_send(attribute)
+    end
+
     def to_key
       # Intentionally returns nil so the form builder picks up only
       # the class name to generate the HTML attributes

--- a/gems/laa_multi_step_forms/spec/forms/steps/base_form_object_spec.rb
+++ b/gems/laa_multi_step_forms/spec/forms/steps/base_form_object_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Steps::BaseFormObject do
         attribute :name
       end
     end
+
     let(:record) { { 'name' => 'James' } }
     let(:form) { klass.new(:record => record, 'name' => name) }
 
@@ -61,6 +62,42 @@ RSpec.describe Steps::BaseFormObject do
       let(:name) { 'Jim' }
 
       it { expect(form).to be_changed }
+    end
+  end
+
+  describe 'attribute_changed?' do
+    before do
+      stub_const('NameForm', form_klass)
+      stub_const('NameRecord', record_klass)
+    end
+
+    let(:form_klass) do
+      Class.new(described_class) do
+        attribute :first_name
+      end
+    end
+
+    let(:record_klass) do
+      Class.new(ApplicationRecord) do
+        attr_accessor :first_name
+
+        def self.load_schema! = @columns_hash = {}
+      end
+    end
+
+    let(:record) { record_klass.new('first_name' => 'James') }
+    let(:form) { form_klass.new(:record => record, 'first_name' => first_name) }
+
+    context 'when the attribute has not changed' do
+      let(:first_name) { 'James' }
+
+      it { expect(form.attribute_changed?(:first_name)).to be false }
+    end
+
+    context 'when attribute has changed' do
+      let(:first_name) { 'Jim' }
+
+      it { expect(form.attribute_changed?(:first_name)).to be true }
     end
   end
 

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -185,7 +185,7 @@ FactoryBot.define do
 
       # next hearing details
       next_hearing { true }
-      next_hearing_date { date + 1 }
+      next_hearing_date { 1.day.from_now }
 
       # quotes
       service_type { service_type_options.sample }

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
 
   let(:arguments) do
     {
-      application:,
+      application: application,
+      record: application,
       **hearing_detail_attributes
     }
   end
 
   describe '#validate' do
-    let(:application) { instance_double(PriorAuthorityApplication) }
+    let(:application) { instance_double(PriorAuthorityApplication, next_hearing_date: nil) }
 
     context 'with hearing details including next hearing date' do
       let(:hearing_detail_attributes) do
@@ -107,6 +108,21 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
         expect(form.errors.messages.values.flatten)
           .to contain_exactly('The next hearing date cannot be in the past')
       end
+    end
+
+    context 'with next hearing date in the past but unchanged' do
+      let(:application) { create(:prior_authority_application, next_hearing: true, next_hearing_date: Date.yesterday) }
+
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: Date.yesterday,
+          plea: 'not_guilty',
+          court_type: 'central_criminal_court',
+        }
+      end
+
+      it { is_expected.to be_valid }
     end
   end
 

--- a/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/hearing_detail_form_spec.rb
@@ -91,6 +91,23 @@ RSpec.describe PriorAuthority::Steps::HearingDetailForm do
           .to include('Date is too far in the past')
       end
     end
+
+    context 'with next hearing date in the past' do
+      let(:hearing_detail_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: Date.yesterday,
+          plea: 'not_guilty',
+          court_type: 'central_criminal_court',
+        }
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.messages.values.flatten)
+          .to contain_exactly('The next hearing date cannot be in the past')
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
+++ b/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
@@ -5,13 +5,14 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
 
   let(:arguments) do
     {
-      application:,
+      application: application,
+      record: application,
       **next_hearing_attributes
     }
   end
 
   describe '#validate' do
-    let(:application) { instance_double(PriorAuthorityApplication) }
+    let(:application) { instance_double(PriorAuthorityApplication, next_hearing_date: nil) }
 
     context 'with next hearing details' do
       let(:next_hearing_attributes) do
@@ -63,6 +64,19 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
         expect(form.errors.messages.values.flatten)
           .to contain_exactly('The next hearing date cannot be in the past')
       end
+    end
+
+    context 'with next hearing date in the past but unchanged' do
+      let(:application) { create(:prior_authority_application, next_hearing: true, next_hearing_date: Date.yesterday) }
+
+      let(:next_hearing_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: Date.yesterday,
+        }
+      end
+
+      it { is_expected.to be_valid }
     end
 
     context 'with invalid combination of next hearing details' do

--- a/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
+++ b/spec/forms/prior_authority/steps/next_hearing_form_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe PriorAuthority::Steps::NextHearingForm do
       end
     end
 
+    context 'with next hearing date in the past' do
+      let(:next_hearing_attributes) do
+        {
+          next_hearing: true,
+          next_hearing_date: Date.yesterday,
+        }
+      end
+
+      it 'has a validation error on the field' do
+        expect(form).not_to be_valid
+        expect(form.errors.messages.values.flatten)
+          .to contain_exactly('The next hearing date cannot be in the past')
+      end
+    end
+
     context 'with invalid combination of next hearing details' do
       let(:next_hearing_attributes) do
         {


### PR DESCRIPTION
## Description of change
Ensure next hearing is in the future the first time entered, but not unless changed thereafter

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1432)

Bug raised by manual testing. Prior authority must be sought for hearings
that are yet to occur.

## Screenshots of changes (if applicable)

![Screenshot 2024-05-08 at 17 26 41](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/f4a0b1d9-0163-4754-8013-0d607fb1386c)
