### PR TITLE
crm457-1594: Add custom date errors for main offence and remittal

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -328,7 +328,13 @@ en:
           attributes:
             main_offence:
               blank: "Enter the name of the offence"
-            main_offence_date: *shared_date_errors
+            main_offence_date:
+              blank: Enter the date of the main offence
+              invalid: The date of the main offence must be a real date
+              invalid_day: The date of the main offence must be a real date
+              invalid_month: The date of the main offence must be a real date
+              invalid_year: The date of the main offence must be a real date
+              future_not_allowed: The date of the main offence must be in the past
             assigned_counsel:
               blank: "Assigned counsel cannot be blank"
             unassigned_counsel:
@@ -337,7 +343,14 @@ en:
               blank: "Agent instructed cannot be blank"
             remitted_to_magistrate:
               blank: "Remitted to magistrate cannot be blank"
-            invalid: You must select at least one option
+              invalid: You must select at least one option
+            remitted_to_magistrate_date:
+              blank: Enter the remittal date
+              invalid: The remittal date must be a real date
+              invalid_day: The remittal date must be a real date
+              invalid_month: The remittal date must be a real date
+              invalid_year: The remittal date must be a real date
+              future_not_allowed: The remittal date must be in the past
         nsm/steps/case_disposal_form:
           attributes:
             plea:


### PR DESCRIPTION
## Description of change
Add custom date errors for main offence and remittal

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1594)

At designer request the main offence date
and remittal date have been given custom
error messages.
