### PR TITLE
Crm457 1612 fix translation

### DIFF
--- a/app/forms/prior_authority/quote_cost_validations.rb
+++ b/app/forms/prior_authority/quote_cost_validations.rb
@@ -11,7 +11,7 @@ module PriorAuthority
 
       with_options if: :per_item? do
         validates :items, item_type_dependant: { pluralize: true }
-        validates :cost_per_item, item_type_dependant: true
+        validates :cost_per_item, cost_item_type_dependant: true
       end
 
       with_options if: :per_hour? do

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -51,9 +51,7 @@ module PriorAuthority
         service_rule.cost_item
       end
 
-      def cost_multiplier
-        service_rule.cost_multiplier
-      end
+      delegate :cost_multiplier, to: :service_rule
 
       def service_name
         if service_type == QuoteServices.new(:custom)

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -51,6 +51,10 @@ module PriorAuthority
         service_rule.cost_item
       end
 
+      def cost_multiplier
+        service_rule.cost_multiplier
+      end
+
       def service_name
         if service_type == QuoteServices.new(:custom)
           application.custom_service_name
@@ -68,7 +72,7 @@ module PriorAuthority
       def item_cost
         return 0 unless cost_per_item.to_f.positive? && items.to_i.positive?
 
-        cost_per_item * items * service_rule.cost_multiplier
+        cost_per_item * items * cost_multiplier
       end
 
       def time_cost

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -47,6 +47,10 @@ module PriorAuthority
         service_rule.item
       end
 
+      def cost_item_type
+        service_rule.cost_item
+      end
+
       def service_name
         if service_type == QuoteServices.new(:custom)
           application.custom_service_name

--- a/app/forms/prior_authority/steps/quote_cost_form.rb
+++ b/app/forms/prior_authority/steps/quote_cost_form.rb
@@ -68,7 +68,7 @@ module PriorAuthority
       def item_cost
         return 0 unless cost_per_item.to_f.positive? && items.to_i.positive?
 
-        cost_per_item * items
+        cost_per_item * items * service_rule.cost_multiplier
       end
 
       def time_cost

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -14,7 +14,7 @@ module PriorAuthority
            QuoteServices::TRANSLATION_AND_TRANSCRIPTION
         new(cost_type: :per_item, item: 'minute')
       when QuoteServices::TRANSLATION_DOCUMENTS
-        new(cost_type: :per_item, item: 'word', cost_item: 'thousand_words')
+        new(cost_type: :per_item, item: 'word', cost_item: 'thousand_words', cost_multiplier: 0.001)
       when QuoteServices::PHOTOCOPYING
         new(cost_type: :per_item, item: 'page')
       when QuoteServices::DNA_REPORT,
@@ -28,14 +28,15 @@ module PriorAuthority
     end
     # rubocop:enable Metrics/MethodLength
 
-    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item', cost_item: item)
+    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item', cost_item: item, cost_multiplier: 1)
       @court_order_relevant = court_order_relevant
       @post_mortem_relevant = post_mortem_relevant
       @cost_type = cost_type
       @item = item
       @cost_item = cost_item
+      @cost_multiplier = cost_multiplier
     end
 
-    attr_reader :court_order_relevant, :post_mortem_relevant, :cost_type, :item, :cost_item
+    attr_reader :court_order_relevant, :post_mortem_relevant, :cost_type, :item, :cost_item, :cost_multiplier
   end
 end

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -28,7 +28,8 @@ module PriorAuthority
     end
     # rubocop:enable Metrics/MethodLength
 
-    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item', cost_item: item, cost_multiplier: 1)
+    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item',
+                   cost_item: item, cost_multiplier: 1)
       @court_order_relevant = court_order_relevant
       @post_mortem_relevant = post_mortem_relevant
       @cost_type = cost_type

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -14,7 +14,7 @@ module PriorAuthority
            QuoteServices::TRANSLATION_AND_TRANSCRIPTION
         new(cost_type: :per_item, item: 'minute')
       when QuoteServices::TRANSLATION_DOCUMENTS
-        new(cost_type: :per_item, item: 'word')
+        new(cost_type: :per_item, item: 'word', cost_item: 'thousand words')
       when QuoteServices::PHOTOCOPYING
         new(cost_type: :per_item, item: 'page')
       when QuoteServices::DNA_REPORT,
@@ -28,13 +28,14 @@ module PriorAuthority
     end
     # rubocop:enable Metrics/MethodLength
 
