### PR TITLE
CRM457-1464: Add wasted costs to NSM

### DIFF
--- a/app/forms/nsm/steps/claim_details_form.rb
+++ b/app/forms/nsm/steps/claim_details_form.rb
@@ -1,7 +1,7 @@
 module Nsm
   module Steps
     class ClaimDetailsForm < ::Steps::BaseFormObject
-      BOOLEAN_FIELDS = %i[supplemental_claim preparation_time work_before work_after].freeze
+      BOOLEAN_FIELDS = %i[supplemental_claim preparation_time work_before work_after wasted_costs].freeze
 
       attribute :prosecution_evidence, :integer
       attribute :defence_statement, :integer

--- a/app/presenters/nsm/check_answers/claim_details_card.rb
+++ b/app/presenters/nsm/check_answers/claim_details_card.rb
@@ -43,7 +43,13 @@ module Nsm
           process_boolean_value(boolean_field: claim.work_after, value_field: claim.work_after_date,
                                 boolean_key: 'work_after', value_key: 'work_after_date') do
             claim.work_after_date.to_fs(:stamp)
-          end
+          end,
+          {
+            head_key: 'wasted_costs',
+            text: check_missing(claim.wasted_costs.present?) do
+              claim.wasted_costs.capitalize
+            end
+          },
         ].flatten
       end
       # rubocop:enable Metrics/AbcSize

--- a/app/presenters/nsm/supporting_evidence/check_list.rb
+++ b/app/presenters/nsm/supporting_evidence/check_list.rb
@@ -27,7 +27,7 @@ module Nsm
         @items << li_for_translation('remittal') if remitted_to_magistrate?
         @items << li_for_translation('supplemental') if supplemental_claim?
         @items << li_for_translation('authority') if any_prior_authority?
-        # TODO: wasted_costs; CRM457-1464 and CRM457-1384
+        @items << li_for_translation('wasted_costs') if wasted_costs?
         @items
       end
 
@@ -66,6 +66,10 @@ module Nsm
 
       def any_prior_authority?
         claim.disbursements.any? { |disbursement| disbursement.prior_authority == 'yes' }
+      end
+
+      def wasted_costs?
+        claim.wasted_costs == 'yes'
       end
     end
   end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -385,6 +385,8 @@ en:
               greater_than_or_equal_to: Number of witnesses cannot be less than 0
             supplemental_claim:
               blank: Select yes or no for supplemental claim
+            wasted_costs:
+              blank: Select yes or no for wasted costs
             preparation_time:
               blank: Select yes or no for preparation time
             work_before:

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -42,6 +42,7 @@ en:
         work_after_date: Date of last court hearing
         work_before: Did you do any work before the representation order date?
         work_after: Did you do any further work after the last court hearing?
+        wasted_costs: Have wasted costs been applied to this case?
       nsm_steps_other_info_form:
         concluded: Did the proceedings conclude over 3 months ago?
         is_other_info: Do you want to add any other information?
@@ -102,6 +103,11 @@ en:
         time_spent: For example, 1 hour and 30 minutes
         work_before_date: For example, 27 3 2023
         work_after_date: For example, 27 3 2023
+        wasted_costs: |
+          Wasted costs are applied when a judge has determined that the lawyer (solicitor or barrister)
+          or a third party has wasted the court‘s time.
+        wasted_costs_options:
+          'yes': We’ll ask you to upload the court order before you submit the claim
       nsm_steps_work_item_form:
         completed_on: For example, 27 3 2007
         fee_earner: For example, JMD
@@ -245,6 +251,9 @@ en:
           'yes': 'Yes'
           'no': 'No'
         work_after_options:
+          'yes': 'Yes'
+          'no': 'No'
+        wasted_costs_options:
           'yes': 'Yes'
           'no': 'No'
       nsm_steps_work_item_form:

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -73,6 +73,7 @@ en:
               work_before_date: Date of work before order was granted
               work_after: Work after last hearing
               work_after_date: Date of work after order was granted
+              wasted_costs: Wasted costs
             letters_calls:
               items: Items
               items_total: <strong>Total per item</strong>

--- a/config/locales/en/nsm/steps.yml
+++ b/config/locales/en/nsm/steps.yml
@@ -219,6 +219,7 @@ en:
             remittal: evidence of remittal
             supplemental: evidence of supplemental claim
             authority: prior authority certification
+            wasted_costs: wasted costs court order
           para2:
             heading: "You might also want to upload:"
             file: file notes

--- a/db/migrate/20240517122619_add_wasted_costs_to_claims.rb
+++ b/db/migrate/20240517122619_add_wasted_costs_to_claims.rb
@@ -1,0 +1,5 @@
+class AddWastedCostsToClaims < ActiveRecord::Migration[7.1]
+  def change
+    add_column :claims, :wasted_costs, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_135039) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_17_122619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -131,6 +131,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_135039) do
     t.integer "allowed_calls_uplift"
     t.string "letters_adjustment_comment"
     t.string "calls_adjustment_comment"
+    t.string "wasted_costs"
     t.index ["firm_office_id"], name: "index_claims_on_firm_office_id"
     t.index ["solicitor_id"], name: "index_claims_on_solicitor_id"
     t.index ["ufn"], name: "index_claims_on_ufn"

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -142,6 +142,7 @@ FactoryBot.define do
       work_before_date { Date.new(2020, 12, 1) }
       work_after { 'yes' }
       work_after_date { Date.new(2020, 1, 1) }
