### PR TITLE
CRM457-1429: Add presenter for supporting evidence checkList

### DIFF
--- a/app/presenters/nsm/supporting_evidence/check_list.rb
+++ b/app/presenters/nsm/supporting_evidence/check_list.rb
@@ -1,0 +1,76 @@
+module Nsm
+  module SupportingEvidence
+    class CheckList
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::TranslationHelper
+
+      # govuk_link_to required modules
+      include GovukLinkHelper
+      include GovukVisuallyHiddenHelper
+      include ActionView::Helpers::UrlHelper
+
+      attr_reader :claim
+
+      def initialize(claim)
+        @claim = claim
+      end
+
+      def self.render(claim)
+        new(claim).render
+      end
+
+      def render
+        tag.ul safe_join(items), class: 'govuk-list govuk-list--bullet govuk-!-margin-bottom-6 govuk-!-padding-left-6'
+      end
+
+      def items
+        return @items if @items.present?
+
+        @items = []
+        @items << li_crm8_form_link if assigned_counsel?
+        @items << li_for_translation('remittal') if remitted_to_magistrate?
+        @items << li_for_translation('supplemental') if supplemental_claim?
+        @items << li_for_translation('authority') if any_prior_authority?
+        # TODO: wasted_costs; CRM457-1464 and CRM457-1384
+        @items
+      end
+
+      private
+
+      def li_crm8_form_link
+        tag.li do
+          govuk_link_to(
+            t('crm8', scope: i18n_scope),
+            'https://www.gov.uk/government/publications/crm8-assigned-counsels-fee-note',
+            class: 'govuk-link--no-visited-state',
+            target: '_blank'
+          )
+        end
+      end
+
+      def li_for_translation(key)
+        tag.li(t(key, scope: i18n_scope))
+      end
+
+      def i18n_scope
+        'nsm.steps.supporting_evidence.content.para1'
+      end
+
+      def assigned_counsel?
+        claim.assigned_counsel == 'yes'
+      end
+
+      def remitted_to_magistrate?
+        claim.remitted_to_magistrate == 'yes'
+      end
+
+      def supplemental_claim?
+        claim.supplemental_claim == 'yes'
+      end
+
+      def any_prior_authority?
+        claim.disbursements.any? { |disbursement| disbursement.prior_authority == 'yes' }
+      end
+    end
+  end
+end

--- a/app/presenters/nsm/supporting_evidence/check_list.rb
+++ b/app/presenters/nsm/supporting_evidence/check_list.rb
@@ -15,10 +15,6 @@ module Nsm
         @claim = claim
       end
 
-      def self.render(claim)
-        new(claim).render
-      end
-
       def render
         tag.ul safe_join(items), class: 'govuk-list govuk-list--bullet govuk-!-margin-bottom-6 govuk-!-padding-left-6'
       end

--- a/app/views/nsm/steps/claim_details/edit.html.erb
+++ b/app/views/nsm/steps/claim_details/edit.html.erb
@@ -9,9 +9,10 @@
       <%= f.govuk_number_field :prosecution_evidence,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
       <%= f.govuk_number_field :defence_statement,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
       <%= f.govuk_number_field :number_of_witnesses,label:{ size: 's'}, min: 1, step: 1, width: 3 %>
+
       <% @form_object.boolean_fields.each do |field| %>
         <%= f.govuk_radio_buttons_fieldset field, legend: { size: 's' } do %>
-          <%= f.govuk_radio_button field, YesNoAnswer::YES do%>
+          <%= f.govuk_radio_button field, YesNoAnswer::YES do %>
             <% if field == :preparation_time %>
               <%= f.govuk_period_field :time_spent,legend: { size: 's', class: 'govuk-!-font-weight-regular' }, width: 'one-third' %>
             <% elsif %i[work_before work_after].include?(field) %>
@@ -19,7 +20,7 @@
             <% end %>
           <% end %>
           <%= f.govuk_radio_button field, YesNoAnswer::NO %>
-        <% end%>
+        <% end %>
       <% end%>
       <%= f.continue_button %>
     <% end %>

--- a/app/views/nsm/steps/supporting_evidence/_content.html.erb
+++ b/app/views/nsm/steps/supporting_evidence/_content.html.erb
@@ -1,20 +1,21 @@
 <div class="govuk-!-margin-bottom-7">
-  <p class="govuk-body"><%= t('.para1.heading') %></p>
-  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6 govuk-!-padding-left-6">
-      <li><%= link_to t('.para1.crm8'), t('.para1.crm8_link'), class: "govuk-link", target: "_blank" %></li>
-      <li> <%= t('.para1.remittal') %> </li>
-      <li> <%= t('.para1.supplemental') %> </li>
-      <li> <%= t('.para1.authority') %> </li>
-  </ul>
 
-  <%# Upload warning %>
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true"><%= t('.upload_warning.icon') %></span>
-    <strong class="govuk-warning-text__text">
-      <span class="govuk-visually-hidden"><%= t('.upload_warning.assistive') %> </span>
-      <%= t('.upload_warning.message') %>
-    </strong>
-  </div>
+  <% check_list = Nsm::SupportingEvidence::CheckList.new(@form_object.application) %>
+
+  <% unless check_list.items.empty? %>
+    <p class="govuk-body"><%= t('.para1.heading') %></p>
+
+    <%= check_list.render %>
+
+    <%# Upload warning %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true"><%= t('.upload_warning.icon') %></span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden"><%= t('.upload_warning.assistive') %> </span>
+        <%= t('.upload_warning.message') %>
+      </strong>
+    </div>
+  <% end%>
 
   <%# Additional upload list %>
   <p class="govuk-body"><%= t('.para2.heading') %></p>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -97,6 +97,8 @@ en:
         defence_statement: For example the total number of pages of defence evidence including any
           statements by the defendant and defence witnesses
         prosecution_evidence: Where applicable, give the approximate number of pages