-    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item')
+    def initialize(court_order_relevant: false, post_mortem_relevant: false, cost_type: :per_hour, item: 'item', cost_item: item)
       @court_order_relevant = court_order_relevant
       @post_mortem_relevant = post_mortem_relevant
       @cost_type = cost_type
       @item = item
+      @cost_item = cost_item
     end
 
-    attr_reader :court_order_relevant, :post_mortem_relevant, :cost_type, :item
+    attr_reader :court_order_relevant, :post_mortem_relevant, :cost_type, :item, :cost_item
   end
 end

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -14,7 +14,7 @@ module PriorAuthority
            QuoteServices::TRANSLATION_AND_TRANSCRIPTION
         new(cost_type: :per_item, item: 'minute')
       when QuoteServices::TRANSLATION_DOCUMENTS
-        new(cost_type: :per_item, item: 'word', cost_item: 'thousand_words', cost_multiplier: 0.001)
+        new(cost_type: :per_item, item: 'word', cost_item: 'thousand_words', cost_multiplier: BigDecimal('0.001'))
       when QuoteServices::PHOTOCOPYING
         new(cost_type: :per_item, item: 'page')
       when QuoteServices::DNA_REPORT,

--- a/app/lib/prior_authority/service_type_rule.rb
+++ b/app/lib/prior_authority/service_type_rule.rb
@@ -14,7 +14,7 @@ module PriorAuthority
            QuoteServices::TRANSLATION_AND_TRANSCRIPTION
         new(cost_type: :per_item, item: 'minute')
       when QuoteServices::TRANSLATION_DOCUMENTS
-        new(cost_type: :per_item, item: 'word', cost_item: 'thousand words')
+        new(cost_type: :per_item, item: 'word', cost_item: 'thousand_words')
       when QuoteServices::PHOTOCOPYING
         new(cost_type: :per_item, item: 'page')
       when QuoteServices::DNA_REPORT,

--- a/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority/quote_payload_builder.rb
@@ -27,7 +27,9 @@ class SubmitToAppStore
       def primary_quote_attributes
         {
           cost_type: service_cost_form.cost_type,
-          item_type: service_cost_form.item_type
+          item_type: service_cost_form.item_type,
+          cost_item_type: service_cost_form.cost_item_type,
+          cost_multiplier: service_cost_form.cost_multiplier
         }
       end
 

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -2,7 +2,7 @@ class CostItemTypeDependantValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     cost_item_type = cost_item_type_for(record)
     cost_item_type = cost_item_type.pluralize if options[:pluralize]
-    cost_type_translated = I18n.t("prior_authority.steps.service_cost.items.#{cost_item_type.to_s}")
+    cost_type_translated = I18n.t("prior_authority.steps.service_cost.items.#{cost_item_type}")
 
     record.errors.add(attribute, :blank, item_type: cost_type_translated) if value.blank?
     record.errors.add(attribute, :not_a_number, item_type: cost_type_translated) if value.is_a?(String)

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -1,0 +1,15 @@
+class CostItemTypeDependantValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    cost_item_type = cost_item_type_for(record)
+    cost_item_type = cost_item_type.pluralize if options[:pluralize]
+    formatted_cost_item_type = cost_item_type.humanize.downcase
+
+    record.errors.add(attribute, :blank, item_type: formatted_cost_item_type) if value.blank?
+    record.errors.add(attribute, :not_a_number, item_type: formatted_cost_item_type) if value.is_a?(String)
+    record.errors.add(attribute, :greater_than, item_type: formatted_cost_item_type) if value.to_d <= 0
+  end
+
+  def cost_item_type_for(record)
+    record.respond_to?(:cost_item_type) ? record.cost_item_type || 'item' : 'item'
+  end
+end

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -2,11 +2,11 @@ class CostItemTypeDependantValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     cost_item_type = cost_item_type_for(record)
     cost_item_type = cost_item_type.pluralize if options[:pluralize]
-    formatted_cost_item_type = cost_item_type.humanize.downcase
+    cost_type_translated = I18n.t("prior_authority.steps.service_cost.items.#{cost_item_type.to_s}")
 
-    record.errors.add(attribute, :blank, item_type: formatted_cost_item_type) if value.blank?
-    record.errors.add(attribute, :not_a_number, item_type: formatted_cost_item_type) if value.is_a?(String)
-    record.errors.add(attribute, :greater_than, item_type: formatted_cost_item_type) if value.to_d <= 0
+    record.errors.add(attribute, :blank, item_type: cost_type_translated) if value.blank?
+    record.errors.add(attribute, :not_a_number, item_type: cost_type_translated) if value.is_a?(String)
+    record.errors.add(attribute, :greater_than, item_type: cost_type_translated) if value.to_d <= 0
   end
 
   def cost_item_type_for(record)

