### PR TITLE
CRM457-1424: Add sorting to your claims page

### DIFF
--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -59,12 +59,14 @@
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.ufn') %></th>
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.defendant') %></th>
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.account') %></th>
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.last_updated') %></th>
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.laa_reference') %></th>
-          <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('.header.status') %></th>
+          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>
+            <%= table_header(key,
+                            'nsm.claims.index.header',
+                            index,
+                            nsm_applications_path,
+                            @sort_by,
+                            @sort_direction) %>
+          <% end %>
         </tr>
       </thead>
 

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -7,7 +7,7 @@ en:
         start_claim: Start a new claim
         table_info_item: claims
         header:
-          ufn: Your UFN
+          ufn: UFN
           defendant: Defendant
           account: Account
           last_updated: Last updated

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -84,6 +84,10 @@ FactoryBot.define do
       defendants { [build(:defendant, :partial)] }
     end
 
+    trait :with_named_defendant do
+      defendants { [build(:defendant, :valid_nsm, first_name: 'Jim', last_name: 'Bob')] }
+    end
+
     trait :case_details do
       main_offence { MainOffence.all.sample.name }
       main_offence_date { Date.yesterday }

--- a/spec/factories/defendants.rb
+++ b/spec/factories/defendants.rb
@@ -16,6 +16,10 @@ FactoryBot.define do
       main { false }
     end
 
+    trait :valid_nsm do
+      valid
+    end
+
     trait :valid_paa do
       first_name { Faker::Name.first_name }
       last_name { Faker::Name.last_name }

--- a/spec/system/nsm/claims_list_spec.rb
+++ b/spec/system/nsm/claims_list_spec.rb
@@ -1,0 +1,133 @@
+require 'system_helper'
+
+RSpec.describe 'NSM claims lists' do
+  before do
+    visit provider_saml_omniauth_callback_path
+
+    # Add office code to test provider to test account number sorting
+    Provider.find_by(uid: 'test-user').tap do |provider|
+      provider.update!(office_codes: %w[1A123B 9A123B])
+    end
+
+    create(:claim,
+           :complete,
+           laa_reference: 'LAA-AAAAA',
+           ufn: '120423/001',
+           status: 'submitted',
+           updated_at: 1.day.ago,
+           defendants: [build(:defendant, :valid_nsm, first_name: 'Burt', last_name: 'Bacharach')])
+
+    create(:claim, :with_named_defendant, ufn: '120423/002', laa_reference: 'LAA-BBBBB',
+           status: 'submitted', updated_at: 2.days.ago)
+
+    create(:claim, :with_named_defendant, ufn: '120423/003', laa_reference: 'LAA-CCCC1',
+           status: 'granted', updated_at: 3.days.ago)
+
+    create(:claim, :with_named_defendant, ufn: '120423/004', laa_reference: 'LAA-CCCC2',
+           status: 'further_info', updated_at: 3.days.ago)
+
+    create(:claim, :with_named_defendant, ufn: '120423/005', laa_reference: 'LAA-CCCC3',
+           status: 'part_grant', updated_at: 3.days.ago)
+
+    create(:claim, :with_named_defendant, ufn: '120423/006', laa_reference: 'LAA-CCCC4',
+           status: 'rejected', updated_at: 3.days.ago)
+
+    create(:claim,
+           :with_named_defendant,
+           ufn: '120423/007',
+           laa_reference: 'LAA-CCCC5',
+           office_code: '9A123B',
+           status: 'provider_requested',
+           updated_at: 3.days.ago)
+
+    create(:claim,
+           ufn: '120423/008',
+           laa_reference: 'LAA-DDDDD',
+           defendants: [build(:defendant, :valid_nsm, first_name: 'Zoe', last_name: 'Zeigler')],
+           status: 'draft',
+           updated_at: 4.days.ago)
+
+    create(:claim,
+           ufn: '111111/111',
+           laa_reference: 'LAA-EEEEE',
+           status: 'draft',
+           office_code: 'OTHER',
+           submitter: create(:provider, :other))
+
+    visit nsm_applications_path
+  end
+
+  it 'shows most recently updated at the top by default' do
+    within top_row_selector do
+      expect(page).to have_content(1.day.ago.to_fs(:stamp))
+    end
+  end
+
+  it 'does not show applications from other offices' do
+    expect(page).to have_no_content 'EEEEE'
+  end
+
+  it 'allows sorting by UFN' do
+    click_on 'UFN'
+    within top_row_selector do
+      expect(page).to have_content('120423/001')
+    end
+
+    click_on 'UFN'
+    within top_row_selector do
+      expect(page).to have_content('120423/008')
+    end
+  end
+
+  it 'allows sorting by Defendant' do
+    click_on 'Defendant'
+    within top_row_selector do
+      expect(page).to have_content('Burt Bacharach')
+    end
+
+    click_on 'Defendant'
+    within top_row_selector do
+      expect(page).to have_content('Zoe Zeigler')
+    end
+  end
+
+  it 'allows sorting by Account (i.e. Office code)' do
+    click_on 'Account'
+    within top_row_selector do
+      expect(page).to have_content('1A123B')
+    end
+
+    click_on 'Account'
+    within top_row_selector do
+      expect(page).to have_content('9A123B')
+    end
+  end
+
+  it 'allows sorting by LAA reference' do
+    click_on 'LAA reference'
+    within top_row_selector do
+      expect(page).to have_content('AAAAA')
+    end
+
+    click_on 'LAA reference'
+    within top_row_selector do
+      expect(page).to have_content('DDDDD')
+    end
+  end
+
+  it 'allows sorting by Status' do
+    click_on 'Status'
+    within top_row_selector do
+      expect(page).to have_content('Draft')
+    end
+
+    click_on 'Status'
+    within top_row_selector do
+      expect(page).to have_content('Submitted')
+    end
+  end
+
+  def top_row_selector
+    '.govuk-table tbody tr:nth-child(1)'
+  end
+end


### PR DESCRIPTION
## Description of change
Add sorting to your claims page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1424)

This follows the basic pattern from prior
authority.

![Screenshot 2024-05-17 at 11 50 06](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/2a153744-5bf2-44ba-b15a-2216a2e5e573)

