### PR TITLE
Crm457 1541/missing travel reason

### DIFF
--- a/app/forms/prior_authority/steps/case_detail_form.rb
+++ b/app/forms/prior_authority/steps/case_detail_form.rb
@@ -84,11 +84,11 @@ module PriorAuthority
       end
 
       def offence_list
-        I18n.t('prior_authority.offences').transform_keys(&:to_s).to_a
+        I18n.t('prior_authority.offences').transform_keys(&:to_s).to_a.sort
       end
 
       def prison_list
-        I18n.t('prior_authority.prisons').transform_keys(&:to_s).to_a
+        I18n.t('prior_authority.prisons').transform_keys(&:to_s).to_a.sort
       end
 
       private

--- a/app/forms/prior_authority/steps/travel_detail_form.rb
+++ b/app/forms/prior_authority/steps/travel_detail_form.rb
@@ -28,6 +28,10 @@ module PriorAuthority
         record.travel_cost_allowed
       end
 
+      def empty?
+        !valid? && travel_cost_reason.blank? && travel_time.blank? && travel_cost_per_hour.blank?
+      end
+
       private
 
       def persist!

--- a/app/presenters/prior_authority/tasks/primary_quote.rb
+++ b/app/presenters/prior_authority/tasks/primary_quote.rb
@@ -41,7 +41,7 @@ module PriorAuthority
       end
 
       def travel_costs_complete?
-        # return true here as no record is the same as no data wchih is true
+        # return true here as no record is the same as no data which is true
         return true unless record
 
         form = ::PriorAuthority::Steps::TravelDetailForm.build(record, application:)

--- a/app/presenters/prior_authority/tasks/primary_quote.rb
+++ b/app/presenters/prior_authority/tasks/primary_quote.rb
@@ -11,7 +11,9 @@ module PriorAuthority
       FORM = ::PriorAuthority::Steps::PrimaryQuoteForm
 
       def path
-        if first_steps_completed?
+        if !travel_costs_complete?
+          edit_prior_authority_steps_travel_detail_path(application)
+        elsif first_steps_completed?
           prior_authority_steps_primary_quote_summary_path(application)
         else
           edit_prior_authority_steps_primary_quote_path(application)
@@ -28,6 +30,7 @@ module PriorAuthority
 
       def completed?
         first_steps_completed? &&
+          travel_costs_complete? &&
           all_additional_costs_completed?
       end
 
@@ -35,6 +38,14 @@ module PriorAuthority
         record &&
           FORM.build(record, application:).valid? &&
           PriorAuthority::Steps::ServiceCostForm.build(record, application:).valid?
+      end
+
+      def travel_costs_complete?
+        # return true here as no record is the same as no data wchih is true
+        return true unless record
+
+        form = ::PriorAuthority::Steps::TravelDetailForm.build(record, application:)
+        form.valid? || form.empty?
       end
 
       def all_additional_costs_completed?

--- a/spec/factories/quote.rb
+++ b/spec/factories/quote.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     postcode { 'CR0 1RE' }
     cost_per_hour { 10 }
     period { 180 }
+    travel_cost_reason { 'Reasons' }
     travel_cost_per_hour { 50.0 }
     travel_time { 150 }
     user_chosen_cost_type { 'per_hour' }

--- a/spec/presenters/prior_authority/tasks/primary_quote_spec.rb
+++ b/spec/presenters/prior_authority/tasks/primary_quote_spec.rb
@@ -3,11 +3,32 @@ require 'rails_helper'
 RSpec.describe PriorAuthority::Tasks::PrimaryQuote, type: :presenter do
   subject(:presenter) { described_class.new(application:) }
 
-  let(:application) { create(:prior_authority_application) }
+  let(:application) { create(:prior_authority_application, primary_quote:, service_type:, prior_authority_granted:) }
+  let(:primary_quote) { nil }
+  let(:service_type) { 'meteorologist' }
+  let(:prior_authority_granted) { true }
 
   describe '#path' do
     subject(:path) { presenter.path }
 
     it { is_expected.to eq("/prior-authority/applications/#{application.id}/steps/primary_quote") }
+
+    context 'when quote is complete (with travel expenses)' do
+      let(:primary_quote) { build(:quote) }
+
+      it { is_expected.to eq("/prior-authority/applications/#{application.id}/steps/primary_quote_summary") }
+    end
+
+    context 'when quote is complete (without travel expenses)' do
+      let(:primary_quote) { build(:quote, travel_cost_reason: nil, travel_cost_per_hour: nil, travel_time: nil) }
+
+      it { is_expected.to eq("/prior-authority/applications/#{application.id}/steps/primary_quote_summary") }
+    end
+
+    context 'when travel expense reason is missing (and non-prison law and not detained)' do
+      let(:primary_quote) { build(:quote, travel_cost_reason: nil) }
+
+      it { is_expected.to eq("/prior-authority/applications/#{application.id}/steps/travel_detail") }
+    end
   end
 end

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
               file_type: 'image/png'
             },
             travel_cost_per_hour: '50.0',
-            travel_cost_reason: nil,
+            travel_cost_reason: 'Reasons',
             travel_time: 150,
             additional_cost_list: nil,
             additional_cost_total: nil,
@@ -121,7 +121,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             id: application.alternative_quotes.first.id,
             document: nil,
             travel_cost_per_hour: '50.0',
-            travel_cost_reason: nil,
+            travel_cost_reason: 'Reasons',
             travel_time: 150,
             additional_cost_list: nil,
             additional_cost_total: nil,


### PR DESCRIPTION
## Description of change
Fix flow when changing from detained to not detained requiring a travel_cost_reason

* Primary quote marked as in process in task list
* click primary quote link will direct user to travel cost screen when it is invalid

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1541)
