### PR TITLE
CRM457-1590: Enable simple onboarding of ALL providers per service

### DIFF
--- a/app/services/providers/gatekeeper.rb
+++ b/app/services/providers/gatekeeper.rb
@@ -13,7 +13,15 @@ module Providers
     end
 
     def provider_enrolled?(service: ANY_SERVICE)
-      email_enrolled? || office_enrolled?(service:)
+      email_enrolled? || all_enrolled?(service:) || office_enrolled?(service:)
+    end
+
+    def all_enrolled?(service: ANY_SERVICE)
+      if service == ANY_SERVICE
+        allowed_office_codes.fetch(:ALL, []).any?
+      else
+        allowed_office_codes.fetch(:ALL, []).include?(service.to_s)
+      end
     end
 
     def office_enrolled?(service: ANY_SERVICE)

--- a/spec/services/providers/gatekeeper_spec.rb
+++ b/spec/services/providers/gatekeeper_spec.rb
@@ -1,54 +1,151 @@
 require 'rails_helper'
 
 RSpec.describe Providers::Gatekeeper do
-  subject { described_class.new(auth_info) }
+  subject(:gatekeeper) { described_class.new(auth_info) }
+
+  before do
+    allow(Rails.configuration.x.gatekeeper)
+      .to receive(:office_codes)
+      .and_return(office_codes_from_config)
+  end
 
   let(:auth_info) do
     double(
-      email:,
-      office_codes:,
+      email:'test@example.com',
+      office_codes: user_office_codes,
     )
   end
 
-  let(:email) { 'test@example.com' }
-  let(:office_codes) { %w[1A123B 2A555X] }
+  let(:user_office_codes) { %w[1A123B 2A555X] }
 
   describe '#provider_enrolled?' do
-    before do
-      allow(subject).to receive_messages(email_enrolled?: false, office_enrolled?: false)
+    context 'when no service is allowed for their office' do
+      let(:office_codes_from_config) { { :"9A999B" => ["crm4"] } }
+
+      it 'checks if the email is enrolled' do
+        expect(gatekeeper).to receive(:email_enrolled?)
+        gatekeeper.provider_enrolled?
+      end
+
+      it 'checks if the all providers enrolled' do
+        expect(gatekeeper).to receive(:all_enrolled?)
+        gatekeeper.provider_enrolled?
+      end
+
+      it 'checks if any office codes are enrolled' do
+        expect(gatekeeper).to receive(:office_enrolled?)
+        gatekeeper.provider_enrolled?
+      end
+
+      it 'returns false when no service is specified' do
+        expect(gatekeeper.provider_enrolled?).to be(false)
+      end
+
+      it 'returns false when any service is specified' do
+        expect(gatekeeper.all_enrolled?(service: :crm4)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm5)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm7)).to be(false)
+      end
     end
 
-    it 'checks if the email is enrolled' do
-      expect(subject).to receive(:email_enrolled?)
-      subject.provider_enrolled?
+    context 'when ALL have access to crm5 BUT only crm4 for their office code' do
+      let(:office_codes_from_config) do
+        {
+          :ALL => ["crm5"],
+          :"1A123B" => ["crm4"]
+        }
+      end
+
+      it 'returns true when no service is specified' do
+        expect(gatekeeper.provider_enrolled?).to be(true)
+      end
+
+      it 'returns true for the service allowed by ALL' do
+        expect(gatekeeper.provider_enrolled?(service: :crm5)).to be(true)
+      end
+
+      it 'returns true for the service allowed for their office' do
+        expect(gatekeeper.provider_enrolled?(service: :crm4)).to be(true)
+      end
+
+      it 'returns false for the service not allowed by ALL or their office' do
+        expect(gatekeeper.provider_enrolled?(service: :crm7)).to be(false)
+      end
+    end
+  end
+
+  describe '#all_enrolled?' do
+    context 'when ALL is specified for one service' do
+      let(:office_codes_from_config) { { :ALL => ['crm5'] } }
+
+      it 'returns true when no service is specified' do
+        expect(gatekeeper.all_enrolled?).to be(true)
+      end
+
+      it 'returns true when an allowed service is specified' do
+        expect(gatekeeper.all_enrolled?(service: :crm5)).to be(true)
+      end
+
+      it 'returns false when disallowed service is specified' do
+        expect(gatekeeper.all_enrolled?(service: :crm4)).to be(false)
+      end
     end
 
-    it 'checks if any office codes are enrolled' do
-      expect(subject).to receive(:office_enrolled?)
-      subject.provider_enrolled?
+    context 'when ALL is NOT specified in the allow list and their office code has none' do
+      let(:office_codes_from_config) { { :"9A999B" => ["crm7", "crm4", "crm5"] } }
+
+      it 'returns false when no service is specified' do
+        expect(gatekeeper.all_enrolled?).to be(false)
+      end
+
+      it 'returns false when service is specified' do
+        expect(gatekeeper.all_enrolled?(service: :crm4)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm5)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm7)).to be(false)
+      end
+    end
+
+    context 'when ALL is specified with no services and their office code has none' do
+      let(:office_codes_from_config) { { ALL: [] } }
+
+      it 'returns false when no service is specified' do
+        expect(gatekeeper.all_enrolled?).to be(false)
+      end
+
+      it 'returns false when service is specified' do
+        expect(gatekeeper.all_enrolled?(service: :crm4)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm5)).to be(false)
+        expect(gatekeeper.all_enrolled?(service: :crm7)).to be(false)
+      end
     end
   end
 
   describe '#office_enrolled?' do
