### PR TITLE
CRM457-1360: Add sidekiq port to service monitor

### DIFF
--- a/helm_deploy/templates/service-monitor.yaml
+++ b/helm_deploy/templates/service-monitor.yaml
@@ -11,4 +11,6 @@ spec:
   endpoints:
   - port: http
     interval: 15s
+  - targetPort: {{ .Values.service.workerPort }}
+    interval: 15s
 {{- end }}

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 namespace: laa-submit-crime-forms-prod
 
 serviceMonitor:
-  enabled: true
+  enabled: false
 
 image:
   repository: nginx

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 namespace: laa-submit-crime-forms-uat
 
 serviceMonitor:
-  enabled: true
+  enabled: false
 
 image:
   repository: nginx


### PR DESCRIPTION
## Description of change

 [[MVP] - MONITORING - Exporting metrics for Redis Queues and Sidekiq](https://dsdmoj.atlassian.net/browse/CRM457-1360)

Adds the sidekiq port to the service monitor - this is to test whether the service monitor can access the worker port
