### PR TITLE
CRM457-1450: RBBA Bug Fix

### DIFF
--- a/app/services/risk_assessment/high_risk_assessment.rb
+++ b/app/services/risk_assessment/high_risk_assessment.rb
@@ -29,7 +29,7 @@ module RiskAssessment
     end
 
     def uplift_applied?
-      @items[:work_items].work_item_forms.any? { _1.uplift&.positive? }
+      @items[:work_items].work_item_forms.any?(&:apply_uplift)
     end
 
     def extradition?

--- a/app/services/risk_assessment/high_risk_assessment.rb
+++ b/app/services/risk_assessment/high_risk_assessment.rb
@@ -29,7 +29,7 @@ module RiskAssessment
     end
 
     def uplift_applied?
-      @items[:work_items].work_item_forms.filter_map(&:uplift).any?
+      @items[:work_items].work_item_forms.filter_map(&:uplift).any?(&:positive?)
     end
 
     def extradition?

--- a/app/services/risk_assessment/high_risk_assessment.rb
+++ b/app/services/risk_assessment/high_risk_assessment.rb
@@ -29,7 +29,7 @@ module RiskAssessment
     end
 
     def uplift_applied?
-      @items[:work_items].work_item_forms.filter_map(&:uplift).any?(&:positive?)
+      @items[:work_items].work_item_forms.any? { _1.uplift&.positive? }
     end
 
     def extradition?

--- a/app/services/risk_assessment/low_risk_assessment.rb
+++ b/app/services/risk_assessment/low_risk_assessment.rb
@@ -24,8 +24,9 @@ module RiskAssessment
       number_of_pages = (@claim.defence_statement || 0) * PAGE_MULTIPLIER
       number_of_witnesses = (@claim.number_of_witnesses || 0) * WITNESS_MULTIPLIER
       length_of_video = @claim.time_spent || 0
-
-      prosecution_evidence + number_of_pages + length_of_video - number_of_witnesses <= multiplied_total_advocacy_time
+      new_prep_time = prosecution_evidence + number_of_pages + length_of_video - number_of_witnesses
+      multiplied_advocacy_time = multiplied_total_advocacy_time
+      new_prep_time <= multiplied_advocacy_time && total_attendance_time <= multiplied_advocacy_time
     end
 
     def total_prep_time

--- a/spec/services/risk_assessment/high_risk_assessment_spec.rb
+++ b/spec/services/risk_assessment/high_risk_assessment_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe RiskAssessment::HighRiskAssessment do
         end
       end
 
+      context 'when there is workitem without an uplift' do
+        let(:uplifted_claim) { build(:claim, :one_work_item) }
+
+        it do
+          expect(described_class.new(uplifted_claim)).not_to be_uplift_applied
+          expect(described_class.new(uplifted_claim).assess).not_to be_truthy
+        end
+      end
+
       context 'when there is an extradition' do
         let(:extradition_claim) { build(:claim, :with_extradition) }
 

--- a/spec/services/risk_assessment/high_risk_assessment_spec.rb
+++ b/spec/services/risk_assessment/high_risk_assessment_spec.rb
@@ -41,15 +41,6 @@ RSpec.describe RiskAssessment::HighRiskAssessment do
         end
       end
 
-      context 'when there is workitem without an uplift' do
-        let(:uplifted_claim) { build(:claim, :one_work_item) }
-
-        it do
-          expect(described_class.new(uplifted_claim)).not_to be_uplift_applied
-          expect(described_class.new(uplifted_claim).assess).not_to be_truthy
-        end
-      end
-
       context 'when there is an extradition' do
         let(:extradition_claim) { build(:claim, :with_extradition) }
 
@@ -70,7 +61,7 @@ RSpec.describe RiskAssessment::HighRiskAssessment do
     end
 
     context 'returns false' do
-      let(:claim) { build(:claim) }
+      let(:claim) { build(:claim, :one_work_item) }
 
       it 'when cost is under £5000' do
         expect(described_class.new(claim)).not_to be_high_cost
@@ -86,6 +77,7 @@ RSpec.describe RiskAssessment::HighRiskAssessment do
 
       it 'when there is not an uplift' do
         expect(described_class.new(claim)).not_to be_uplift_applied
+        expect(described_class.new(claim).assess).not_to be_truthy
       end
 
       it 'when there is not an extradition' do