+    let(:office_codes_from_config) { { :"1A123B" => ["crm4"] } }
+
     context 'when any of the office codes are in the allow list' do
       it 'returns true when no service is specified' do
-        expect(subject.office_enrolled?).to be(true)
+        expect(gatekeeper.office_enrolled?).to be(true)
       end
 
-      it 'returns true when a service is specified' do
-        expect(subject.office_enrolled?(service: :crm7)).to be(true)
+      it 'returns true when an allowed service is specified' do
+        expect(gatekeeper.office_enrolled?(service: :crm4)).to be(true)
+      end
+
+      it 'returns false when a disallowed service is specified' do
+        expect(gatekeeper.office_enrolled?(service: :crm7)).to be(false)
       end
     end
 
     context 'when no office codes are in the allow list' do
-      let(:office_codes) { %w[1X000X] }
+      let(:user_office_codes) { %w[1X000X] }
 
       it 'returns false when no service is specified' do
-        expect(subject.office_enrolled?).to be(false)
+        expect(gatekeeper.office_enrolled?).to be(false)
       end
 
       it 'returns false when a service is specified' do
-        expect(subject.office_enrolled?(service: :crm4)).to be(false)
+        expect(gatekeeper.office_enrolled?(service: :crm4)).to be(false)
       end
     end
   end

--- a/spec/services/providers/gatekeeper_spec.rb
+++ b/spec/services/providers/gatekeeper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Providers::Gatekeeper do
 
   let(:auth_info) do
     double(
-      email:'test@example.com',
+      email: 'test@example.com',
       office_codes: user_office_codes,
     )
   end
@@ -20,7 +20,7 @@ RSpec.describe Providers::Gatekeeper do
 
   describe '#provider_enrolled?' do
     context 'when no service is allowed for their office' do
-      let(:office_codes_from_config) { { :"9A999B" => ["crm4"] } }
+      let(:office_codes_from_config) { { '9A999B': ['crm4'] } }
 
       it 'checks if the email is enrolled' do
         expect(gatekeeper).to receive(:email_enrolled?)
@@ -51,8 +51,8 @@ RSpec.describe Providers::Gatekeeper do
     context 'when ALL have access to crm5 BUT only crm4 for their office code' do
       let(:office_codes_from_config) do
         {
-          :ALL => ["crm5"],
-          :"1A123B" => ["crm4"]
+          ALL: ['crm5'],
+          '1A123B': ['crm4']
         }
       end
 
@@ -76,7 +76,7 @@ RSpec.describe Providers::Gatekeeper do
 
   describe '#all_enrolled?' do
     context 'when ALL is specified for one service' do
-      let(:office_codes_from_config) { { :ALL => ['crm5'] } }
+      let(:office_codes_from_config) { { ALL: ['crm5'] } }
 
       it 'returns true when no service is specified' do
         expect(gatekeeper.all_enrolled?).to be(true)
@@ -92,7 +92,7 @@ RSpec.describe Providers::Gatekeeper do
     end
 
     context 'when ALL is NOT specified in the allow list and their office code has none' do
-      let(:office_codes_from_config) { { :"9A999B" => ["crm7", "crm4", "crm5"] } }
+      let(:office_codes_from_config) { { '9A999B': %w[crm7 crm4 crm5] } }
 
       it 'returns false when no service is specified' do
         expect(gatekeeper.all_enrolled?).to be(false)
@@ -121,7 +121,7 @@ RSpec.describe Providers::Gatekeeper do
   end
 
   describe '#office_enrolled?' do
-    let(:office_codes_from_config) { { :"1A123B" => ["crm4"] } }
+    let(:office_codes_from_config) { { '1A123B': ['crm4'] } }
 
     context 'when any of the office codes are in the allow list' do
       it 'returns true when no service is specified' do

--- a/spec/system/access_spec.rb
+++ b/spec/system/access_spec.rb
@@ -2,9 +2,21 @@ require 'rails_helper'
 
 RSpec.describe 'System Access', type: :system do
   before do
+    allow(Rails.configuration.x.gatekeeper)
+      .to receive(:office_codes)
+      .and_return(office_codes_from_config)
+
     visit provider_saml_omniauth_callback_path(
       info: { name: 'Test User', email: 'provider@example.com', office_codes: provider.office_codes }
     )
+  end
+
+  let(:office_codes_from_config) do
+    {
+      AAAAAA: ['crm7'],
+      BBBBBB: ['crm4'],
+      CCCCCC: ['crm5']
+    }
   end
 
   context 'user with office codes with access to NSM and PAA' do

