### PR TITLE
CRM457-1404: Remove planning expert from list of services

### DIFF
--- a/app/value_objects/prior_authority/quote_services.rb
+++ b/app/value_objects/prior_authority/quote_services.rb
@@ -75,7 +75,6 @@ module PriorAuthority
       PHOTOCOPYING = new(:photocopying),
       PHOTOGRAPHER = new(:photographer),
       PHYSIOTHERAPIST = new(:physiotherapist),
-      PLANNING_EXPERT = new(:planning_expert),
       PLASTIC_SURGEON = new(:plastic_surgeon),
       PRIVATE_INVESTIGATOR = new(:private_investigator),
       PROCESS_SERVER = new(:process_server),

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -449,7 +449,6 @@ en:
       photocopying: Photocopying
       photographer: Photographer
       physiotherapist: Physiotherapist
-      planning_expert: Planning expert
       plastic_surgeon: Plastic surgeon
       private_investigator: Private investigator
       process_server: Process server


### PR DESCRIPTION
## Description of change
Remove planning expert from list of services

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1404)

Request from BA inline with updated services list
