### PR TITLE
Increase Clamav limits

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -64,7 +64,7 @@ app_resources:
 
 clamav_resources:
   limits:
-    cpu: 500m
+    cpu: 2000m
     memory: 4Gi
   requests:
     cpu: 10m


### PR DESCRIPTION

## Description of change
Increase CLAMAV container resource limits

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)

To prevent HPA from spinning up more pods
to handle usage.