+      wasted_costs { 'yes' }
     end
 
     trait :claim_details_no do
@@ -152,6 +153,7 @@ FactoryBot.define do
       work_before_date { nil }
       work_after { 'no' }
       work_after_date { nil }
+      wasted_costs { 'no' }
     end
 
     trait :letters_calls do

--- a/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_details_card_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
   end
 
   describe '#row_data' do
-    context 'all boolean field with yes values and additional fields' do
+    context 'when all boolean field have "Yes" values plus additional fields' do
       it 'generates case detail rows' do
         expect(subject.row_data).to eq(
           [
@@ -55,13 +55,17 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             {
               head_key: 'work_after_date',
               text: '1 January 2020'
-            }
+            },
+            {
+              head_key: 'wasted_costs',
+              text: 'Yes'
+            },
           ]
         )
       end
     end
 
-    context 'all boolean field with no values' do
+    context 'when all boolean field have "No" values' do
       let(:claim) { build(:claim, :claim_details, :claim_details_no) }
 
       it 'generates case detail rows' do
@@ -94,7 +98,11 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             {
               head_key: 'work_after',
               text: 'No'
-            }
+            },
+            {
+              head_key: 'wasted_costs',
+              text: 'No'
+            },
           ]
         )
       end
@@ -133,13 +141,17 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             {
               head_key: 'work_after',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
+            },
+            {
+              head_key: 'wasted_costs',
+              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             }
           ]
         )
       end
     end
 
-    context 'all boolean field with yes values, but missing addition data' do
+    context 'all boolean field with yes values, but missing additional data' do
       let(:claim) { build(:claim, :claim_details, time_spent: nil, work_before_date: nil, work_after_date: nil) }
 
       it 'generates case detail rows' do
@@ -184,6 +196,10 @@ RSpec.describe Nsm::CheckAnswers::ClaimDetailsCard do
             {
               head_key: 'work_after_date',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
+            },
+            {
+              head_key: 'wasted_costs',
+              text: 'Yes'
             }
           ]
         )

--- a/spec/presenters/nsm/supporting_evidence/check_list_spec.rb
+++ b/spec/presenters/nsm/supporting_evidence/check_list_spec.rb
@@ -73,5 +73,17 @@ RSpec.describe Nsm::SupportingEvidence::CheckList do
 
       it { is_expected.not_to include('prior authority') }
     end
+
+    context 'with wasted costs' do
+      before { claim.wasted_costs = 'yes' }
+
+      it { is_expected.to include('<li>wasted costs court order</li>') }
+    end
+
+    context 'without wasted costs' do
+      before { claim.wasted_costs = 'no' }
+
+      it { is_expected.not_to include('wasted costs') }
+    end
   end
 end

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
           'submitted_total_inc_vat' => nil,
           'submitter' => { 'description' => nil, 'email' => 'provider@example.com' },
           'supplemental_claim' => 'yes',
+          'wasted_costs' => 'yes',
           'time_spent' => 121,
           'ufn' => '120423/001',
           'unassigned_counsel' => 'no',

--- a/spec/system/nsm/claim_details_spec.rb
+++ b/spec/system/nsm/claim_details_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'User can fill in claim details', type: :system do
       fill_in 'Year', with: '2023'
     end
     find('.govuk-form-group', text: 'Did you do any further work after the last court hearing?').choose 'No'
+    find('.govuk-form-group', text: 'Have wasted costs been applied to this case?').choose 'Yes'
 
     click_on 'Save and continue'
     expect(claim.reload).to have_attributes(

--- a/spec/system/nsm/supporting_evidence_spec.rb
+++ b/spec/system/nsm/supporting_evidence_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'User can provide supporting evidence', type: :system do
 
   context 'when no supporting evidence required options chosen' do
     before do
-      claim.update!(assigned_counsel: 'no', remitted_to_magistrate: 'no', supplemental_claim: 'no')
+      claim.update!(assigned_counsel: 'no', remitted_to_magistrate: 'no', supplemental_claim: 'no', wasted_costs: 'no')
       claim.disbursements.map { |d| d.update!(prior_authority: 'no') }
 
       visit provider_saml_omniauth_callback_path


### PR DESCRIPTION
## Description of change
Add wasted costs to NSM claims

[Link to claim details form wasted costs ticket](https://dsdmoj.atlassian.net/browse/CRM457-1464)
[Link to supporting evidence wasted costs ticket](https://dsdmoj.atlassian.net/browse/CRM457-1501)

- [X] Add wasted costs column to claims table
- [X] Add wasted costs field to form
- [X] Add wasted costs to supporting evidence checklist
- [X] Ensure payload builder sends wasted costs
- [x] Add wasted costs to check details card

## E2E fix branch
https://github.com/ministryofjustice/nsm-e2e-test/pull/83


## Claim details form updated
![Screenshot 2024-05-17 at 14 56 48](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/717057ed-c174-4d44-b213-0b53dc317efa)

## Supporting evidence checklist updated
![Screenshot 2024-05-17 at 15 01 39](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/a00b8500-fb68-4717-9d58-0aad32a1ea3e)

### Check answers updated
![Screenshot 2024-05-17 at 14 56 13](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/389ced9f-a5ea-4294-b5de-b95b206ae74e)
