### PR TITLE
CRM457-1649: Only display prior authority for other type disbursements

### DIFF
--- a/app/views/nsm/steps/view_claim/disbursement.html.erb
+++ b/app/views/nsm/steps/view_claim/disbursement.html.erb
@@ -30,7 +30,7 @@
         [{ text: t(".date"), width: 'govuk-!-width-one-half' }, disbursement.disbursement_date.strftime('%-d %B %Y')],
         [t(".type"), disbursement.translated_disbursement_type],
         [t(".details"), multiline_text(disbursement.details)],
-        [t(".prior_auth"), disbursement.prior_authority.humanize],
+        ([t(".prior_auth"), disbursement.prior_authority.humanize] if disbursement.prior_authority),
         ([t(".miles"), t(".mileage", count: disbursement.miles, miles: NumberTo.formatted(disbursement.miles))] if disbursement.miles),
         [t(".net_cost"), NumberTo.pounds(disbursement.total_cost_pre_vat)],
         [t(".vat"), NumberTo.pounds(disbursement.vat)],

--- a/spec/system/nsm/view_claim/disbursement_spec.rb
+++ b/spec/system/nsm/view_claim/disbursement_spec.rb
@@ -1,0 +1,95 @@
+require 'system_helper'
+
+RSpec.describe 'View disbursement after submission', :javascript, type: :system do
+  before do
+    visit provider_saml_omniauth_callback_path
+    click_link 'Accept analytics cookies'
+
+    visit item_nsm_steps_view_claim_path(id: claim, item_type: 'disbursement', item_id: disbursement.id)
+  end
+
+  let(:some_date) { 1.month.ago.to_date }
+  let(:claim) { create(:claim) }
+
+  context 'With a "mileage" type disbursement' do
+    let(:disbursement) do
+      create(:disbursement,
+             disbursement_type: DisbursementTypes::CAR.to_s,
+             other_type: nil,
+             disbursement_date: some_date,
+             details: 'I need it...',
+             miles: 101,
+             apply_vat: 'true',
+             claim: claim)
+    end
+
+    it 'displays the expected title' do
+      expect(page).to have_title('Claim details')
+    end
+
+    it 'displays the expected h1' do
+      expect(page).to have_css('h1', text: 'Car mileage')
+    end
+
+    it 'displays the expected table caption' do
+      expect(page).to have_css('caption', text: 'Your claimed costs')
+    end
+
+    it 'displays the expected details for the disbursement' do
+      expect(page)
+        .to have_content("Date #{some_date.to_fs(:stamp)}")
+        .and have_content('Disbursement type Car mileage')
+        .and have_content('Disbursement description I need it')
+        .and have_content('Mileage 101 miles')
+        .and have_content('Net cost £45.45')
+        .and have_content('VAT £9.09')
+        .and have_content('Total cost £54.54')
+    end
+
+    it 'does not display the prior authority question and answer' do
+      expect(page).to have_no_content('Prior authority granted?')
+    end
+  end
+
+  context 'With an "other" type disbursement' do
+    let(:disbursement) do
+      create(:disbursement,
+             disbursement_type: DisbursementTypes::OTHER.to_s,
+             other_type: 'accident_reconstruction_report',
+             disbursement_date: some_date,
+             prior_authority: 'yes',
+             details: 'I need it...',
+             miles: nil,
+             total_cost_without_vat: 90.10,
+             apply_vat: 'true',
+             claim: claim)
+    end
+
+    it 'displays the expected title' do
+      expect(page).to have_title('Claim details')
+    end
+
+    it 'displays the expected h1' do
+      expect(page).to have_css('h1', text: 'Accident Reconstruction Report')
+    end
+
+    it 'displays the expected table caption' do
+      expect(page).to have_css('caption', text: 'Your claimed costs')
+    end
+
+    it 'displays the expected details for the disbursement' do
+      expect(page)
+        .to have_content("Date #{some_date.to_fs(:stamp)}")
+        .and have_content('Disbursement type Accident Reconstruction Report')
+        .and have_content('Disbursement description I need it')
+        .and have_content('Prior authority granted? Yes')
+        .and have_content('Net cost £90.10')
+        .and have_content('VAT £18.02')
+        .and have_content('Total cost £108.12')
+    end
+
+    it 'does not display the mileage question and answer' do
+      expect(page).to have_no_content('Mileage')
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Only display prior authority for "other" type disbursements

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)

Prior authority question is not asked for mileage disbursements

### Before changes:
:boom:

### After changes:

<img width="520" alt="Screenshot 2024-06-20 at 14 49 45" src="https://github.com/ministryofjustice/laa-submit-crime-forms/assets/7016425/db98ac82-81b8-46d8-9c98-f858c2e72d63">


