### PR TITLE
Differentiate between app and worker deployments in selector labels

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "laa-submit-crime-forms.selectorLabels" . | nindent 6 }}
+      app: {{ include "laa-submit-crime-forms.fullname" . }}-worker
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -19,6 +20,7 @@ spec:
       {{- end }}
       labels:
         {{- include "laa-submit-crime-forms.selectorLabels" . | nindent 8 }}
+        app: {{ include "laa-submit-crime-forms.fullname" . }}-worker
     spec:
       serviceAccountName: {{ .Values.service_account.name }}
       {{- with .Values.imagePullSecrets }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "laa-submit-crime-forms.selectorLabels" . | nindent 6 }}
+      app: {{ include "laa-submit-crime-forms.fullname" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -19,6 +20,7 @@ spec:
       {{- end }}
       labels:
         {{- include "laa-submit-crime-forms.selectorLabels" . | nindent 8 }}
+        app: {{ include "laa-submit-crime-forms.fullname" . }}
     spec:
       serviceAccountName: {{ .Values.service_account.name }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
## Description of change

 [Unexpected Scaling of Pods](https://dsdmoj.atlassian.net/browse/CRM457-1508)

Trying to add an extra selector label: app - which will be used to differentiate worker deployment pods from app deployment pods - in an attempt to fix the issue with our autoscaler scaling our pods up when we seemingly haven't breached limitations

