### PR TITLE
CRM457-1564: Ensure paragraphs maintained for incorrect info

### DIFF
--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -11,7 +11,7 @@
       <% if @form_object.errors.of_kind?(:base, :application_not_corrected) %>
         <div class="govuk-form-group--error">
           <p class="govuk-error-message" id="prior-authority-steps-check-answers-form-base-field-error"><%= t('.incorrect_information_heading') %></p>
-          <p class="govuk-body"><%= @form_object.application.incorrect_information_explanation %></p>
+          <p class="govuk-body"><%= simple_format @form_object.application.incorrect_information_explanation %></p>
         </div>
       <% else %>
         <div class="govuk-inset-text">


### PR DESCRIPTION
## Description of change
Ensure paragraphs maintained for incorrect info

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1564)

so when page renders errors the incorrect info
is displayed using the same formatting when there
are no errors.

Picked up by designer.

### Before

![Screenshot 2024-06-03 at 17 05 41](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/9c4ea754-ef4e-4eb3-96db-550dd3600878)


### After

![Screenshot 2024-06-03 at 17 04 41](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/790632f6-a265-4124-b896-cd3a97b4de1f)