--- a/spec/system/access_spec.rb
+++ b/spec/system/access_spec.rb
@@ -19,18 +19,6 @@ RSpec.describe 'System Access', type: :system do
       visit prior_authority_applications_path
       expect(page).to have_content('Your applications')
     end
-
-    context 'selectes an alternative office code that does not have access' do
-      it 'can access NSM' do
-        visit nsm_applications_path
-        expect(page).to have_content('Your claims')
-      end
-
-      it 'can access PAA' do
-        visit prior_authority_applications_path
-        expect(page).to have_content('Your applications')
-      end
-    end
   end
 
   context 'user with office codes with access to NSM only' do
@@ -60,19 +48,6 @@ RSpec.describe 'System Access', type: :system do
     it 'cannot view EOL link on home page' do
       visit root_path
       expect(page).to have_no_content 'Apply for extension of upper limits'
-    end
-
-    context 'selects an alternative office code that does not have access' do
-      it 'can access NSM' do
-        visit nsm_applications_path
-        expect(page).to have_content('Your claims')
-      end
-
-      it 'can access PAA' do
-        visit prior_authority_applications_path
-        expect(page).to have_no_content('Your applications')
-        expect(page).to have_current_path(root_path)
-      end
     end
   end
 
@@ -104,19 +79,6 @@ RSpec.describe 'System Access', type: :system do
       visit root_path
       expect(page).to have_no_content 'Apply for extension of upper limits'
     end
-
-    context 'selectes an alternative office code that does not have access' do
-      it 'can not access NSM' do
-        visit nsm_applications_path
-        expect(page).to have_no_content('Your claims')
-        expect(page).to have_current_path(root_path)
-      end
-
-      it 'can access PAA' do
-        visit prior_authority_applications_path
-        expect(page).to have_content('Your applications')
-      end
-    end
   end
 
   context 'user with office codes with access to neither NSM, PAA nor EOL' do
@@ -132,20 +94,6 @@ RSpec.describe 'System Access', type: :system do
       visit prior_authority_applications_path
       expect(page).to have_no_content('Your Applications')
       expect(page).to have_current_path(new_provider_session_path)
-    end
-
-    context 'selectes an alternative office code that does not have access' do
-      it 'can not access NSM' do
-        visit nsm_applications_path
-        expect(page).to have_no_content('Your claims')
-        expect(page).to have_current_path(new_provider_session_path)
-      end
-
-      it 'can not access PAA' do
-        visit prior_authority_applications_path
-        expect(page).to have_no_content('Your Applications')
-        expect(page).to have_current_path(new_provider_session_path)
-      end
     end
   end
 

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Sign in user journey' do
+  before do
+    allow(Rails.configuration.x.gatekeeper)
+      .to receive(:office_codes)
+      .and_return(office_codes_from_config)
+  end
+
+  let(:office_codes_from_config) { { '1A111A': %w[crm7 crm4 crm5] } }
+
   context 'user is not signed in' do
     it 'redirects to the login page' do
       visit '/'
@@ -11,13 +19,11 @@ RSpec.describe 'Sign in user journey' do
 
   context 'user signs in but is not yet enrolled' do
     before do
-      allow(
-        OmniAuth.config
-      ).to receive(:mock_auth).and_return(
-        saml: OmniAuth::AuthHash.new(info: { office_codes: ['1X000X'] })
-      )
       visit provider_saml_omniauth_callback_path
     end
+
+    # NOTE: test relies on mock_auth having office code of "1A123B"
+    let(:office_codes_from_config) { { '1X000X': %w[crm7 crm4 crm5] } }
 
     it 'redirects to the error page' do
       expect(current_url).to match(laa_msf.not_enrolled_errors_path)
@@ -27,12 +33,11 @@ RSpec.describe 'Sign in user journey' do
 
   context 'user is signed in' do
     before do
-      allow_any_instance_of(
-        Provider
-      ).to receive(:office_codes).and_return(['1A123B'])
-
       visit provider_saml_omniauth_callback_path
     end
+
+    # NOTE: test relies on mock_auth having office code of "1A123B"
+    let(:office_codes_from_config) { { '1A123B': %w[crm7 crm4 crm5] } }
 
     it 'authenticates the user and redirects to the dashboard' do
       expect(page).to have_current_path(root_path)


### PR DESCRIPTION
## Description of change
Enable simple onboarding of ALL providers per service

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1590)


Current onboarding approach requires adding all office codes to the provider app and specifying which service(s) they can use. This will become onerous as we onboard more and pointless when we go to public
beta and ALL crime providers (in LAA portal) will be allowed access.

This enables us to switch on a specific form type/service for all providers with the portal link, sa below (for crm5)

```
# gatekeeper.yml
production:
  office_codes:
    ALL: ['crm5']
```

## Notes for reviewer
You can test locally by adding below config and try to access with a test user mock login that normally would have no access.

```
# gatekeeper.yml
localhost:
  office_codes:
    ALL: ['crm5']
```