--- a/spec/services/risk_assessment/low_risk_assessment_spec.rb
+++ b/spec/services/risk_assessment/low_risk_assessment_spec.rb
@@ -45,21 +45,24 @@ RSpec.describe RiskAssessment::LowRiskAssessment do
             prosecution_evidence: 5,
             defence_statement: 7,
             number_of_witnesses: 3,
-            time_spent: 24)
+            time_spent: 24,)
     end
+
     let(:low_risk_assessment) { described_class.new(claim) }
 
     it 'returns true if new preparation time and total attendance time are less than or equal to double the advocacy time' do
+      allow(low_risk_assessment).to receive(:multiplied_total_advocacy_time).and_return(200)
       expect(low_risk_assessment.new_prep_advocacy?).to be(true)
     end
 
     it 'returns false if new preparation time is greater than double the advocacy time' do
+      allow(low_risk_assessment).to receive(:multiplied_total_advocacy_time).and_return(20)
       allow(claim).to receive(:prosecution_evidence).and_return(100)
       expect(low_risk_assessment.new_prep_advocacy?).to be(false)
     end
 
     it 'returns false if total attendance time is greater than double the advocacy time' do
-      allow(claim).to receive(:time_spent).and_return(100)
+      allow(low_risk_assessment).to receive_messages(multiplied_total_advocacy_time: 20, total_attendance_time: 100)
       expect(low_risk_assessment.new_prep_advocacy?).to be(false)
     end
   end

--- a/spec/services/risk_assessment/low_risk_assessment_spec.rb
+++ b/spec/services/risk_assessment/low_risk_assessment_spec.rb
@@ -38,4 +38,29 @@ RSpec.describe RiskAssessment::LowRiskAssessment do
       end
     end
   end
+
+  describe '#new_prep_advocacy?' do
+    let(:claim) do
+      build(:claim,
+            prosecution_evidence: 5,
+            defence_statement: 7,
+            number_of_witnesses: 3,
+            time_spent: 24)
+    end
+    let(:low_risk_assessment) { described_class.new(claim) }
+
+    it 'returns true if new preparation time and total attendance time are less than or equal to double the advocacy time' do
+      expect(low_risk_assessment.new_prep_advocacy?).to be(true)
+    end
+
+    it 'returns false if new preparation time is greater than double the advocacy time' do
+      allow(claim).to receive(:prosecution_evidence).and_return(100)
+      expect(low_risk_assessment.new_prep_advocacy?).to be(false)
+    end
+
+    it 'returns false if total attendance time is greater than double the advocacy time' do
+      allow(claim).to receive(:time_spent).and_return(100)
+      expect(low_risk_assessment.new_prep_advocacy?).to be(false)
+    end
+  end
 end

--- a/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
+++ b/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe RiskAssessment::RiskAssessmentScorer do
+  let(:fee_earner_initial) { Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 2, min_numeric: 0) }
+
   describe '#calculate' do
     context 'returns high risk' do
       let(:claim) { build(:claim, :with_assigned_council) }
@@ -13,7 +15,35 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
     end
 
     context 'returns medium risk' do
