### PR TITLE
CRM457-1689: Changeable work types

### DIFF
--- a/app/models/concerns/work_item_costs.rb
+++ b/app/models/concerns/work_item_costs.rb
@@ -24,7 +24,7 @@ module WorkItemCosts
   end
 
   def allowed_total_cost
-    return total_cost if allowed_time_spent.nil? && allowed_uplift.nil?
+    return total_cost if allowed_time_spent.nil? && allowed_uplift.nil? && allowed_work_type.nil?
 
     uplifted_time_spent = apply_uplift!((allowed_time_spent || time_spent).to_d, allowed_uplift || uplift)
     # We need to use a Rational because some numbers divided by 60 cannot be accurately represented as a decimal,
@@ -39,6 +39,10 @@ module WorkItemCosts
 
   def pricing
     @pricing ||= Pricing.for(application)
+  end
+
+  def assessed_work_type
+    allowed_work_type.presence || work_type
   end
 
   private

--- a/app/models/concerns/work_item_costs.rb
+++ b/app/models/concerns/work_item_costs.rb
@@ -26,10 +26,11 @@ module WorkItemCosts
   def allowed_total_cost
     return total_cost if allowed_time_spent.nil? && allowed_uplift.nil?
 
+    uplifted_time_spent = apply_uplift!((allowed_time_spent || time_spent).to_d, allowed_uplift || uplift)
     # We need to use a Rational because some numbers divided by 60 cannot be accurately represented as a decimal,
     # and when summing up multiple work items with sub-penny precision, those small inaccuracies can lead to
     # a larger inaccuracy when the total is eventually rounded to 2 decimal places.
-    Rational(apply_uplift!((allowed_time_spent || time_spent).to_d, allowed_uplift || uplift) * pricing[work_type], 60)
+    Rational(uplifted_time_spent * pricing[assessed_work_type], 60)
   end
 
   def apply_uplift!(val, multipler = uplift)

--- a/app/models/work_item.rb
+++ b/app/models/work_item.rb
@@ -20,8 +20,8 @@ class WorkItem < ApplicationRecord
     )
   end
 
-  def translated_work_type
-    translations(work_type, 'nsm.steps.check_answers.show.sections.work_items')
+  def translated_work_type(value: :original)
+    translations(value == :assessed ? assessed_work_type : work_type, 'nsm.steps.check_answers.show.sections.work_items')
   end
 
   def sort_position
@@ -37,9 +37,5 @@ class WorkItem < ApplicationRecord
     return false if work_type.blank?
 
     WorkTypes::VALUES.detect { _1.to_s == work_type }.display?(application)
-  end
-
-  def assessed_work_type
-    allowed_work_type.presence || work_type
   end
 end

--- a/app/models/work_item.rb
+++ b/app/models/work_item.rb
@@ -38,4 +38,8 @@ class WorkItem < ApplicationRecord
 
     WorkTypes::VALUES.detect { _1.to_s == work_type }.display?(application)
   end
+
+  def assessed_work_type
+    allowed_work_type.presence || work_type
+  end
 end

--- a/app/services/nsm/assessment_syncer.rb
+++ b/app/services/nsm/assessment_syncer.rb
@@ -48,13 +48,18 @@ module Nsm
     end
 
     def sync_work_items
-      work_items.each do |work_item|
-        record = claim.work_items.find(work_item['id'])
-        record.allowed_time_spent = work_item['time_spent'] if work_item['time_spent_original'].present?
-        record.allowed_uplift = work_item['uplift'] if work_item['uplift_original'].present?
-        record.adjustment_comment = work_item['adjustment_comment'] if work_item['adjustment_comment'].present?
-        record.save
+      work_items.each do |work_item_payload|
+        record = claim.work_items.find(work_item_payload['id'])
+        sync_work_item(record, work_item_payload)
       end
+    end
+
+    def sync_work_item(record, payload)
+      record.allowed_time_spent = payload['time_spent'] if payload['time_spent_original'].present?
+      record.allowed_uplift = payload['uplift'] if payload['uplift_original'].present?
+      record.adjustment_comment = payload['adjustment_comment'] if payload['adjustment_comment'].present?
+      record.allowed_work_type = payload.dig('work_type', 'value') if payload['work_type_original'].present?
+      record.save
     end
 
     def sync_disbursements

