### PR TITLE
CRM457-1617: Add progress bar and check mark to denote successful upload

### DIFF
--- a/app/javascript/file-upload.js
+++ b/app/javascript/file-upload.js
@@ -25,19 +25,22 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
         data: formData,
         processData: false,
         contentType: false,
-        success: $.proxy(function (response) {
+
+        success: function (response) {
             feedback.html(this.getSuccessHtml(`${response.success.file_name} has been uploaded`));
             this.status.html(`${response.success.file_name} has been uploaded`);
             item.find(`a.remove-link.moj-multi-file-upload__delete`).attr("value", response.success.evidence_id ?? file.name)
             item.find(`a.remove-link.moj-multi-file-upload__delete`).removeClass('govuk-!-display-none')
             this.params.uploadFileExitHook(this, file, response);
-        }, this),
-        error: $.proxy(function (jqXHR, textStatus, errorThrown) {
+        }.bind(this),
+
+        error: function (jqXHR, textStatus, errorThrown) {
             feedback.html(this.getErrorHtml(jqXHR.responseJSON.error.message));
             this.status.html(jqXHR.responseJSON.error.message);
             this.feedbackContainer.find(`#${fileListLength}`).remove();
             this.params.uploadFileErrorHook(this, file, jqXHR, textStatus, errorThrown);
-        }, this),
+        }.bind(this),
+
         xhr: function () {
             var xhr = new XMLHttpRequest();
             xhr.upload.addEventListener('progress', function (e) {
@@ -78,19 +81,21 @@ MOJFrontend.MultiFileUpload.prototype.onFileDeleteClick = function (e) {
     $.ajax({
         url: `${this.params.deleteUrl}?evidence_id=${button.attr('value')}`,
         type: 'delete',
-        success: $.proxy(function (response) {
+
+        success: function (response) {
             feedback.html(this.getSuccessHtml(`${fileName} has been deleted`));
             button.parents('.moj-multi-file-upload__row').remove();
             if (this.feedbackContainer.find('.moj-multi-file-upload__row').length === 0) {
                 this.feedbackContainer.addClass('moj-hidden');
             }
             this.params.fileDeleteHook(this, response);
-        }, this),
-        error: $.proxy(function (jqXHR, textStatus, errorThrown) {
+        }.bind(this),
+
+        error: function (jqXHR, textStatus, errorThrown) {
             feedback.html(this.getErrorHtml(jqXHR.responseJSON.error.message));
             this.status.html(jqXHR.responseJSON.error.message);
             this.params.fileDeleteHook(this, jqXHR, textStatus, errorThrown);
-        }, this),
+        }.bind(this),
     });
 };
 MOJFrontend.MultiFileUpload.prototype.onDrop = function (e) {
@@ -143,4 +148,3 @@ $(function(){
     headers: { 'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content') }
   });
 });
-

--- a/app/javascript/file-upload.js
+++ b/app/javascript/file-upload.js
@@ -9,9 +9,14 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
     let formData = new FormData();
     formData.append('documents', file);
     let fileListLength = this.feedbackContainer.find('.govuk-table__row.moj-multi-file-upload__row').length
-    let item = $(this.getFileRowHtml(file, fileListLength));
+    let fileRow = $(this.getFileRowHtml(file, fileListLength, 0));
     let feedback = $(".moj-multi-file-upload__message");
-    this.feedbackContainer.find('.moj-multi-file-upload__list').append(item);
+    this.feedbackContainer.find('.moj-multi-file-upload__list').append(fileRow);
+
+    let checkSvg =
+      `<svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+          <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path>
+      </svg>`
 
     if (file.size > maxFileSize) {
         this.feedbackContainer.find(`#${fileListLength}`).remove();
@@ -29,8 +34,9 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
         success: function (response) {
             feedback.html(this.getSuccessHtml(`${response.success.file_name} has been uploaded`));
             this.status.html(`${response.success.file_name} has been uploaded`);
-            item.find(`a.remove-link.moj-multi-file-upload__delete`).attr("value", response.success.evidence_id ?? file.name)
-            item.find(`a.remove-link.moj-multi-file-upload__delete`).removeClass('govuk-!-display-none')
+            fileRow.find(`a.remove-link.moj-multi-file-upload__delete`).attr("value", response.success.evidence_id ?? file.name)
+            fileRow.find(`a.remove-link.moj-multi-file-upload__delete`).removeClass('govuk-!-display-none')
+            fileRow.find('progress').replaceWith(checkSvg)
             this.params.uploadFileExitHook(this, file, response);
         }.bind(this),
 
@@ -45,9 +51,9 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
             var xhr = new XMLHttpRequest();
             xhr.upload.addEventListener('progress', function (e) {
                 if (e.lengthComputable) {
-                    var percentComplete = e.loaded / e.total;
-                    percentComplete = parseInt(percentComplete * 100, 10);
-                    item.find('.moj-multi-file-upload__progress').text(' ' + percentComplete + '%');
+                  var percentComplete = e.loaded / e.total;
+                  percentComplete = parseInt(percentComplete * 100, 10);
+                  fileRow.find('progress').prop('value', percentComplete).text(percentComplete + '%');
                 }
             }, false);
             return xhr;
@@ -55,15 +61,18 @@ MOJFrontend.MultiFileUpload.prototype.uploadFile = function (file) {
     });
 };
 
