### PR TITLE
CRM457-1599: Make CRM7's prior authority question conditional

### DIFF
--- a/app/forms/nsm/steps/disbursement_cost_form.rb
+++ b/app/forms/nsm/steps/disbursement_cost_form.rb
@@ -46,6 +46,7 @@ if: :other_disbursement_type?
       def attributes_with_resets
         attributes.merge(
           'miles' => other_disbursement_type? ? nil : miles,
+          'prior_authority' => other_disbursement_type? ? prior_authority : nil,
           'total_cost_without_vat' => total_cost_pre_vat,
           'vat_amount' => vat,
           'apply_vat' => apply_vat ? 'true' : 'false'

--- a/app/forms/nsm/steps/disbursement_cost_form.rb
+++ b/app/forms/nsm/steps/disbursement_cost_form.rb
@@ -13,7 +13,7 @@ module Nsm
       validates :total_cost_without_vat, presence: true, numericality: { greater_than: 0 },
 if: :other_disbursement_type?
       validates :details, presence: true
-      validates :prior_authority, presence: true, inclusion: { in: YesNoAnswer.values }
+      validates :prior_authority, presence: true, inclusion: { in: YesNoAnswer.values }, if: :other_disbursement_type?
 
       def apply_vat
         @apply_vat.nil? ? record.vat_amount.to_f.positive? : @apply_vat == 'true'

--- a/app/forms/nsm/steps/disbursement_type_form.rb
+++ b/app/forms/nsm/steps/disbursement_type_form.rb
@@ -25,7 +25,11 @@ module Nsm
       end
 
       def attributes_with_resets
-        attributes.merge('other_type' => other_disbursement_type? ? other_type : nil)
+        attributes.merge(
+          'other_type' => other_disbursement_type? ? other_type : nil,
+          'miles' => other_disbursement_type? ? nil : record.miles,
+          'prior_authority' => other_disbursement_type? ? record.prior_authority : nil,
+        )
       end
 
       def other_disbursement_type?

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -15,8 +15,9 @@ class Disbursement < ApplicationRecord
     )
   end
 
-  def date_and_prior_authority_valid?
-    disbursement_date.present? && prior_authority.present?
+  def type_and_cost_valid?
+    Nsm::Steps::DisbursementTypeForm.build(self, application: claim).valid? &&
+      Nsm::Steps::DisbursementCostForm.build(self, application: claim).valid?
   end
 
   def translated_disbursement_type

--- a/app/views/nsm/steps/disbursement_cost/edit.html.erb
+++ b/app/views/nsm/steps/disbursement_cost/edit.html.erb
@@ -12,10 +12,12 @@
         <%= f.govuk_number_field :miles, min: 1, step: 1, width: 3, suffix_text: 'Miles', label: { tag: 'strong' }, data: { selector: 'valueField', multipler: @form_object.multiplier } %>
       <% end %>
       <%= f.govuk_text_area :details , label: { tag: 'strong' } %>
-      <%= f.govuk_radio_buttons_fieldset :prior_authority, legend: { size: 's' } do %>
-        <%= f.govuk_radio_button :prior_authority, YesNoAnswer::YES.to_s %>
-        <%= f.govuk_radio_button :prior_authority, YesNoAnswer::NO.to_s %>
-      <% end%>
+      <% if @form_object.other_disbursement_type? %>
+        <%= f.govuk_radio_buttons_fieldset :prior_authority, legend: { size: 's' } do %>
+          <%= f.govuk_radio_button :prior_authority, YesNoAnswer::YES.to_s %>
+          <%= f.govuk_radio_button :prior_authority, YesNoAnswer::NO.to_s %>
+        <% end%>
+      <% end %>
       <%= f.govuk_check_box :apply_vat, 'true', 'false', multiple: false, data: { selector: 'vatField', multipler: @form_object.vat_rate } %>
 
       <%= f.refresh_button %>

--- a/app/views/nsm/steps/disbursements/edit.html.erb
+++ b/app/views/nsm/steps/disbursements/edit.html.erb
@@ -33,7 +33,7 @@
                 <% end %>
               </td>
               <td class="govuk-table__cell"><%= check_missing(disbursement.total_cost) { NumberTo.pounds(disbursement.total_cost) } %></td>
