### PR TITLE
CRM457-1535: Allow text/rtf mime types for upload

### DIFF
--- a/app/models/supported_file_types.rb
+++ b/app/models/supported_file_types.rb
@@ -1,6 +1,6 @@
 class SupportedFileTypes
   SUPPORTED_FILE_TYPES = %w[
     application/msword application/vnd.openxmlformats-officedocument.wordprocessingml.document
-    application/rtf image/jpeg image/bmp image/png image/tiff application/pdf
+    application/rtf text/rtf image/jpeg image/bmp image/png image/tiff application/pdf
   ].freeze
 end


### PR DESCRIPTION
## Description of change
Allow text/rtf mime types for upload

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1535)

`application/rtf` and `text/rtf` are both valid mime types
for RTF so allow both so RTF files can be uploaded as
supporting evidence.

## Notes for reviewer
There is a sample RTF file on the ticket which can be used to test on primary quote page for CRM4

