### PR TITLE
double the memory limits on clamav

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 3Gi
+              memory: 6Gi
             requests:
               cpu: 10m
               memory: 1Gi


### PR DESCRIPTION
## Description of change

 [Unexpected Scaling Up of Pods](https://dsdmoj.atlassian.net/browse/CRM457-1508)

Tests:

- Double memory on clamav to 6GB