### PR TITLE
CMR457-1550: Fix account number select page "Save and come back later"

### DIFF
--- a/app/controllers/prior_authority/steps/office_code_controller.rb
+++ b/app/controllers/prior_authority/steps/office_code_controller.rb
@@ -8,13 +8,17 @@ module PriorAuthority
       end
 
       def update
-        update_and_advance(OfficeCodeForm, as: :pa_office_code)
+        update_and_advance(OfficeCodeForm, as:, after_commit_redirect_path:)
       end
 
       private
 
       def decision_tree_class
         Decisions::DecisionTree
+      end
+
+      def as
+        :pa_office_code
       end
     end
   end

--- a/spec/system/prior_authority/case_contact_spec.rb
+++ b/spec/system/prior_authority/case_contact_spec.rb
@@ -85,10 +85,17 @@ RSpec.describe 'Prior authority applications - add case contact' do
       end
 
       it 'saves the selection' do
-        choose '1A123B'
+        choose '1K022G'
         click_on 'Save and continue'
         expect(page).to have_content 'Case contact Completed'
-        expect(PriorAuthorityApplication.first.office_code).to eq '1A123B'
+        expect(PriorAuthorityApplication.first.office_code).to eq '1K022G'
+      end
+
+      it 'allows save and come back later' do
+        expect(page).to have_content 'Which firm account number is this application for?'
+        click_on 'Save and come back later'
+
+        expect(page).to have_title 'Your applications'
       end
     end
   end


### PR DESCRIPTION
## Description of change
Fix account number select page "Save and come back later"

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1550)

PA controllers need to specify an after_commit_redirect_path
to overide redirect in shared base controller.
