### PR TITLE
CRM457-1437: All radios vertical, with yes before no

### DIFF
--- a/app/views/nsm/steps/office_code/edit.html.erb
+++ b/app/views/nsm/steps/office_code/edit.html.erb
@@ -6,7 +6,6 @@
     <%= govuk_error_summary(@form_object) %>
     <%= step_form @form_object do |f| %>
       <%= f.govuk_collection_radio_buttons :office_code, @form_object.options, :to_s, :to_s,
-                                           inline: false,
                                            legend: { tag: 'h1', size: 'xl', text: t('.page_title') },
                                            hint: { text: t('.subheading') } %>
       <%= f.continue_button %>

--- a/app/views/prior_authority/steps/additional_costs/edit.html.erb
+++ b/app/views/prior_authority/steps/additional_costs/edit.html.erb
@@ -20,7 +20,6 @@
         :value,
         :label,
         value: nil,
-        inline: true,
         legend: { text: t('.question'), size: 's' }
       ) %>
 

--- a/app/views/prior_authority/steps/alternative_quotes/_no_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_no_alternative_quotes.html.erb
@@ -9,14 +9,14 @@
       <%= form.govuk_radio_buttons_fieldset :alternative_quotes_still_to_add,
                                             legend: { text: t('.page_title'), size: 'xl', tag: 'h1' } do %>
         <%= form.govuk_radio_button :alternative_quotes_still_to_add,
+                                    true,
+                                    link_errors: true,
+                                    label: { text: t('prior_authority.generic.yes_choice') } %>
+        <%= form.govuk_radio_button :alternative_quotes_still_to_add,
                                     false,
-                                    label: { text: t('prior_authority.generic.no_choice') },
-                                    link_errors: true do %>
+                                    label: { text: t('prior_authority.generic.no_choice') } do %>
           <%= form.govuk_text_area :no_alternative_quote_reason, label: { text: t('.why_not') } %>
         <% end %>
-        <%= form.govuk_radio_button :alternative_quotes_still_to_add,
-                                    true,
-                                    label: { text: t('prior_authority.generic.yes_choice') } %>
       <% end %>
 
       <%= form.continue_button %>

--- a/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
@@ -24,7 +24,6 @@
           YesNoAnswer.radio_options,
           :value,
           :label,
-          inline: true,
           legend: { text: t('.question'), size: 's' }
         ) %>
       <% end %>

--- a/app/views/prior_authority/steps/office_code/edit.html.erb
+++ b/app/views/prior_authority/steps/office_code/edit.html.erb
@@ -7,7 +7,6 @@
    <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <%= step_form @form_object do |form| %>
       <%= form.govuk_collection_radio_buttons :office_code, @form_object.options, :to_s, :to_s,
-                                              inline: false,
                                               legend: { tag: 'h1', size: 'xl', text: t('.page_title') },
                                               hint: { text: t('.subheading') } %>
 

--- a/app/views/prior_authority/steps/service_cost/edit.html.erb
+++ b/app/views/prior_authority/steps/service_cost/edit.html.erb
@@ -12,6 +12,7 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
+            inline: true,
             legend: { text: t('.prior_authority_granted'), size: 's' }
           ) %>
       <% if @form_object.court_order_relevant %>
@@ -20,6 +21,7 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
+            inline: true,
             legend: { text: t('.ordered_by_court'), size: 's' }
           ) %>
       <% end %>
@@ -29,6 +31,7 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
+            inline: true,
             legend: { text: t('.related_to_post_mortem'), size: 's' }
           ) %>
       <% end %>

--- a/app/views/prior_authority/steps/service_cost/edit.html.erb
+++ b/app/views/prior_authority/steps/service_cost/edit.html.erb
@@ -12,7 +12,6 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
-            inline: true,
             legend: { text: t('.prior_authority_granted'), size: 's' }
           ) %>
       <% if @form_object.court_order_relevant %>
@@ -21,7 +20,6 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
-            inline: true,
             legend: { text: t('.ordered_by_court'), size: 's' }
           ) %>
       <% end %>
@@ -31,7 +29,6 @@
             YesNoAnswer.radio_options,
             :value,
             :label,
-            inline: true,
             legend: { text: t('.related_to_post_mortem'), size: 's' }
           ) %>
       <% end %>


### PR DESCRIPTION
## Description of change
All radios vertical, with yes before no (and redundant 'inline' config removed)

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1437)