-MOJFrontend.MultiFileUpload.prototype.getFileRowHtml = function (file, fileListLength) {
+MOJFrontend.MultiFileUpload.prototype.getFileRowHtml = function (file, fileListLength, percentComplete) {
     return `<tr class="govuk-table__row moj-multi-file-upload__row" id="${fileListLength}">
-            <td class="govuk-table__cell moj-multi-file-upload__filename_progress">
-                <span class="moj-multi-file-upload__filename"> ${file.name}</span>
-                <span class="moj-multi-file-upload__progress">(0%)</span></td>
+            <td class="govuk-table__cell moj-multi-file-upload__filename" data-label="File name">
+              <span class="file-name">${file.name}</span>
+            </td>
+            <td class="govuk-table__cell moj-multi-file-upload__progress" data-label="Upload Progress">
+              <progress value="0" max="100">0%</progress>
+            </td>
             <td class="govuk-table__cell moj-multi-file-upload__actions">
-                <a class="remove-link moj-multi-file-upload__delete govuk-!-display-none" href="#0" value="${file.name}">Delete
+              <a class="remove-link moj-multi-file-upload__delete govuk-!-display-none" href="#0" value="${file.name}">Delete
                 <span class="govuk-visually-hidden">${file.name}</span>
-                </a>
+              </a>
             </td>
         </tr>`;
 };

--- a/app/views/shared/_multifile_upload.html.erb
+++ b/app/views/shared/_multifile_upload.html.erb
@@ -19,6 +19,7 @@
       <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">File name</th>
+        <th scope="col" class="govuk-table__header">Upload progress</th>
         <th scope="col" class="govuk-table__header">Action</th>
       </tr>
       </thead>
@@ -26,9 +27,14 @@
       <tbody class="govuk-table__body moj-multi-file-upload__list">
       <% supporting_documents.each_with_index do |record, index| %>
         <tr class="govuk-table__row moj-multi-file-upload__row" id="<%= index %>" >
-          <td class="govuk-table__cell moj-multi-file-upload__filename_progress">
-            <span class="moj-multi-file-upload__filename"><%= record.file_name %></span>
-            <span class="moj-multi-file-upload__progress">100%</span></td>
+          <td class="govuk-table__cell moj-multi-file-upload__filename" data-label="File name">
+            <span class="file-name"><%= record.file_name %></span>
+          </td>
+          <td class="govuk-table__cell moj-multi-file-upload__progress" data-label="Upload Progress">
+            <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+              <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path>
+            </svg>
+          </td>
           <td class="govuk-table__cell moj-multi-file-upload__actions">
             <a class="remove-link moj-multi-file-upload__delete" href="#0" value="<%= record.id %>">Delete
               <span class="govuk-visually-hidden"><%= record.id %></span>

--- a/spec/system/nsm/supporting_evidence_spec.rb
+++ b/spec/system/nsm/supporting_evidence_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'User can provide supporting evidence', type: :system do
 
       find('.moj-multi-file-upload__dropzone').drop(file_fixture('test_2.png'))
 
-      within('.govuk-table') { expect(page).to have_content(/test_2.png\s+100%\s+Delete/) }
+      within('.govuk-table') { expect(page).to have_content(/test_2.png.*Delete/) }
 
       click_on 'Delete'
 

--- a/spec/system/prior_authority/further_information_request_spec.rb
+++ b/spec/system/prior_authority/further_information_request_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Prior authority applications - provider responds to further info
 
     find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
 
-    within('.govuk-table') { expect(page).to have_content(/test.png\s+100%\s+Delete/) }
+    within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
 
     click_on 'Delete'
 

--- a/spec/system/prior_authority/reason_why_spec.rb
+++ b/spec/system/prior_authority/reason_why_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Prior authority applications - add case contact', :javascript, t
 
     find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
 
-    within('.govuk-table') { expect(page).to have_content(/test.png\s+100%\s+Delete/) }
+    within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
 
     click_on 'Delete'
 


### PR DESCRIPTION
## Description of change
Add progress bar and check mark to denote successful upload

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1617)

- [X] Remove deprecated proxy usage in file upload
- [X] Display progress bar and checkmark on successful upload
- [X] Disable save buttons while upload in progress
- [X] Display file and warning symbol when upload failed 


This mechanism overides the MOJFrontend uploadFiles (not the plural)
method and leverages promises and async functions to wait for ALL
uploads to complete before re-enabling.

It also changes the behaviour to NOT hide/remove failed uploads but rather
display them with a warning icon. This is because in such instances
the top level feedback warning may be overwritten by successful uploads
in the same drag and drop batch, leaving the user unaware their upload for
one or more of their files failed.



### After changes:

<img width="497" alt="Screenshot 2024-06-14 at 09 14 23" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/c76af7f0-f7dc-4239-a6f6-3af317cfa6f8">


https://www.loom.com/share/b1f93a88a43b4f49849718f1d5e2878a?sid=e996c454-f8f5-4ddd-83d7-7c662a95dc63
