### PR TITLE
CMR457-1604: Remove NSM solicitor reference hint text

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -68,7 +68,6 @@ en:
       nsm_steps_firm_details_form:
         solicitor_details: Enter the details of the solicitor managing this case
         solicitor_attributes:
-          reference_number: For example, 2P341B
           alternative_contact_details: |
             We’ll use the contact details on your account if we need to ask you for
             more information to complete your claim. If you add alternative contact


### PR DESCRIPTION

## Description of change
Remove NSM solicitor reference hint text

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1604)

Was wrong, as using office code example, plus
is not needed, as requested by content design.

## Before
![Screenshot 2024-06-11 at 09 40 59](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/020cd6cf-4a3c-4989-a0e8-9a9ea981bf7c)


## After
![Screenshot 2024-06-11 at 09 38 53](https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/4e57e643-fd25-4332-b7c7-9b617423811b)