--- a/app/services/submit_to_app_store/nsm_payload_builder.rb
+++ b/app/services/submit_to_app_store/nsm_payload_builder.rb
@@ -62,9 +62,11 @@ class SubmitToAppStore
 
     def work_item_data
       claim.work_items.map do |work_item|
-        data = work_item.as_json(except: [*DEFAULT_IGNORE, 'allowed_uplift', 'allowed_time_spent', 'adjustment_comment'])
+        data = work_item.as_json(except: [*DEFAULT_IGNORE, 'allowed_uplift', 'allowed_time_spent', 'adjustment_comment',
+                                          'allowed_work_type'])
         data['completed_on'] = data['completed_on'].to_s
         data['pricing'] = pricing[work_item.work_type].to_f
+        data['attendance_with_counsel_pricing'] = pricing['attendance_with_counsel'].to_f
         data
       end
     end

--- a/app/views/nsm/steps/view_claim/_allowed_work_items.html.erb
+++ b/app/views/nsm/steps/view_claim/_allowed_work_items.html.erb
@@ -24,16 +24,18 @@
       vat_rate = current_application.firm_office.vat_registered == 'true' ? Pricing.new(@claim).vat : 0
       sorted_work_items = @work_items.sort_by(&:sort_position)
 
-      rows = sorted_work_items.group_by(&:work_type).map do |work_type, work_items_for_type|
+      rows = sorted_work_items.group_by(&:assessed_work_type).map do |work_type, work_items_for_type|
         time = work_items_for_type.sum(&:time_spent)
         net_cost = work_items_for_type.sum(&:total_cost)
         allowed_time = work_items_for_type.sum { _1.allowed_time_spent || _1.time_spent }
         allowed_net_cost = work_items_for_type.sum(&:allowed_total_cost)
         total_cost += net_cost
         allowed_total_cost += allowed_net_cost
+        translated_work_type = t("summary.nsm/cost_summary/work_items.#{work_type.to_s}")
+        translated_work_type = "#{translated_work_type} *" if work_items_for_type.any? { _1.allowed_work_type.present? }
 
         [
-          { text: t("summary.nsm/cost_summary/work_items.#{work_type.to_s}"), width: 'govuk-!-width-one-quarter' },
+          { text: translated_work_type, width: 'govuk-!-width-one-quarter' },
           { text: format_period(time, style: :minimal_html), numeric: true },
           { text: NumberTo.pounds(net_cost), numeric: true },
           { text: format_period(allowed_time, style: :minimal_html), numeric: true },
@@ -56,6 +58,10 @@
         table.with_foot(rows: foot)
       end
     %>
+
+    <% if @work_items.any? { _1.allowed_work_type.present? } %>
+      <p><%= t('.type_change_explanation') %></p>
+    <% end %>
   <% end %>
 
   <%=
@@ -69,15 +75,17 @@
     }
 
     rows = work_items.map do |work_item|
-      item_with_link = link_to(t("summary.nsm/cost_summary/work_items.#{work_item.work_type.to_s}"),
+      item_with_link = link_to(t("summary.nsm/cost_summary/work_items.#{work_item.assessed_work_type.to_s}"),
                                item_nsm_steps_view_claim_path(id: current_application.id,
                                                               item_type: :work_item,
                                                               item_id: work_item.id,
                                                               page: pagy.page))
 
+      to_display = work_item.allowed_work_type.present? ? safe_join([item_with_link, " *"]) : item_with_link
+
       [
         { header: true, text: work_item.position, numeric: false},
-        { header: true, text: item_with_link, numeric: false},
+        { header: true, text: to_display, numeric: false},
         { text: work_item.adjustment_comment, numeric: false},
         { text: format_period(work_item.allowed_time_spent || work_item.time_spent, style: :minimal_html), numeric: true },
         { text: NumberTo.percentage((work_item.allowed_uplift || work_item.uplift).to_f, multiplier: 1), numeric: true },
@@ -103,5 +111,8 @@
 
     govuk_table_with_cell(header_row, rows, caption: { text: t('.accessibility.work_items_caption'), html_attributes: { 'class': 'govuk-visually-hidden'} })
   %>
+  <% if work_items.any? { _1.allowed_work_type.present? } %>
+    <p><%= t('.type_change_explanation') %></p>
+  <% end %>
   <%= render "shared/pagination",  { pagy: pagy, item: t('.table_info_item') } %>
 <% end %>

--- a/app/views/nsm/steps/view_claim/_allowed_work_items.html.erb
+++ b/app/views/nsm/steps/view_claim/_allowed_work_items.html.erb
@@ -80,7 +80,6 @@
                                                               item_type: :work_item,
                                                               item_id: work_item.id,
                                                               page: pagy.page))
