### PR TITLE
CRM457-1067: Reduce rounding error issues

### DIFF
--- a/app/forms/nsm/steps/disbursement_cost_form.rb
+++ b/app/forms/nsm/steps/disbursement_cost_form.rb
@@ -42,21 +42,21 @@ if: :other_disbursement_type?
 
       # we return 1 here when no pricing data exists to simplify the FE
       def multiplier
-        pricing[record.disbursement_type] || 1.0
+        pricing[record.disbursement_type] || BigDecimal('1')
       end
 
       def total_cost_pre_vat
         @total_cost_pre_vat ||= if other_disbursement_type?
                                   total_cost_without_vat
                                 elsif miles
-                                  miles.to_f * multiplier
+                                  miles.to_d * multiplier
                                 end
       end
 
       def vat
         return nil unless total_cost_pre_vat
 
-        apply_vat ? (total_cost_pre_vat * vat_rate).round(2) : 0.0
+        apply_vat ? (total_cost_pre_vat * vat_rate).round(2) : BigDecimal('0')
       end
 
       def total_cost

--- a/app/forms/nsm/steps/letters_calls_form.rb
+++ b/app/forms/nsm/steps/letters_calls_form.rb
@@ -41,7 +41,7 @@ module Nsm
 
       def letters_after_uplift
         if apply_letters_uplift && letters_before_uplift
-          letters_before_uplift * (1 + (letters_uplift.to_f / 100))
+          letters_before_uplift * (1 + (letters_uplift.to_d / 100))
         elsif letters_before_uplift&.positive?
           letters_before_uplift
         end
@@ -49,7 +49,7 @@ module Nsm
 
       def calls_after_uplift
         if apply_calls_uplift && calls_before_uplift
-          calls_before_uplift * (1 + (calls_uplift.to_f / 100))
+          calls_before_uplift * (1 + (calls_uplift.to_d / 100))
         elsif calls_before_uplift&.positive?
           calls_before_uplift
         end
@@ -58,7 +58,7 @@ module Nsm
       def total_cost
         return unless letters_after_uplift&.positive? || calls_after_uplift&.positive?
 
-        letters_after_uplift.to_f + calls_after_uplift.to_f
+        letters_after_uplift.to_d + calls_after_uplift.to_d
       end
 
       def total_cost_inc_vat
@@ -130,11 +130,11 @@ module Nsm
       end
 
       def letters_before_uplift
-        letters.to_f * pricing.letters if letters && !letters.zero?
+        letters.to_d * pricing.letters if letters && !letters.zero?
       end
 
       def calls_before_uplift
-        calls.to_f * pricing.letters if calls && !calls.zero?
+        calls.to_d * pricing.letters if calls && !calls.zero?
       end
     end
   end

--- a/app/lib/pricing.rb
+++ b/app/lib/pricing.rb
@@ -37,7 +37,7 @@ class Pricing
 
   def initialize(data = {})
     FIELDS.each do |field|
-      instance_variable_set(:"@#{field}", data.fetch(field, nil)&.to_f)
+      instance_variable_set(:"@#{field}", data.fetch(field, nil)&.to_d)
     end
     @name = data.fetch('name', nil)
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -62,9 +62,9 @@ class Claim < ApplicationRecord
     pricing = Pricing.for(self)
     [
       { 'type' => translations('letters', 'helpers.label.nsm_steps_letters_calls_form.type_options'),
-        'count' => letters, 'pricing' => pricing.letters, 'uplift' => letters_uplift },
+        'count' => letters, 'pricing' => pricing.letters.to_f, 'uplift' => letters_uplift },
       { 'type' => translations('calls', 'helpers.label.nsm_steps_letters_calls_form.type_options'),
-        'count' => calls, 'pricing' => pricing.calls, 'uplift' => calls_uplift },
+        'count' => calls, 'pricing' => pricing.calls.to_f, 'uplift' => calls_uplift },
     ]
   end
 