--- a/app/views/prior_authority/steps/primary_quote_summary/_service_cost_subtable.html.erb
+++ b/app/views/prior_authority/steps/primary_quote_summary/_service_cost_subtable.html.erb
@@ -11,7 +11,7 @@
         </th>
         <th scope="col" class="govuk-table__header">
           <%= t('prior_authority.steps.service_cost.items.cost_per_item',
-                item: t("prior_authority.steps.service_cost.items.#{costs.item_type}")) %>
+                item: t("prior_authority.steps.service_cost.items.#{costs.cost_item_type}")) %>
         </th>
       <% else %>
         <th scope="col" class="govuk-table__header"><%= t('.period') %></th>

--- a/app/views/prior_authority/steps/service_cost/_items.html.erb
+++ b/app/views/prior_authority/steps/service_cost/_items.html.erb
@@ -5,4 +5,4 @@
                           prefix_text: "&pound;".html_safe,
                           inputmode: "decimal",
                           value: gbp_field_value(@form_object.cost_per_item),
-                          label: { text: t('.cost_per_item', item: t(".#{@form_object.item_type}")), size: size } %>
+                          label: { text: t('.cost_per_item', item: t(".#{@form_object.cost_item_type}")), size: size } %>

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -127,6 +127,7 @@ en:
           item: item
           minute: minute
           word: word
+          thousand_words: thousand words
           page: page
         time:
           period: Time

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -127,7 +127,7 @@ en:
           item: item
           minute: minute
           word: word
-          thousand_words: thousand words
+          thousand_words: 1000 words
           page: page
         time:
           period: Time

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -87,6 +87,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             cost_per_item: nil,
             items: nil,
             item_type: 'item',
+            cost_item_type: 'item',
+            cost_multiplier: 1,
             ordered_by_court: nil,
             related_to_post_mortem: true,
             id: application.primary_quote.id,

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -118,6 +118,8 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
             cost_per_item: nil,
             items: nil,
             item_type: 'item',
+            cost_item_type: 'item',
+            cost_multiplier: 1,
             ordered_by_court: nil,
             related_to_post_mortem: true,
             id: application.alternative_quotes.first.id,

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         click_on 'Save and continue'
         expect(page)
           .to have_content('Enter the number of words')
-          .and have_content('Enter the cost per thousand words')
+          .and have_content('Enter the cost per 1000 words')
       end
     end
 

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       let(:service_type) { 'translation_documents' }
 
       it 'asks a question about words' do
-        expect(page).to have_content 'What is the cost per word?'
+        expect(page).to have_content 'What is the cost per thousand words?'
       end
 
       it 'validates appropriately with partial data' do

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
       let(:service_type) { 'translation_documents' }
 
       it 'asks a question about words' do
-        expect(page).to have_content 'What is the cost per thousand words?'
+        expect(page).to have_content 'What is the cost per 1000 words?'
       end
 
       it 'validates appropriately with partial data' do

--- a/spec/system/prior_authority/alternative_quotes_spec.rb
+++ b/spec/system/prior_authority/alternative_quotes_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'Prior authority applications - alternative quote' do
         click_on 'Save and continue'
         expect(page)
           .to have_content('Enter the number of words')
-          .and have_content('Enter the cost per word')
+          .and have_content('Enter the cost per thousand words')
       end
     end
 

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Prior authority applications - add service costs' do
       click_on 'Save and continue'
       expect(page)
         .to have_content('Enter the number of words')
-        .and have_content('Enter the cost per thousand words')
+        .and have_content('Enter the cost per 1000 words')
     end
   end
 

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Prior authority applications - add service costs' do
     let(:service_type) { 'Translation (documents)' }
 
     it 'asks a question about words' do
-      expect(page).to have_content 'What is the cost per word?'
+      expect(page).to have_content 'What is the cost per thousand words?'
     end
 
     it 'validates appropriately with partial data' do

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Prior authority applications - add service costs' do
     let(:service_type) { 'Translation (documents)' }
 
     it 'asks a question about words' do
-      expect(page).to have_content 'What is the cost per thousand words?'
+      expect(page).to have_content 'What is the cost per 1000 words?'
     end
 
     it 'validates appropriately with partial data' do

