### PR TITLE
Set maxReplicas to 50 for Production and UAT Deployments

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -61,7 +61,7 @@ resources:
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 50
   targetCPUUtilizationPercentage: 80
 
 variables:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -61,7 +61,7 @@ resources:
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 50
   targetCPUUtilizationPercentage: 80
 
 variables:


### PR DESCRIPTION
[Production](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-prod/03-resourcequota.yaml) and [UAT](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/laa-submit-crime-forms-uat/03-resourcequota.yaml) cloud platform environments have a max pod count of 50, yet our helm deploy config allows for up to 100 max replicas