### PR TITLE
Mark test user's office as inactive/dead

### DIFF
--- a/config/inactive_offices.yml
+++ b/config/inactive_offices.yml
@@ -17,7 +17,9 @@ localhost:
     - 4C567D
 
 development:
-  inactive_office_codes: []
+  inactive_office_codes:
+    # Test user office from portal A.CLARK - with eForms role - (see 1Password for login details)
+    - 0X416R
 
 uat:
   inactive_office_codes: []


### PR DESCRIPTION
## Description of change
Mark test user's office as inactive/dead

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1414)