--- a/spec/system/prior_authority/service_cost_spec.rb
+++ b/spec/system/prior_authority/service_cost_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Prior authority applications - add service costs' do
       click_on 'Save and continue'
       expect(page)
         .to have_content('Enter the number of words')
-        .and have_content('Enter the cost per word')
+        .and have_content('Enter the cost per thousand words')
     end
   end
 

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe CostItemTypeDependantValidator do
           ActiveModel::Name.new(self, nil, 'temp')
         end
 
-        attribute :item_type, :string
+        attribute :cost_item_type, :string
 
         attribute :items
         attribute :cost_per_item, :gbp
@@ -106,7 +106,7 @@ RSpec.describe CostItemTypeDependantValidator do
       it 'include item type option from model, pluralizing if option set' do
         instance.validate
         expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
-        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('thousand words')
+        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('1000 words')
       end
     end
   end

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe CostItemTypeDependantValidator do
 
       it 'include item type option from model, pluralizing if option set' do
         instance.validate
-        expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
+        expect(instance.errors.details[:items].flat_map(&:values)).to include('1000 words')
         expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('1000 words')
       end
     end

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe CostItemTypeDependantValidator do
+  subject(:instance) { klass.new(items:, cost_per_item:) }
+
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, 'temp')
+      end
+
+      attribute :items
+      attribute :cost_per_item, :gbp
+
+      validates :items, cost_item_type_dependant: { pluralize: true }
+      validates :cost_per_item, cost_item_type_dependant: true
+    end
+  end
+
+  context 'when attribute is a positive number' do
+    let(:items) { 1 }
+    let(:cost_per_item) { 100 }
+
+    it 'form object is valid' do
+      expect(instance).to be_valid
+    end
+  end
+
+  context 'when attribute is a positive number less than one' do
+    let(:items) { 1 }
+    let(:cost_per_item) { 0.1 }
+
+    it 'form object is valid' do
+      expect(instance).to be_valid
+    end
+  end
+
+  context 'when attribute is nil' do
+    let(:items) { nil }
+    let(:cost_per_item) { nil }
+
+    it 'adds blank error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :blank)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :blank)).to be(true)
+    end
+
+    it 'adds item_type option to error object' do
+      instance.validate
+      expect(instance.errors.map(&:options)).to all(include(:item_type))
+    end
+  end
+
+  context 'when attribute is a string' do
+    let(:items) { 'one' }
+    let(:cost_per_item) { '100 hundred' }
+
+    it 'adds not_a_number error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :not_a_number)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :not_a_number)).to be(true)
+    end
+  end
+
+  context 'when attribute is less zero or less' do
+    let(:items) { 0 }
+    let(:cost_per_item) { 0 }
+
+    it 'adds greater_than error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :greater_than)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
+    end
+  end
+
+  context 'when model has an cost_item_type attribute' do
+    subject(:instance) { klass.new(items:, cost_per_item:, cost_item_type:) }
+
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, 'temp')
+        end
+
+        attribute :item_type, :string
+
+        attribute :items
+        attribute :cost_per_item, :gbp
+
+        validates :items, cost_item_type_dependant: { pluralize: true }
+        validates :cost_per_item, cost_item_type_dependant: true
+      end
+    end
+
+    context 'when attribute is nil' do
+      let(:items) { nil }
+      let(:cost_per_item) { nil }
+      let(:cost_item_type) { 'thousand_word' }
+
+      it 'include item type option from model, pluralizing if option set' do
+        instance.validate
+        expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
+        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('thousand words')
+      end
+    end
+  end
+end

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe CostItemTypeDependantValidator do
     context 'when attribute is nil' do
       let(:items) { nil }
       let(:cost_per_item) { nil }
-      let(:cost_item_type) { 'thousand_word' }
+      let(:cost_item_type) { 'thousand_words' }
 
       it 'include item type option from model, pluralizing if option set' do
         instance.validate


### PR DESCRIPTION
## Description of change

 [CRM4 - Content Change - Service Type - Translation (documents)](https://dsdmoj.atlassian.net/browse/CRM457-1612)
 

-  Add Cost Multiplier To Service Type Rules
-  Default Cost Multiplier To 1 If Not Provided In Initiailization
-  Set Cost Multiplier To 0.001 For Translation (documents)
-  Use Cost Multiplier In Service Cost Form
-  Add Cost Item to Service Type Rule For Alternate Qualifiers (such as thousand words instead of words)
- Update Tests
