### PR TITLE
CRM457-1515: Add second CRM4 onboarding tranche - 11/06/2024

### DIFF
--- a/config/gatekeeper_crm4.yml
+++ b/config/gatekeeper_crm4.yml
@@ -69,3 +69,36 @@ production:
     - 2Q510X
     - 2Q511Y
     - 2Q512Z
+
+    # Second CRM4 onboarding tranche - 11/06/2024
+    - 0W160B
+    - 2M075N
+    - 2M847C
+    - 2N849R
+    - 2P203B
+    - 2P328M
+    - 2P475X
+    - 2P476Y
+    - 2P479B
+    - 2P481D
+    - 2Q202M
+    - 2Q203N
+    - 2Q268J
+    - 2Q269K
+    - 2Q413R
+    - 2Q414T
+    - 2Q613J
+    - 1L461W
+    - 0W953N
+    - 1W341Y
+    - 2M402U
+    - 2M408A
+    - 2M603M
+    - 2N128H
+    - 2N822M
+    - 2N869N
+    - 2Q621T
+    - 2Q622U
+    - 2Q623V
+
+


### PR DESCRIPTION
## Description of change
Add second CRM4 onboarding tranche - 11/06/2024

**NOT BEFORE 11/06/2024**

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1515)

Early adopters part 2
