### PR TITLE
CRM457-1611: Onboard addtional early adopters for CRM5/EoUL

### DIFF
--- a/config/gatekeeper_crm5.yml
+++ b/config/gatekeeper_crm5.yml
@@ -75,3 +75,10 @@ production:
     - 2Q510X
     - 2Q511Y
     - 2Q512Z
+
+    # Third CRM5 onboarding tranche - 12/06/2024
+    - 0P276F
+    - 0W966C
+    - 2N791D
+    - 2E061P
+    - 2L888K


### PR DESCRIPTION

## Description of change
Onboard addtional early adopters for CRM5/EoUL

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1611)

To give caseworkers more graduated learning curve
of handling CRM5/EoUL submissions they have
asked for more onboarding of early adopters before
we open it up to all providers.
