### PR TITLE
Crm457 1505: Provider login: deactivating office causes ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -28,6 +28,7 @@ module Providers
 
     def check_provider_is_enrolled
       gatekeeper = Providers::Gatekeeper.new(auth_hash.info)
+      Rails.logger.info auth_hash.info.office_codes
       return if gatekeeper.provider_enrolled?
 
       Rails.logger.warn "Not enrolled provider access attempt, UID: #{auth_hash.uid}, " \

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,7 +1,7 @@
 feature_flags:
   omniauth_test_mode:
     local: <%= ENV.fetch("OMNIAUTH_TEST_MODE", false) %>
-    development: true
+    development: false
     uat: false
     production: false # must never be enabled in the live service
   postal_evidence:


### PR DESCRIPTION
## Description of change

 [Provider login: deactivating office causes ERR_TOO_MANY_REDIRECTS](https://dsdmoj.atlassian.net/browse/CRM457-1505)

## Notes for reviewer


## How to manually test the feature