-
       to_display = work_item.allowed_work_type.present? ? safe_join([item_with_link, " *"]) : item_with_link
 
       [

--- a/app/views/nsm/steps/view_claim/work_item.html.erb
+++ b/app/views/nsm/steps/view_claim/work_item.html.erb
@@ -6,12 +6,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= work_item.translated_work_type[I18n.locale] %></h1>
+    <h1 class="govuk-heading-xl"><%=  %></h1>
 
     <%=
       if work_item.adjustment_comment
         rows = [
-          [{ text: t(".allowed_hours"), width: 'govuk-!-width-one-half' }, format_period(work_item.allowed_time_spent || work_item.time_spent)],
+          [{ text: t(".allowed_work_type"), width: 'govuk-!-width-one-half'}, work_item.translated_work_type(value: :assessed)[I18n.locale]],
+          [t(".allowed_hours"), format_period(work_item.allowed_time_spent || work_item.time_spent)],
           [t(".allowed_uplift"), NumberTo.percentage((work_item.allowed_uplift || work_item.uplift).to_f, multiplier: 1)],
           [t(".allowed_net_cost"), NumberTo.pounds(work_item.allowed_total_cost)],
           [t(".adjustment_comment"), work_item.adjustment_comment]
@@ -25,7 +26,8 @@
     %>
     <%=
       rows = [
-        [{ text: t(".date"), width: 'govuk-!-width-one-half' }, work_item.completed_on.strftime('%-d %B %Y')],
+        [{ text:  t('.work_type'), width: 'govuk-!-width-one-half' }, work_item.translated_work_type[I18n.locale]],
+        [t(".date"), work_item.completed_on.strftime('%-d %B %Y')],
         [t(".fee_earner"), work_item.fee_earner],
         [t(".rate"), NumberTo.pounds(work_item.pricing[work_item.work_type])],
         [t(".hours"), format_period(work_item.time_spent)],

--- a/config/locales/en/nsm/view_claim.yml
+++ b/config/locales/en/nsm/view_claim.yml
@@ -66,6 +66,7 @@ en:
           table_info_item: work item
           total: Total
           no_data: You do not have any adjusted work items
+          type_change_explanation: '* denotes that a work item has been adjusted from one type to another'
         letters_and_calls:
           page_title: Claim details
           letters_and_calls: Letters and calls
@@ -136,12 +137,14 @@ en:
         # view pages
         work_item:
           page_title: Claim details
+          work_type: Work type
           date: Date
           fee_earner: Fee earner initials
           rate: Rate applied
           hours: Number of hours
           uplift: Uplift
           net_cost: Net cost
+          allowed_work_type: Allowed work type
           allowed_hours: Number of hours allowed
           allowed_uplift: Uplift allowed
           allowed_net_cost: Net cost allowed

--- a/db/migrate/20240628134832_add_allowed_work_type_to_work_items.rb
+++ b/db/migrate/20240628134832_add_allowed_work_type_to_work_items.rb
@@ -1,0 +1,5 @@
+class AddAllowedWorkTypeToWorkItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :work_items, :allowed_work_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,6 +315,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_140456) do
     t.integer "allowed_time_spent"
     t.string "adjustment_comment"
     t.integer "position"
+    t.string "allowed_work_type"
     t.index ["claim_id"], name: "index_work_items_on_claim_id"
   end
 

--- a/spec/services/nsm/assessment_syncer_spec.rb
+++ b/spec/services/nsm/assessment_syncer_spec.rb
@@ -153,7 +153,9 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
                 time_spent: 20,
                 uplift_original: 15,
                 adjustment_comment: 'Changed work item',
-                time_spent_original: 40
+                time_spent_original: 40,
+                work_type: { en: 'Bananas', value: 'bananas' },
+                work_type_original: { en: 'Pyjamas', value: 'pyjamas' },
               },
               {
                 id: work_item.id,
@@ -175,12 +177,14 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
         expect(uplifted_work_item.allowed_uplift).to eq 0
         expect(uplifted_work_item.adjustment_comment).to eq 'Changed work item'
         expect(uplifted_work_item.allowed_time_spent).to eq 20
+        expect(uplifted_work_item.allowed_work_type).to eq 'bananas'
       end
 
       it 'does not sync non adjusted work item' do
         expect(work_item.allowed_time_spent).to be_nil
         expect(work_item.allowed_uplift).to be_nil
         expect(work_item.adjustment_comment).to be_nil
+        expect(work_item.allowed_work_type).to be_nil
       end
     end
 

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -153,7 +153,6 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
             'time_spent' => an_instance_of(Integer),
             'uplift' => nil,
             'work_type' => { en: an_instance_of(String), value: work_item.work_type },
-            'attendance_with_counsel_pricing' => 35.68,
           }],
           'youth_court' => 'no',
           'supporting_evidences' =>