+        supplemental_claim_options:
+          'yes': We’ll ask you to upload evidence of this before you submit this claim
         time_spent: For example, 1 hour and 30 minutes
         work_before_date: For example, 27 3 2023
         work_after_date: For example, 27 3 2023

--- a/config/locales/en/nsm/steps.yml
+++ b/config/locales/en/nsm/steps.yml
@@ -216,7 +216,6 @@ en:
           para1:
             heading: "Based on your answers, you must upload:"
             crm8: CRM8 form
-            crm8_link: "https://www.gov.uk/government/publications/crm8-assigned-counsels-fee-note"
             remittal: evidence of remittal
             supplemental: evidence of supplemental claim
             authority: prior authority certification

--- a/spec/presenters/nsm/supporting_evidence/check_list_spec.rb
+++ b/spec/presenters/nsm/supporting_evidence/check_list_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe Nsm::SupportingEvidence::CheckList do
+  subject(:presenter) { described_class.new(claim) }
+
+  let(:claim) { create(:claim, :complete, :one_other_disbursement) }
+
+  it { is_expected.to respond_to(:items) }
+
+  describe '#render' do
+    subject(:content) { presenter.render }
+
+    context 'with assigned counsel' do
+      before { claim.assigned_counsel = 'yes' }
+
+      it 'includes CRM8 form' do
+        expect(content)
+          .to include(
+            '<li>' \
+            '<a class="govuk-link govuk-link--no-visited-state" ' \
+            'target="_blank" ' \
+            'href="https://www.gov.uk/government/publications/crm8-assigned-counsels-fee-note">' \
+            'CRM8 form</a>' \
+            '</li>'
+          )
+      end
+    end
+
+    context 'without assigned counsel' do
+      before { claim.assigned_counsel = 'no' }
+
+      it { is_expected.not_to include('CRM8') }
+    end
+
+    context 'with remittal' do
+      before { claim.remitted_to_magistrate = 'yes' }
+
+      it { is_expected.to include('<li>evidence of remittal</li>') }
+    end
+
+    context 'without remittal' do
+      before { claim.remitted_to_magistrate = 'no' }
+
+      it { is_expected.not_to include('remittal') }
+    end
+
+    context 'with supplemental claim' do
+      before { claim.supplemental_claim = 'yes' }
+
+      it { is_expected.to include('<li>evidence of supplemental claim</li>') }
+    end
+
+    context 'without supplemental claim' do
+      before { claim.supplemental_claim = 'no' }
+
+      it { is_expected.not_to include('supplemental claim') }
+    end
+
+    context 'with disbursement with prior authority' do
+      before { claim.disbursements.first.update!(prior_authority: 'yes') }
+
+      it { is_expected.to include('<li>prior authority certification</li>') }
+    end
+
+    context 'without disbursement with prior authority' do
+      before { claim.disbursements.map { |d| d.update!(prior_authority: 'no') } }
+
+      it { is_expected.not_to include('prior authority') }
+    end
+
+    context 'without disbursement' do
+      before { claim.disbursements.destroy_all }
+
+      it { is_expected.not_to include('prior authority') }
+    end
+  end
+end

--- a/spec/system/nsm/supporting_evidence_spec.rb
+++ b/spec/system/nsm/supporting_evidence_spec.rb
@@ -59,4 +59,39 @@ RSpec.describe 'User can provide supporting evidence', type: :system do
       end
     end
   end
+
+  context 'when all supporting evidence required options chosen' do
+    before do
+      claim.update!(assigned_counsel: 'yes', remitted_to_magistrate: 'yes', supplemental_claim: 'yes')
+      claim.disbursements.first.update!(prior_authority: 'yes')
+
+      visit provider_saml_omniauth_callback_path
+      visit edit_nsm_steps_supporting_evidence_path(claim.id)
+    end
+
+    it 'displays all supporting evidence requirements' do
+      expect(page)
+        .to have_content('Based on your answers, you must upload:')
+        .and have_content('If you do not upload this evidence, it might take longer to assess your claim.')
+        .and have_content('CRM8 form')
+        .and have_content('evidence of remittal')
+        .and have_content('evidence of supplemental claim')
+        .and have_content('prior authority certification')
+    end
+  end
+
+  context 'when no supporting evidence required options chosen' do
+    before do
+      claim.update!(assigned_counsel: 'no', remitted_to_magistrate: 'no', supplemental_claim: 'no')
+      claim.disbursements.map { |d| d.update!(prior_authority: 'no') }
+
+      visit provider_saml_omniauth_callback_path
+      visit edit_nsm_steps_supporting_evidence_path(claim.id)
+    end
+
+    it 'does not display the supporting evidence requirements' do
+      expect(page).to have_no_content 'Based on your answers'
+      expect(page).to have_no_content 'If you do not upload this evidence'
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Add conditional supporting evidence upload help text

[Relates to bug ticket](https://dsdmoj.atlassian.net/browse/CRM457-1232)
[Link to feature ticket](https://dsdmoj.atlassian.net/browse/CRM457-1429)

To apply conditional logic to the individual checklist items
and the upload instructions it has been separated it out to a
presenter like object.