-              <td class="govuk-table__cell"><%= check_missing(disbursement.date_and_prior_authority_valid? && disbursement.details) %></td>
+              <td class="govuk-table__cell"><%= check_missing(disbursement.type_and_cost_valid? && disbursement.details) %></td>
               <td class="govuk-table__cell govuk-table__nowrap">
                 <%= link_to t('.change'), edit_nsm_steps_disbursement_type_path(@form_object.application, disbursement_id: disbursement.id) %>
               </td>

--- a/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
+++ b/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
@@ -28,33 +28,68 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
   let(:apply_vat) { 'false' }
   let(:vat_amount) { nil }
 
-  describe '#validations' do
+  describe '#validate' do
     context 'when disbursement_type is not other' do
-      %w[miles details].each do |field|
-        describe "#when #{field} is blank" do
-          let(field) { nil }
+      context 'and miles are blank' do
+        let(:miles) { nil }
 
-          it 'has an error' do
-            expect(form).not_to be_valid
-            expect(form.errors.of_kind?(field, :blank)).to be(true)
-          end
+        it 'has an error' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:miles, :blank)).to be(true)
         end
+      end
+
+      context 'and details are blank' do
+        let(:details) { nil }
+
+        it 'has an error' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:details, :blank)).to be(true)
+        end
+      end
+
+      context 'and prior_authority is blank' do
+        let(:prior_authority) { nil }
+
+        it { is_expected.to be_valid }
       end
     end
 
     context 'when disbursement_type is other' do
       let(:disbursement_type) { DisbursementTypes::OTHER.to_s }
-      let(:miles) { nil }
+      let(:prior_authority) { YesNoAnswer::YES }
       let(:total_cost_without_vat) { 10.0 }
 
-      %w[total_cost_without_vat details].each do |field|
-        describe "#when #{field} is blank" do
-          let(field) { nil }
+      context 'and miles are blank' do
+        let(:miles) { nil }
 
-          it 'has an error' do
-            expect(form).not_to be_valid
-            expect(form.errors.of_kind?(field, :blank)).to be(true)
-          end
+        it { is_expected.to be_valid }
+      end
+
+      context 'and details are blank' do
+        let(:details) { nil }
+
+        it 'has an error' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:details, :blank)).to be(true)
+        end
+      end
+
+      context 'and prior_authority is blank' do
+        let(:prior_authority) { nil }
+
+        it 'has an error' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:prior_authority, :blank)).to be(true)
+        end
+      end
+
+      context 'and total_cost_without_vat is blank' do
+        let(:total_cost_without_vat) { nil }
+
+        it 'has an error' do
+          expect(form).not_to be_valid
+          expect(form.errors.of_kind?(:total_cost_without_vat, :blank)).to be(true)
         end
       end
     end
@@ -132,7 +167,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
     end
   end
 
-  describe 'save!' do
+  describe '#save!' do
     let(:application) { create(:claim) }
     let(:record) { Disbursement.create!(disbursement_type: disbursement_type, claim: application) }
     let(:disbursement_type) { DisbursementTypes::Car.to_s }

--- a/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
+++ b/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
@@ -40,23 +40,6 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
           end
         end
       end
-
-      context 'when total without vat is >= £100' do
-        let(:miles) { 1000 }
-
-        context 'when prior_authority is not set' do
-          it 'has an error' do
-            expect(subject).not_to be_valid
-            expect(subject.errors.of_kind?(:prior_authority, :blank)).to be(true)
-          end
-        end
-
-        context 'when prior_authority is set' do
-          let(:prior_authority) { YesNoAnswer.values.sample.to_s }
-
-          it { expect(subject).to be_valid }
-        end
-      end
     end
 
     context 'when disbursement_type is other' do
@@ -69,26 +52,9 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
           let(field) { nil }
 
           it 'has an error' do
-            expect(subject).not_to be_valid
-            expect(subject.errors.of_kind?(field, :blank)).to be(true)
+            expect(form).not_to be_valid
+            expect(form.errors.of_kind?(field, :blank)).to be(true)
           end
