### PR TITLE
CMR457-1594: Fix GDS error handling on remittal date field

### DIFF
--- a/app/views/nsm/steps/case_details/edit.html.erb
+++ b/app/views/nsm/steps/case_details/edit.html.erb
@@ -14,7 +14,7 @@
         <%= f.govuk_radio_buttons_fieldset field, legend: { size: 's' } do %>
           <%= f.govuk_radio_button field, YesNoAnswer::YES.to_s do %>
            <% if field == :remitted_to_magistrate %>
-              <%= f.govuk_fully_validatable_date_field "#{field}_date", width: 'one-third', legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
+              <%= f.govuk_fully_validatable_date_field :"#{field}_date", width: 'one-third', legend: { size: 's', class: 'govuk-date-legend-non-bold' } %>
             <% end %>
           <% end %>
           <%= f.govuk_radio_button field, YesNoAnswer::NO.to_s %>


### PR DESCRIPTION
## Description of change
Fix GDS error handling on nested remittal date field

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1594)

Just needed to be a symbol to pick up the
default behaviour.

### Before changes:

<img width="238" alt="remittal_date-error" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/d02a7e4d-14b2-4a49-baf4-dee8fd235d5e">


### After changes:

![remittal-error-after](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/7fc4176f-a81b-4d74-9426-58048ad6d560)