--- a/app/services/submit_to_app_store/nsm_payload_builder.rb
+++ b/app/services/submit_to_app_store/nsm_payload_builder.rb
@@ -35,7 +35,7 @@ class SubmitToAppStore
         'submitter' => claim.submitter.attributes.slice('email', 'description'),
         'supporting_evidences' => supporting_evidence,
         'cost_totals' => costs_data,
-        'vat_rate' => pricing[:vat],
+        'vat_rate' => pricing[:vat].to_f,
       )
     end
 
@@ -51,18 +51,20 @@ class SubmitToAppStore
       )
     end
 
+    # rubocop:disable Metrics/AbcSize
     def disbursement_data
       claim.disbursements.map do |disbursement|
         data = disbursement.as_json(except: [*DEFAULT_IGNORE, 'allowed_total_cost_without_vat', 'allowed_vat_amount',
                                              'adjustment_comment'])
         data['disbursement_date'] = data['disbursement_date'].to_s
-        data['pricing'] = pricing[disbursement.disbursement_type] || 1.0
-        data['vat_rate'] = pricing[:vat]
+        data['pricing'] = pricing[disbursement.disbursement_type].to_f || 1.0
+        data['vat_rate'] = pricing[:vat].to_f
         data['vat_amount'] = data['vat_amount'].to_f
         data['total_cost_without_vat'] = data['total_cost_without_vat'].to_f
         data
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def work_item_data
       claim.work_items.map do |work_item|

--- a/app/services/submit_to_app_store/nsm_payload_builder.rb
+++ b/app/services/submit_to_app_store/nsm_payload_builder.rb
@@ -68,7 +68,7 @@ class SubmitToAppStore
       claim.work_items.map do |work_item|
         data = work_item.as_json(except: [*DEFAULT_IGNORE, 'allowed_uplift', 'allowed_time_spent', 'adjustment_comment'])
         data['completed_on'] = data['completed_on'].to_s
-        data['pricing'] = pricing[work_item.work_type]
+        data['pricing'] = pricing[work_item.work_type].to_f
         data
       end
     end

--- a/spec/presenters/nsm/cost_summary/summary_spec.rb
+++ b/spec/presenters/nsm/cost_summary/summary_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Nsm::CostSummary::Summary do
+  subject { described_class.new(claim) }
+
+  let(:claim) { create(:claim, work_items:) }
+
+  describe '#profit_costs_net' do
+    context 'when figures could be vulnerable to a floating point rounding error' do
+      let(:work_items) { [build(:work_item, time_spent: 138, work_type: 'advocacy')] }
+
+      before do
+        allow(Pricing).to receive(:for).with(claim).and_return(Pricing.new('advocacy' => 24.35))
+      end
+
+      it 'generates a number that rounds correctly' do
+        # 2.3 * 24.35 = £56.005 which rounds up, but using floats can result in £56.0049 which rounds down
+        expect(NumberTo.pounds(subject.profit_costs_net)).to eq '£56.01'
+      end
+    end
+
+    context 'when figures could be vulnerable to a decimal precision error' do
+      let(:work_items) { Array.new(30) { build(:work_item, time_spent: 175, work_type: 'advocacy') } }
+
+      before do
+        allow(Pricing).to receive(:for).with(claim).and_return(Pricing.new('advocacy' => 45.35))
+      end
+
+      it 'generates a number that rounds correctly' do
+        # 30 * 175 * 45.35 / 60 = £3968.125 which rounds up,
+        # but using decimals can result in £3968.124999... which rounds down
+        expect(NumberTo.pounds(subject.profit_costs_net)).to eq '£3,968.13'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Stop using floats to represent money in as many places as possible
When we need to hold onto a value that could be an infinite-digit fraction of a penny (e.g. 0.33333333333), represent it as a Rational rather than a BigDecimal to avoid imprecision errors

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1067)