### PR TITLE
Add snyk ignores to codebase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.1.0
   browser-tools: circleci/browser-tools@1.4.7
-  snyk: snyk/snyk@1.1.2
+  snyk: snyk/snyk@2.1.0
   aws-cli: circleci/aws-cli@4.1.3
   aws-ecr: circleci/aws-ecr@9.0.2
   crime-forms-end-to-end-tests: ministryofjustice/crime-forms-end-to-end-tests@volatile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,7 @@ jobs:
           project: ministryofjustice/laa-submit-crime-forms
           severity-threshold: "high"
           fail-on-issues: true
+          additional-arguments: --policy-path=.snyk
 
   build-to-ecr:
     executor: aws-ecr/default

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-BRACES-6838727:
+    - '*':
+        reason: no fix; no-impact
+        expires: 2099-01-01T00:00:00.000Z
+        created: 2024-05-13T21:14:53.339Z
+patch: {}


### PR DESCRIPTION
## Description of change
Add .snyk file for vulnerability ignores

The webui ignore mechanism does not appear to be working
plus this mechanism makes it simpler to manage in any event.

You can install the snyk cli locally following this
https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli

or just `brew install snyk-cli`

See [how to create a snyk file locally](https://docs.snyk.io/manage-risk/prioritize-your-issues/the-.snyk-file)

TL;DR:

This command was run to generate a .snyk file to ignore this problematic vulnerability
```sh
snyk ignore --id=SNYK-JS-BRACES-6838727 --reason="no fix; no-impact" --expiry=2099-01-01
````