-      let(:claim) { build(:claim, :medium_risk_work_item) }
+      let(:claim) do
+        build(:claim,
+              letters: 19,
+              calls: 1,
+              prosecution_evidence: 50,
+              defence_statement: 1,
+              number_of_witnesses: 1,
+              time_spent: 24,
+              assigned_counsel: 'no',
+              reasons_for_claim: [ReasonForClaim::CORE_COSTS_EXCEED_HIGHER_LMTS.to_s],
+              work_items: [
+                build(:work_item, work_type: WorkTypes::PREPARATION,
+                  time_spent: '23',
+                  completed_on: Time.zone.today,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::ATTENDANCE_WITHOUT_COUNSEL,
+                  time_spent: '40',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::ADVOCACY,
+                  time_spent: '26',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::TRAVEL,
+                  time_spent: '156',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+              ])
+      end
 
       it do
         expect(described_class.calculate(claim)).to eq('medium')
@@ -21,7 +51,35 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
     end
 
     context 'returns low risk' do
-      let(:claim) { build(:claim) }
+      let(:claim) do
+        build(:claim,
+              letters: 19,
+              calls: 1,
+              prosecution_evidence: 50,
+              defence_statement: 1,
+              number_of_witnesses: 1,
+              time_spent: 24,
+              assigned_counsel: 'no',
+              reasons_for_claim: [ReasonForClaim::CORE_COSTS_EXCEED_HIGHER_LMTS.to_s],
+              work_items: [
+                build(:work_item, work_type: WorkTypes::PREPARATION,
+                  time_spent: '552',
+                  completed_on: Time.zone.today,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::ATTENDANCE_WITHOUT_COUNSEL,
+                  time_spent: '282',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::ADVOCACY,
+                  time_spent: '246',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+                build(:work_item, work_type: WorkTypes::TRAVEL,
+                  time_spent: '156',
+                  completed_on: Time.zone.yesterday,
+                  fee_earner: fee_earner_initial),
+              ])
+      end
 
       it do
         expect(described_class.calculate(claim)).to eq('low')

--- a/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
+++ b/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
@@ -17,26 +17,22 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
     context 'returns medium risk' do
       let(:claim) do
         build(:claim,
-              prosecution_evidence: 50,
+              prosecution_evidence: 1,
               defence_statement: 1,
               number_of_witnesses: 1,
               work_items: [
                 build(:work_item, work_type: WorkTypes::PREPARATION,
-                  time_spent: '23',
+                  time_spent: '623',
                   completed_on: Time.zone.today,
                   fee_earner: fee_earner_initial),
                 build(:work_item, work_type: WorkTypes::ATTENDANCE_WITHOUT_COUNSEL,
-                  time_spent: '40',
+                  time_spent: '1240',
                   completed_on: Time.zone.yesterday,
                   fee_earner: fee_earner_initial),
                 build(:work_item, work_type: WorkTypes::ADVOCACY,
-                  time_spent: '26',
+                  time_spent: '2',
                   completed_on: Time.zone.yesterday,
-                  fee_earner: fee_earner_initial),
-                build(:work_item, work_type: WorkTypes::TRAVEL,
-                  time_spent: '156',
-                  completed_on: Time.zone.yesterday,
-                  fee_earner: fee_earner_initial),
+                  fee_earner: fee_earner_initial)
               ])
       end
 

--- a/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
+++ b/spec/services/risk_assessment/risk_assessment_scorer_spec.rb
@@ -17,14 +17,9 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
     context 'returns medium risk' do
       let(:claim) do
         build(:claim,
-              letters: 19,
-              calls: 1,
               prosecution_evidence: 50,
               defence_statement: 1,
               number_of_witnesses: 1,
-              time_spent: 24,
-              assigned_counsel: 'no',
-              reasons_for_claim: [ReasonForClaim::CORE_COSTS_EXCEED_HIGHER_LMTS.to_s],
               work_items: [
                 build(:work_item, work_type: WorkTypes::PREPARATION,
                   time_spent: '23',
@@ -53,14 +48,10 @@ RSpec.describe RiskAssessment::RiskAssessmentScorer do
     context 'returns low risk' do
       let(:claim) do
         build(:claim,
-              letters: 19,
-              calls: 1,
               prosecution_evidence: 50,
               defence_statement: 1,
               number_of_witnesses: 1,
               time_spent: 24,
-              assigned_counsel: 'no',
-              reasons_for_claim: [ReasonForClaim::CORE_COSTS_EXCEED_HIGHER_LMTS.to_s],
               work_items: [
                 build(:work_item, work_type: WorkTypes::PREPARATION,
                   time_spent: '552',


### PR DESCRIPTION
## Description of change
The `uplift_applied?` method checks if any work item has a positive uplift.
currently it uses `filter_map` to extract the `uplift` of each work item, and checks if any of them are positive. 

Issue is if uplift is 0, `any?` returns true and all of our application was being assessed as High Risk.

Added `positive?` method to check if a number is greater than 0. So, method is only returns true if uplift is more than 0.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-752)

## Notes for reviewer
Tested with Paper form PP2 that had initial assessment of Low risk from Caseworker.

### Before changes:
**Current Dev env - Wrong assessment**
![Screenshot 2024-05-14 at 15 54 25](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/90189839/80a1eca7-bc1b-44e5-98c6-6cdbe6d4bd64)
### After changes:
Current fixed env - Correct assessment
![Screenshot 2024-05-14 at 15 32 33](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/90189839/329e5cad-8dc8-4bce-a552-fe3d2844ca01)