-        end
-      end
-
-      context 'when total without vat is >= £100' do
-        let(:total_cost_without_vat) { 100.00 }
-
-        context 'when prior_authority is not set' do
-          it 'has an error' do
-            expect(subject).not_to be_valid
-            expect(subject.errors.of_kind?(:prior_authority, :blank)).to be(true)
-          end
-        end
-
-        context 'when prior_authority is set' do
-          let(:prior_authority) { YesNoAnswer.values.sample.to_s }
-
-          it { expect(subject).to be_valid }
         end
       end
     end

--- a/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
+++ b/spec/forms/nsm/steps/disbursements_cost_form_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
           let(field) { nil }
 
           it 'has an error' do
-            expect(subject).not_to be_valid
-            expect(subject.errors.of_kind?(field, :blank)).to be(true)
+            expect(form).not_to be_valid
+            expect(form.errors.of_kind?(field, :blank)).to be(true)
           end
         end
       end
@@ -65,13 +65,13 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       context 'and is the true string' do
         let(:apply_vat) { 'true' }
 
-        it { expect(subject.apply_vat).to be(true) }
+        it { expect(form.apply_vat).to be(true) }
       end
 
       context 'and is the false string' do
         let(:apply_vat) { 'false' }
 
-        it { expect(subject.apply_vat).to be(false) }
+        it { expect(form.apply_vat).to be(false) }
       end
     end
 
@@ -81,13 +81,13 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       context 'and a vat_amount exists on the record' do
         let(:vat_amount) { 10 }
 
-        it { expect(subject.apply_vat).to be(true) }
+        it { expect(form.apply_vat).to be(true) }
       end
 
       context 'and a vat_amount does not exist on the record' do
         let(:vat_amount) { nil }
 
-        it { expect(subject.apply_vat).to be(false) }
+        it { expect(form.apply_vat).to be(false) }
       end
     end
   end
@@ -98,7 +98,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       let(:total_cost_without_vat) { 150 }
 
       it 'is equal to total_cost_witout_vat' do
-        expect(subject.total_cost).to eq(150.0)
+        expect(form.total_cost).to eq(150.0)
       end
     end
 
@@ -108,14 +108,14 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       context 'when miles are nil' do
         let(:miles) { nil }
 
-        it { expect(subject.total_cost).to be_nil }
+        it { expect(form.total_cost).to be_nil }
       end
 
       context 'when miles are not nil' do
         let(:miles) { 100 }
 
         it 'equal to miles times rate/mile' do
-          expect(subject.total_cost).to eq(25.0)
+          expect(form.total_cost).to eq(25.0)
         end
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       let(:total_cost_without_vat) { nil }
 
       it 'returns a nil total cost' do
-        expect(subject.send(:vat)).to be_nil
+        expect(form.send(:vat)).to be_nil
       end
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       let(:disbursement_type) { DisbursementTypes::CAR.to_s }
 
       it 'calculates and stores the total_cost_without_vat' do
