### PR TITLE
Disable mock portal auth in UAT

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -2,7 +2,7 @@ feature_flags:
   omniauth_test_mode:
     local: <%= ENV.fetch("OMNIAUTH_TEST_MODE", false) %>
     development: true
-    uat: true
+    uat: false
     production: false # must never be enabled in the live service
   postal_evidence:
     local: <%= ENV.fetch("POSTAL_EVIDENCE", false) %>


### PR DESCRIPTION
## Description of change
Disable mock portal auth on UAT

For parity with production and to enable debugging
of any portal login issues on a pre-prod environment.
