### PR TITLE
Remove meta_request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-  gem 'meta_request'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,9 +257,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    meta_request (0.8.2)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 8)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
@@ -331,8 +328,6 @@ GEM
     raabro (1.4.0)
     racc (1.8.0)
     rack (3.0.11)
-    rack-contrib (2.5.0)
-      rack (< 4)
     rack-protection (4.0.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0, < 4)
@@ -558,7 +553,6 @@ DEPENDENCIES
   laa_multi_step_forms!
   launchy
   logstasher (~> 2.1)
-  meta_request
   oauth2 (~> 2.0)
   overcommit
   pagy (~> 8.4.2)


### PR DESCRIPTION
## Description of change
For reasons not clear, this gem is interfering with Rails form objects, meaning that in dev mode on local, we're getting SystemStackErrors when trying to view pages that pass the form object to the multifile_upload partial. As this gem is only a development helper added in passing in another PR, I think we can safely remove it.
