### PR TITLE
CRM457-1600: Supporting evidence delete button fix

### DIFF
--- a/app/controllers/prior_authority/steps/further_information_controller.rb
+++ b/app/controllers/prior_authority/steps/further_information_controller.rb
@@ -3,8 +3,6 @@ module PriorAuthority
     class FurtherInformationController < BaseController
       include MultiFileUploadable
 
-      skip_before_action :verify_authenticity_token, only: [:destroy]
-
       def edit
         @form_object = FurtherInformationForm.build(record, application: current_application)
       end

--- a/app/controllers/prior_authority/steps/reason_why_controller.rb
+++ b/app/controllers/prior_authority/steps/reason_why_controller.rb
@@ -3,8 +3,6 @@ module PriorAuthority
     class ReasonWhyController < BaseController
       include MultiFileUploadable
 
-      skip_before_action :verify_authenticity_token, only: [:destroy]
-
       def edit
         @form_object = ReasonWhyForm.build(
           current_application

--- a/app/javascript/file-upload.js
+++ b/app/javascript/file-upload.js
@@ -54,7 +54,7 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
 
 MOJFrontend.MultiFileUpload.prototype.getFileRowHtml = function (file, fileListLength) {
     return `<tr class="govuk-table__row moj-multi-file-upload__row" id="${fileListLength}">
-            <td class="govuk-table__cell moj-multi-file-upload__filename">
+            <td class="govuk-table__cell moj-multi-file-upload__filename_progress">
                 <span class="moj-multi-file-upload__filename"> ${file.name}</span>
                 <span class="moj-multi-file-upload__progress">(0%)</span></td>
             <td class="govuk-table__cell moj-multi-file-upload__actions">
@@ -69,7 +69,11 @@ MOJFrontend.MultiFileUpload.prototype.onFileDeleteClick = function (e) {
     e.preventDefault(); // if user refreshes page and then deletes
     let button = $(e.currentTarget);
     let feedback = $(".moj-multi-file-upload__message");
-    let fileName = button.parents('.govuk-table__row.moj-multi-file-upload__row').attr('id')
+
+    let fileName = button
+                    .parents('.govuk-table__row.moj-multi-file-upload__row')
+                    .find('.moj-multi-file-upload__filename')
+                    .text()
 
     $.ajax({
         url: `${this.params.deleteUrl}?evidence_id=${button.attr('value')}`,

--- a/app/javascript/file-upload.js
+++ b/app/javascript/file-upload.js
@@ -133,3 +133,10 @@ $(function() {
     }
 })
 
+$(function(){
+  // always pass csrf tokens on ajax calls
+  $.ajaxSetup({
+    headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') }
+  });
+});
+

--- a/app/views/nsm/steps/supporting_evidence/edit.html.erb
+++ b/app/views/nsm/steps/supporting_evidence/edit.html.erb
@@ -8,18 +8,17 @@
     <%= govuk_error_summary(@form_object) %>
     <div class="moj-multi-file-upload__message"></div>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-6"><%= t('.heading') %></h1>
-    <%# Answers upload list %>
+
     <%= render template: 'nsm/steps/supporting_evidence/_content' %>
 
-    <%# Additional upload list %>
     <%= step_form @form_object do |f| %>
-      <%# File upload component %>
       <%= render 'shared/multifile_upload',
           supporting_documents: @supporting_documents,
           field: :supporting_evidence,
           form: f,
           locale_prefix: 'nsm.steps.supporting_evidence.edit',
           hint: t('.upload_hint', size: FileUpload::FileUploader.human_readable_max_file_size) %>
+
       <% if FeatureFlags.postal_evidence.enabled? %>
         <%# Postal address component %>
         <%= f.govuk_check_boxes_fieldset :send_by_post, multiple: false, legend: nil do %>
@@ -28,7 +27,7 @@
           <% end -%>
         <% end -%>
       <% end %>
-      <%# Continue %>
+
       <%= f.continue_button %>
     <% end -%>
   </div>

--- a/app/views/prior_authority/steps/further_information/edit.html.erb
+++ b/app/views/prior_authority/steps/further_information/edit.html.erb
@@ -20,7 +20,11 @@
         <%= t(".supporting_documentation_caption_html", size: FileUpload::FileUploader.human_readable_max_file_size) %>
       </span>
 
-      <%= render 'shared/multifile_upload', supporting_documents: @form_object.supporting_documents, form: form, locale_prefix: 'prior_authority.steps.further_information.edit' %>
+      <%= render 'shared/multifile_upload',
+          supporting_documents: @form_object.supporting_documents,
+          form: form,
+          locale_prefix: 'prior_authority.steps.further_information.edit' %>
+
       <%= form.continue_button %>
     <% end %>
   </div>

--- a/app/views/shared/_multifile_upload.html.erb
+++ b/app/views/shared/_multifile_upload.html.erb
@@ -26,7 +26,7 @@
       <tbody class="govuk-table__body moj-multi-file-upload__list">
       <% supporting_documents.each_with_index do |record, index| %>
         <tr class="govuk-table__row moj-multi-file-upload__row" id="<%= index %>" >
-          <td class="govuk-table__cell moj-multi-file-upload__filename">
+          <td class="govuk-table__cell moj-multi-file-upload__filename_progress">
             <span class="moj-multi-file-upload__filename"><%= record.file_name %></span>
             <span class="moj-multi-file-upload__progress">100%</span></td>
           <td class="govuk-table__cell moj-multi-file-upload__actions">

--- a/spec/factories/further_informations.rb
+++ b/spec/factories/further_informations.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :further_information do
-    information_requested { 'please provider further evidence' }
+    information_requested { 'please provide further evidence' }
     information_supplied { nil }
     caseworker_id { '87e88ac6-d89a-4180-80d4-e03285023fb0' }
     requested_at { DateTime.new(2024, 1, 1, 1, 1, 1) }

--- a/spec/presenters/prior_authority/check_answers/further_information_card_spec.rb
+++ b/spec/presenters/prior_authority/check_answers/further_information_card_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe PriorAuthority::CheckAnswers::FurtherInformationCard do
           [
             {
               head_key: 'information_requested',
-              text: '<p>please provider further evidence</p>',
+              text: '<p>please provide further evidence</p>',
             },
             {
               head_key: 'information_supplied',

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
                 document_type: 'supporting_document'
               }
             ],
-            information_requested: 'please provider further evidence',
+            information_requested: 'please provide further evidence',
             information_supplied: 'here is the extra information you requested',
             requested_at: DateTime.new(2024, 1, 1, 1, 1, 1),
           }

--- a/spec/system/nsm/supporting_evidence_spec.rb
+++ b/spec/system/nsm/supporting_evidence_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require 'system_helper'
 
 RSpec.describe 'User can provide supporting evidence', type: :system do
   let(:claim) { create(:claim, :complete) }

--- a/spec/system/nsm/supporting_evidence_spec.rb
+++ b/spec/system/nsm/supporting_evidence_spec.rb
@@ -94,4 +94,26 @@ RSpec.describe 'User can provide supporting evidence', type: :system do
       expect(page).to have_no_content 'If you do not upload this evidence'
     end
   end
+
+  context 'when submitting evidence', :javascript, type: :system do
+    let(:claim) { create(:claim) }
+
+    before do
+      visit provider_saml_omniauth_callback_path
+      visit edit_nsm_steps_supporting_evidence_path(claim.id)
+    end
+
+    it 'Allows me to upload and delete evidence' do
+      expect(page).to have_no_content('test_2.png')
+
+      find('.moj-multi-file-upload__dropzone').drop(file_fixture('test_2.png'))
+
+      within('.govuk-table') { expect(page).to have_content(/test_2.png\s+100%\s+Delete/) }
+
+      click_on 'Delete'
+
+      within('.moj-banner') { expect(page).to have_content('test_2.png has been deleted') }
+      expect(page).to have_no_css('.govuk-table')
+    end
+  end
 end

--- a/spec/system/prior_authority/further_information_request_spec.rb
+++ b/spec/system/prior_authority/further_information_request_spec.rb
@@ -1,0 +1,54 @@
+require 'system_helper'
+
+RSpec.describe 'Prior authority applications - provider responds to further information request',
+               :javascript, type: :system do
+  let(:application) { create(:prior_authority_application, :with_further_information_request) }
+
+  before do
+    visit provider_saml_omniauth_callback_path
+    visit edit_prior_authority_steps_further_information_path(application)
+  end
+
+  it 'displays requested information' do
+    expect(page).to have_title('Further information requested')
+    expect(page).to have_content('Your application needs the following further information to proceed')
+    expect(page).to have_content('please provide further evidence')
+  end
+
+  it 'allows user to submit further information without attachments' do
+    fill_in 'Enter the information requested', with: 'here is the information requested'
+
+    click_on 'Save and continue'
+
+    expect(application.reload.further_informations.first)
+      .to have_attributes(
+        information_supplied: 'here is the information requested'
+      )
+  end
+
+  it 'allows user to submit further information with attachments' do
+    fill_in 'Enter the information requested', with: 'here is the information requested'
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+    click_on 'Save and continue'
+
+    expect(application.reload.further_informations.first)
+      .to have_attributes(
+        information_supplied: 'here is the information requested'
+      )
+
+    expect(application.further_informations.first.supporting_documents.first.file_name).to eq 'test.png'
+  end
+
+  it 'allows user to upload and delete attachments' do
+    expect(page).to have_no_content('test.png')
+
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+
+    within('.govuk-table') { expect(page).to have_content(/test.png\s+100%\s+Delete/) }
+
+    click_on 'Delete'
+
+    within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
+    expect(page).to have_no_css('.govuk-table')
+  end
+end

--- a/spec/system/prior_authority/reason_why_spec.rb
+++ b/spec/system/prior_authority/reason_why_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Prior authority applications - add case contact', :javascript, t
     click_on 'Reason for prior authority'
   end
 
-  it 'can have a reason without attachments' do
+  it 'allows user to submit a reason without attachments' do
     fill_in 'Why is prior authority required?', with: 'important reasons'
 
     click_on 'Save and continue'
@@ -21,17 +21,27 @@ RSpec.describe 'Prior authority applications - add case contact', :javascript, t
     )
   end
 
-  it 'can have a reason with attachments' do
-    # Bypass malware scanning in test environment
-    allow(Clamby).to receive(:safe?).and_return(true)
-
+  it 'allows user to submit a reason with attachments' do
     fill_in 'Why is prior authority required?', with: 'important reasons'
-    find('.moj-multi-file-upload__dropzone').drop(Rails.root.join('spec/support/assets/test.png'))
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
     click_on 'Save and continue'
 
     expect(application.reload).to have_attributes(
       reason_why: 'important reasons'
     )
     expect(application.supporting_documents.first.file_name).to eq 'test.png'
+  end
+
+  it 'allows user to upload and delete attachments' do
+    expect(page).to have_no_content('test.png')
+
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+
+    within('.govuk-table') { expect(page).to have_content(/test.png\s+100%\s+Delete/) }
+
+    click_on 'Delete'
+
+    within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
+    expect(page).to have_no_css('.govuk-table')
   end
 end

--- a/spec/system/support/screenshot_helper.rb
+++ b/spec/system/support/screenshot_helper.rb
@@ -1,0 +1,29 @@
+module ScreenshotHelper
+  # selenium headless chrome solution for full screenshot
+  def screenshot_and_open_image
+    file_path = screenshot_image
+    Launchy.open file_path
+  end
+
+  # rubocop:disable Lint/Debugger
+  def screenshot_image(name = 'capybara-screenshot')
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(*dimensions)
+    screenshot_name = "#{Time.current.utc.iso8601.delete('-').delete(':')}-#{name}.png"
+    file_path = Rails.root.join("tmp/capybara/#{screenshot_name}").to_s
+    save_screenshot(file_path)
+    file_path
+  end
+  # rubocop:enable Lint/Debugger
+
+  def dimensions
+    driver = Capybara.current_session.driver
+    total_width = driver.execute_script('return document.body.offsetWidth')
+    total_height = driver.execute_script('return document.body.scrollHeight')
+    [total_width, total_height]
+  end
+end
+
+RSpec.configure do |config|
+  config.include ScreenshotHelper, type: :system
+end


### PR DESCRIPTION
## Description of change
Supporting evidence delete button fix

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1600)

Fix delete link  functionality on NSM supporting evidence page.

- [X] Supply csrf token to ajax call in headers
- [X] Replace mechanism (ignore authenticity token) for other upload pages
- [X] Fix file deletion flash message - "{index} file has been deleted" --> "{filename} file has been deleted"
- [x] Write system spec to cover this behaviour for NSM, plus equivalent regression tests for PA.