-        subject.save!
+        form.save!
         expect(record.reload).to have_attributes(
           miles: 10,
           total_cost_without_vat: 4.5,
@@ -153,7 +153,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
         let(:apply_vat) { 'true' }
 
         it 'calculates and stores the total_cost_without_vat and vat_amount' do
-          subject.save!
+          form.save!
           expect(record.reload).to have_attributes(
             miles: 10,
             total_cost_without_vat: 4.5,
@@ -165,7 +165,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
           let(:miles) { 11.5 }
 
           it 'calculates and stores the total_cost_without_vat and vat_amount rounded to the nearest penny' do
-            subject.save!
+            form.save!
             expect(record.reload).to have_attributes(
               miles: 11.5,
               total_cost_without_vat: 5.18,
@@ -181,7 +181,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
       let(:total_cost_without_vat) { 50 }
 
       it 'stores the total_cost_without_vat' do
-        subject.save!
+        form.save!
         expect(record.reload).to have_attributes(
           miles: nil,
           total_cost_without_vat: 50.0,
@@ -193,7 +193,7 @@ RSpec.describe Nsm::Steps::DisbursementCostForm do
         let(:apply_vat) { 'true' }
 
         it 'stores the total_cost_without_vat and vat_amount' do
-          subject.save!
+          form.save!
           expect(record.reload).to have_attributes(
             miles: nil,
             total_cost_without_vat: 50.0,

--- a/spec/system/nsm/disbursement_type/disbursement_costs_spec.rb
+++ b/spec/system/nsm/disbursement_type/disbursement_costs_spec.rb
@@ -1,0 +1,48 @@
+require 'system_helper'
+
+RSpec.describe 'Mileage and Other disbursement cost conditional fields', :javascript, type: :system do
+  before do
+    visit provider_saml_omniauth_callback_path
+    click_link 'Accept analytics cookies'
+
+    visit edit_nsm_steps_disbursement_cost_path(id: claim, disbursement_id: disbursement.id)
+  end
+
+  let(:disbursement) do
+    create(:disbursement,
+           disbursement_type: disbursement_type,
+           disbursement_date: 1.month.ago.to_date,
+           claim: claim)
+  end
+
+  let(:claim) { create(:claim) }
+  let(:disbursement_type) { DisbursementTypes::CAR.to_s }
+
+  it 'displays the expected title' do
+    expect(page).to have_title('Disbursement cost')
+  end
+
+  context 'With a "mileage" type disbursement' do
+    let(:disbursement_type) { DisbursementTypes::CAR.to_s }
+
+    it 'displays the mileage field' do
+      expect(page).to have_field('Number of miles')
+    end
+
+    it 'hides the prior authority question' do
+      expect(page).to have_no_content('Have you been granted prior authority')
+    end
+  end
+
+  context 'With an "other" type disbursement' do
+    let(:disbursement_type) { DisbursementTypes::OTHER.to_s }
+
+    it 'hides mileage field' do
+      expect(page).to have_no_field('Number of miles')
+    end
+
+    it 'displays prior authority question' do
+      expect(page).to have_content('Have you been granted prior authority for this disbursement?')
+    end
+  end
+end

--- a/spec/system/nsm/disbursements_spec.rb
+++ b/spec/system/nsm/disbursements_spec.rb
@@ -116,9 +116,8 @@ RSpec.describe 'User can manage disbursements', type: :system do
     expect(page).to have_content('Check your payment claim')
   end
 
-  it 'forces me to complete disbursements before continuing' do
+  it 'forces me to complete "mileage" disbursements before continuing' do
     visit edit_nsm_steps_disbursement_add_path(claim.id)
-
     choose 'Yes'
 
     click_on 'Save and continue'
@@ -132,7 +131,6 @@ RSpec.describe 'User can manage disbursements', type: :system do
     choose 'Car'
 
     click_on 'Save and come back later'
-
     click_on 'Disbursements'
 
     expect(page).to have_no_content 'Do you want to add another disbursement?'
@@ -145,7 +143,6 @@ RSpec.describe 'User can manage disbursements', type: :system do
     click_on 'Save and continue'
 
     fill_in 'Number of miles', with: 100
-    choose 'Yes'
     fill_in 'Enter details of this disbursement', with: 'details'
 
     click_on 'Save and continue'
@@ -155,5 +152,6 @@ RSpec.describe 'User can manage disbursements', type: :system do
 
     click_on 'Save and continue'
     expect(page).to have_no_content 'You cannot save and continue if any disbursements are incomplete'
+    expect(page).to have_title 'Check your payment claim'
   end
 end


### PR DESCRIPTION
## Description of change
 Make CRM7's prior authority question conditional

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1599)

Inline with bug raised by BA, the prior authority question
should only be asked if the disbursement of an "other" type
and NOT for mileage disbursements.

- [X] Remove redundant tests
- [X] Use named subject
- [X] Only validate presence of prior_authority for "other" disbursement types
- [X] Reset miles and prior authority attributes if type changed
- [X] Add system spec for disbursement type conditional field display
- [X] User form validity to check for incomplete disbursements

## Notes for reviewer
