### PR TITLE
CRM457-1401: Stop preselecting radio button

### DIFF
--- a/app/forms/nsm/steps/firm_details/solicitor_form.rb
+++ b/app/forms/nsm/steps/firm_details/solicitor_form.rb
@@ -12,6 +12,7 @@ module Nsm
         validates :first_name, presence: true
         validates :last_name, presence: true
         validates :reference_number, presence: true
+        validates :alternative_contact_details, presence: true
 
         with_options if: :alternative_contact_details? do
           validates :contact_first_name, presence: true
@@ -22,7 +23,10 @@ module Nsm
         def alternative_contact_details
           return @alternative_contact_details unless @alternative_contact_details.nil?
 
-          [contact_last_name, contact_first_name, contact_email].any?(&:present?) ? YesNoAnswer::YES : YesNoAnswer::NO
+          return YesNoAnswer::YES if [contact_last_name, contact_first_name, contact_email].any?(&:present?)
+          return YesNoAnswer::NO if application.solicitor&.persisted?
+
+          nil
         end
 
         def alternative_contact_details=(val)

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -293,6 +293,8 @@ en:
 
             reference_number:
               blank: "Enter the solicitor's reference number"
+            alternative_contact_details:
+              blank: "Select yes if you want to add alternative contact details"
             contact_first_name:
               blank: "Enter the first name of the alternative contact"
             contact_last_name:


### PR DESCRIPTION
## Description of change
We infer the alternate contact details value from the presence of conditionally revealed details when the page is first loaded. But when the page has not previously been saved, the absence of contact details should cause the radio to be unselected. This PR does that.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1401)
