### PR TITLE
CRM457-1387: Cost type is never variable for alternative quotes

### DIFF
--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -70,6 +70,17 @@ module PriorAuthority
 
         delegate :contact_full_name, to: :record
 
+        def variable_cost_type?
+          false
+        end
+
+        def cost_type
+          @cost_type ||= ServiceCostForm.build(
+            application.primary_quote,
+            application:
+          ).cost_type
+        end
+
         private
 
         def persist!

--- a/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
+++ b/spec/forms/prior_authority/steps/alternative_quotes/detail_form_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
   let(:travel_cost_per_hour) { '' }
   let(:additional_cost_list) { '' }
   let(:record) { build(:quote, document: nil) }
-  let(:application) { build(:prior_authority_application, service_type:) }
+  let(:quotes) { [build(:quote, :primary)] }
+  let(:application) { create(:prior_authority_application, service_type:, quotes:) }
   let(:service_type) { 'photocopying' }
 
   let(:file_upload) { instance_double(ActionDispatch::Http::UploadedFile, tempfile:, content_type:) }
@@ -113,7 +114,7 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
       let(:items) { '3' }
       let(:cost_per_item) { '20' }
       let(:user_chosen_cost_type) { 'per_hour' }
-      let(:application) { create(:prior_authority_application, service_type: 'custom') }
+      let(:application) { create(:prior_authority_application, service_type: 'custom', quotes: quotes) }
       let(:record) { build(:quote, document: nil, prior_authority_application: application) }
       let(:file_upload) { nil }
 
@@ -154,6 +155,17 @@ RSpec.describe PriorAuthority::Steps::AlternativeQuotes::DetailForm do
 
     it 'handles <£1 values' do
       expect(subject.total_cost).to eq 0.25
+    end
+  end
+
+  describe '#cost_type' do
+    context 'when service has variable cost type' do
+      let(:service_type) { 'dna_report' }
+      let(:quotes) { [build(:quote, :primary_per_item)] }
+
+      it 'uses the same cost type as the user-chosen primary quote cost type' do
+        expect(subject.cost_type).to eq 'per_item'
+      end
     end
   end
 end

--- a/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/alternative_quotes_card_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe PriorAuthority::CheckAnswers::AlternativeQuotesCard do
     context 'when alternative quotes exist' do
       let(:quotes) do
         [
+          build(:quote, :primary),
           build(:quote, :alternative, contact_first_name: 'Jim', contact_last_name: 'Bob',
                 cost_per_hour: 20, period: 60, travel_cost_per_hour: 30, travel_time: 60),
           build(:quote, :alternative, contact_first_name: 'John', contact_last_name: 'Boy', document: nil,

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -2,7 +2,7 @@ require 'system_helper'
 
 RSpec.describe 'Prior authority applications - alternative quote' do
   let(:application) do
-    create(:prior_authority_application, :with_primary_quote)
+    create(:prior_authority_application, :with_primary_quote, quotes: [build(:quote, :primary_per_item)])
   end
 
   before do
@@ -39,7 +39,6 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
-        choose 'Charged per item'
         fill_in 'Number of items', with: '2'
         fill_in 'What is the cost per item?', with: '3'
         click_on 'Save and continue'
@@ -53,7 +52,6 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
-        choose 'Charged per item'
         fill_in 'Number of items', with: '2'
         fill_in 'What is the cost per item?', with: '3'
         attach_file(file_fixture('test.png'))
@@ -68,7 +66,6 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         fill_in 'Last name', with: 'Expert'
         fill_in 'Organisation', with: 'ExpertiseCo'
         fill_in 'Postcode', with: 'SW1 1AA'
-        choose 'Charged per item'
         fill_in 'Number of items', with: '1'
         fill_in 'What is the cost per item?', with: '100'
         fill_in 'prior_authority_steps_alternative_quotes_detail_form_travel_time_1', with: '1'
@@ -91,7 +88,6 @@ RSpec.describe 'Prior authority applications - alternative quote' do
           fill_in 'Last name', with: 'Expert'
           fill_in 'Organisation', with: 'ExpertiseCo'
           fill_in 'Postcode', with: 'SW1 1AA'
-          choose 'Charged per item'
           fill_in 'Number of items', with: '2'
           fill_in 'What is the cost per item?', with: '3'
           click_on 'Save and continue'
@@ -150,7 +146,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
 
   context 'when I already have 3 quotes' do
     before do
-      create_list(:quote, 3, :alternative, prior_authority_application: application)
+      create_list(:quote, 3, :alternative, :cost_per_item, prior_authority_application: application)
     end
 
     it 'does not prompt me to add more' do

--- a/spec/system/support/prior_authority/step_helpers.rb
+++ b/spec/system/support/prior_authority/step_helpers.rb
@@ -222,7 +222,6 @@ module PriorAuthority
       fill_in 'Organisation', with: 'Experts Inc.'
       fill_in 'Postcode', with: 'SW1A 1AA'
 
-      choose 'Charged per item'
       fill_in 'Number of items', with: '1'
       fill_in 'What is the cost per item?', with: '100'
       fill_in 'prior_authority_steps_alternative_quotes_detail_form_travel_time_1', with: '1'


### PR DESCRIPTION
## Description of change
When service has variable cost type, alternative quotes always take the user-chosen cost type from the primary quote.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1387)
