### PR TITLE
Exclude ping endpoints from sentry trace samples

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,18 +1,25 @@
 require Rails.root.join('lib/host_env')
 
+EXCLUDE_PATHS = %w[/ping /ping.json /health /health.json].freeze
+
 if ENV.fetch('SENTRY_DSN', nil).present?
   Sentry.init do |config|
     config.environment = HostEnv.env_name
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = [:active_support_logger]
     config.release = ENV.fetch('BUILD_TAG', 'unknown')
+
+    # Don't log RetryJobError exceptions in Sentry as they will have already been logged as part of the failed job
+    config.excluded_exceptions += ['RetryJobError']
+
     # Set traces_sample_rate to 1.0 to capture 100%
     # of transactions for performance monitoring.
     # We recommend adjusting this value in production.
-    config.traces_sample_rate = 0.05
-    # or
-    config.traces_sampler = lambda do |context|
-      true
+    config.traces_sampler = lambda do |sampling_context|
+      transaction_context = sampling_context[:transaction_context]
+      transaction_name = transaction_context[:name]
+
+      transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.05
     end
 
     # Opt in to new Rails error reporting API


### PR DESCRIPTION
## Description of change
The Sentry Projects should [ignore administrative endpoints](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/sentry.html#ignoring-transactions-on-administrative-endpoints)
