### PR TITLE
Fix Alternative Quotes Incorrect Data

### DIFF
--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -86,8 +86,8 @@ module PriorAuthority
         def persist!
           return false unless save_file
 
-          attributes.merge(cost_type:)
-          record.update!(attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
+          all_attributes = attributes.merge({cost_type:})
+          record.update!(all_attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
         end
 
         def file_is_optional?

--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -11,7 +11,6 @@ module PriorAuthority
         attribute :id, :string
         attribute :contact_first_name, :string
         attribute :contact_last_name, :string
-        attribute :cost_type, :string
         attribute :organisation, :string
         attribute :postcode, :string
         attribute :travel_time, :time_period
@@ -87,11 +86,7 @@ module PriorAuthority
         def persist!
           return false unless save_file
 
-          record.update!(attributes_to_reset.except('id', 'service_type', 'file_upload').merge(reset_attributes))
-        end
-
-        def attributes_to_reset
-          attributes.merge{cost_type:}
+          record.update!(attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
         end
 
         def file_is_optional?

--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -86,6 +86,7 @@ module PriorAuthority
         def persist!
           return false unless save_file
 
+          attributes.merge(cost_type:)
           record.update!(attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
         end
 

--- a/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
+++ b/app/forms/prior_authority/steps/alternative_quotes/detail_form.rb
@@ -11,6 +11,7 @@ module PriorAuthority
         attribute :id, :string
         attribute :contact_first_name, :string
         attribute :contact_last_name, :string
+        attribute :cost_type, :string
         attribute :organisation, :string
         attribute :postcode, :string
         attribute :travel_time, :time_period
@@ -86,8 +87,11 @@ module PriorAuthority
         def persist!
           return false unless save_file
 
-          all_attributes = attributes.merge({cost_type:})
-          record.update!(all_attributes.except('id', 'service_type', 'file_upload').merge(reset_attributes))
+          record.update!(attributes_to_reset.except('id', 'service_type', 'file_upload').merge(reset_attributes))
+        end
+
+        def attributes_to_reset
+          attributes.merge{cost_type:}
         end
 
         def file_is_optional?

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -22,7 +22,7 @@ class SubmitToAppStore
 
       def primary_item_type
         form = ::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
-        form.cost_type
+        form.item_type
       end
 
       def document(quote)

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -7,14 +7,22 @@ class SubmitToAppStore
 
       def payload
         @application.quotes.map do |quote|
-          form = ::PriorAuthority::Steps::ServiceCostForm.build(quote, application: @application)
-
           quote.as_json(only: ATTRIBUTES).merge(
-            cost_type: form.cost_type,
-            item_type: form.item_type,
+            cost_type: primary_cost_type,
+            item_type: primary_item_type,
             document: document(quote)
           )
         end
+      end
+
+      def primary_cost_type
+        form = ::::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form.cost_type
+      end
+
+      def primary_item_type
+        form = ::::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form.cost_type
       end
 
       def document(quote)

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -3,6 +3,7 @@ class SubmitToAppStore
     class QuotePayloadBuilder
       def initialize(application)
         @application = application
+        @primary_quote = application.primary_quote
       end
 
       def payload
@@ -16,12 +17,12 @@ class SubmitToAppStore
       end
 
       def primary_cost_type
-        form = ::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form = ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
         form.cost_type
       end
 
       def primary_item_type
-        form = ::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form = ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
         form.item_type
       end
 

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -14,14 +14,6 @@ class SubmitToAppStore
         end
       end
 
-      def primary_quote_attributes
-        form = ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
-        {
-          cost_type: form.cost_type,
-          item_type: form.item_type
-        }
-      end
-
       def document(quote)
         return nil unless quote.document
 
@@ -30,6 +22,17 @@ class SubmitToAppStore
                                         file_size
                                         file_path
                                         document_type])
+      end
+
+      def primary_quote_attributes
+        {
+          cost_type: service_cost_form.cost_type,
+          item_type: service_cost_form.item_type
+        }
+      end
+
+      def service_cost_form
+        @service_cost_form ||= ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
       end
 
       ATTRIBUTES = %i[

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -9,21 +9,17 @@ class SubmitToAppStore
       def payload
         @application.quotes.map do |quote|
           quote.as_json(only: ATTRIBUTES).merge(
-            cost_type: primary_cost_type,
-            item_type: primary_item_type,
             document: document(quote)
-          )
+          ).merge(primary_quote_attributes)
         end
       end
 
-      def primary_cost_type
+      def primary_quote_attributes
         form = ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
-        form.cost_type
-      end
-
-      def primary_item_type
-        form = ::PriorAuthority::Steps::ServiceCostForm.build(@primary_quote, application: @application)
-        form.item_type
+        {
+          cost_type: form.cost_type,
+          item_type: form.item_type
+        }
       end
 
       def document(quote)

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -16,12 +16,12 @@ class SubmitToAppStore
       end
 
       def primary_cost_type
-        form = ::::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form = ::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
         form.cost_type
       end
 
       def primary_item_type
-        form = ::::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
+        form = ::PriorAuthority::Steps::ServiceCostForm.build(@application.primary_quote, application: @application)
         form.cost_type
       end
 

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -125,11 +125,12 @@ FactoryBot.define do
       further_informations { [build(:further_information, :with_response, :with_supporting_documents)] }
       after(:build) do |paa|
         build(:quote, :primary, prior_authority_application_id: paa.id)
-        build(:quote, :alternative, document: nil)
+        build(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
       end
+
       after(:create) do |paa|
         create(:quote, :primary, prior_authority_application_id: paa.id)
-        create(:quote, :alternative, document: nil)
+        create(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
       end
     end
 

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -127,6 +127,10 @@ FactoryBot.define do
         build(:quote, :primary, prior_authority_application_id: paa.id)
         build(:quote, :alternative, document: nil)
       end
+      after(:create) do |paa|
+        create(:quote, :primary, prior_authority_application_id: paa.id)
+        create(:quote, :alternative, document: nil)
+      end
     end
 
     trait :sent_back_for_incorrect_info do

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -118,12 +118,15 @@ FactoryBot.define do
       youth_court { 'something' }
       next_hearing { true }
       supporting_documents { build_list(:supporting_document, 2) }
-      quotes { [build(:quote, :primary), build(:quote, :alternative, document: nil)] }
       prior_authority_granted { false }
       no_alternative_quote_reason { 'a reason' }
       service_type { 'pathologist_report' }
       custom_service_name { nil }
       further_informations { [build(:further_information, :with_response, :with_supporting_documents)] }
+      after(:build) do |paa|
+        build(:quote, :primary, prior_authority_application_id: paa.id)
+        build(:quote, :alternative, document: nil)
+      end
     end
 
     trait :sent_back_for_incorrect_info do

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -132,7 +132,6 @@ FactoryBot.define do
         create(:quote, :primary, prior_authority_application_id: paa.id)
         create(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
       end
-      
       incorrect_informations { [build(:incorrect_information, :with_edits)] }
     end
 

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -123,6 +123,7 @@ FactoryBot.define do
       service_type { 'pathologist_report' }
       custom_service_name { nil }
       further_informations { [build(:further_information, :with_response, :with_supporting_documents)] }
+      incorrect_informations { [build(:incorrect_information, :with_edits)] }
       after(:build) do |paa|
         build(:quote, :primary, prior_authority_application_id: paa.id)
         build(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
@@ -132,7 +133,6 @@ FactoryBot.define do
         create(:quote, :primary, prior_authority_application_id: paa.id)
         create(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
       end
-      incorrect_informations { [build(:incorrect_information, :with_edits)] }
     end
 
     trait :sent_back_for_incorrect_info do


### PR DESCRIPTION
## Description of change

 [CRM4 Caseworker: Application cannot be opened potentially due to number of uploads](https://dsdmoj.atlassian.net/browse/CRM457-1567)


## Notes for reviewer

*Misleading bug, the real issue is that there are issues with the quotes data and the way that data is consumed by caseworker app 

This PR uses the primary quote item type and cost type for alternative quotes when constructing the payload because these are defined as such in the business process

This PR is to address[ this error ](https://ministryofjustice.sentry.io/issues/5453466200/?alert_rule_id=14899609&alert_type=issue&notification_uuid=56ce2154-7606-407b-91c5-e19f3f0e3438&project=4506020469473280&referrer=slack) which seems to be happening because the cost type isn't being set on alternative quotes