@@ -169,6 +168,11 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
                'id' => an_instance_of(String),
                'updated_at' => '2023-08-17T12:13:14.000Z'
             }],
+            'work_item_pricing' => {
+              'advocacy' => 65.42,
+              'attendance_without_counsel' => 52.15,
+              'preparation' => 52.15
+            },
         },
         application_id: claim.id,
         application_state: 'submitted',

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
             'time_spent' => an_instance_of(Integer),
             'uplift' => nil,
             'work_type' => { en: an_instance_of(String), value: work_item.work_type },
+            'attendance_with_counsel_pricing' => 35.68,
           }],
           'youth_court' => 'no',
           'supporting_evidences' =>

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe 'View claim page', type: :system do
 
   let(:work_items) do
     [
-      build(:work_item, :attendance_without_counsel, fee_earner: 'AB', time_spent: 90, completed_on: 1.day.ago),
+      build(:work_item,
+            :attendance_without_counsel,
+            fee_earner: 'AB',
+            time_spent: 90,
+            completed_on: 1.day.ago,
+            allowed_work_type: :attendance_with_counsel),
       build(:work_item, :advocacy, :with_adjustment, time_spent: 104, completed_on: 1.day.ago),
       build(:work_item, :advocacy, time_spent: 86, completed_on: 2.days.ago),
       build(:work_item, :waiting, time_spent: 23, completed_on: 3.days.ago),

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -201,10 +201,10 @@ RSpec.describe 'View claim page', type: :system do
   it 'show a work item' do
     visit item_nsm_steps_view_claim_path(id: claim.id, item_type: :work_item, item_id: work_items.first.id)
 
-    expect(find('h1').text).to eq('Attendance without counsel')
     expect(all('table caption, table td').map(&:text)).to eq(
       [
         'Your claimed costs',
+        'Work type', 'Attendance without counsel',
         'Date',	1.day.ago.to_fs(:stamp),
         'Fee earner initials', 'AB',
         'Rate applied', '£52.15',
@@ -626,16 +626,17 @@ RSpec.describe 'View claim page', type: :system do
     it 'show a work item' do
       visit item_nsm_steps_view_claim_path(id: claim.id, item_type: :work_item, item_id: work_items.last.id)
 
-      expect(find('h1').text).to eq('Advocacy')
       expect(all('table caption, table td').map(&:text)).to eq(
         [
           'Adjusted claim',
+          'Allowed work type', 'Advocacy',
           'Number of hours allowed', '0 hours 52 minutes',
           'Uplift allowed', '0%',
           'Net cost allowed', '£56.70',
           'Reason for adjustment', 'WI adjustment',
 
           'Your claimed costs',
+          'Work type', 'Advocacy',
           'Date',	Time.current.to_fs(:stamp),
           'Fee earner initials', 'BC',
           'Rate applied', '£65.42',


### PR DESCRIPTION
## Description of change
- Put relevant pricing data into the payload
- Sync back changes to work type post assessment
- Display adjusted work items in correct places with correct pricing

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1689)

## Notes for reviewer
We've agreed that in future pricing data may be held centrally so that caseworker can access what it needs without help like this, but for now adding relevant pricing to the payload is the least painful way of being ready for private beta.
