### PR TITLE
CRM457-1319: Swallow team-only nooification client errors on DEV/UAT

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,0 +1,10 @@
+class NotifyMailer < GovukNotifyRails::Mailer
+  rescue_from 'Notifications::Client::BadRequestError' do |e|
+    if HostEnv.production? || e.message.exclude?('team-only API')
+      Rails.logger.warn("Reraising exception #{e.class} with message \"#{e.message}\"")
+      raise e
+    else
+      Rails.logger.warn("Swallowing exception #{e.class} with message \"#{e.message}\"")
+    end
+  end
+end

--- a/app/mailers/nsm/submission_mailer.rb
+++ b/app/mailers/nsm/submission_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Nsm
-  class SubmissionMailer < GovukNotifyRails::Mailer
+  class SubmissionMailer < NotifyMailer
     def notify(claim)
       @claim = claim
       set_template('0403454c-47a5-4540-804c-cb614e77dc22')

--- a/app/mailers/prior_authority/submission_mailer.rb
+++ b/app/mailers/prior_authority/submission_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PriorAuthority
-  class SubmissionMailer < GovukNotifyRails::Mailer
+  class SubmissionMailer < NotifyMailer
     def notify(application)
       @application = application
       set_template('d07d03fd-65d0-45e4-8d49-d4ee41efad35')

--- a/spec/mailers/nsm/submission_mailer_spec.rb
+++ b/spec/mailers/nsm/submission_mailer_spec.rb
@@ -63,4 +63,8 @@ RSpec.describe Nsm::SubmissionMailer, type: :mailer do
       end
     end
   end
+
+  it_behaves_like 'notification client error handler' do
+    let(:submission) { claim }
+  end
 end

--- a/spec/mailers/prior_authority/submission_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_mailer_spec.rb
@@ -44,4 +44,8 @@ RSpec.describe PriorAuthority::SubmissionMailer, type: :mailer do
       )
     end
   end
+
+  it_behaves_like 'notification client error handler' do
+    let(:submission) { application }
+  end
 end

--- a/spec/support/shared_examples/submission_mailer_examples.rb
+++ b/spec/support/shared_examples/submission_mailer_examples.rb
@@ -1,0 +1,74 @@
+RSpec.shared_examples 'notification client error handler' do
+  context 'when client error response received' do
+    before do
+      allow(Notifications::Client).to receive(:new)
+        .and_return(notify_client)
+      allow(notify_client).to receive(:send_email)
+        .and_raise(Notifications::Client::BadRequestError.new(response))
+
+      allow(Rails.logger).to receive(:warn)
+    end
+
+    let(:notify_client) { double('Notifications::Client') }
+
+    context 'when on DEV or UAT environment' do
+      before do
+        allow(HostEnv).to receive(:production?).and_return(false)
+      end
+
+      context 'with a team API key client error' do
+        let(:response) { double(code: 400, body: "Can't send to this recipient using a team-only API key") }
+
+        it 'does not raise error' do
+          expect { described_class.notify(submission).deliver_now }.not_to raise_error
+        end
+
+        it 'logs the rescued error' do
+          described_class.notify(submission).deliver_now
+
+          expect(Rails.logger)
+            .to have_received(:warn)
+            .with(/Swallowing exception Notifications::Client::BadRequestError with/)
+        end
+      end
+
+      context 'with another kind of client error' do
+        let(:response) { double(code: 400, body: 'some other client error') }
+
+        it 'raises error' do
+          expect { described_class.notify(submission).deliver_now }
+            .to raise_error(Notifications::Client::BadRequestError, 'some other client error')
+        end
+
+        it 'logs the rescued error' do
+          described_class.notify(submission).deliver_now
+        rescue Notifications::Client::BadRequestError
+          expect(Rails.logger)
+            .to have_received(:warn)
+            .with(/Reraising exception Notifications::Client::BadRequestError with/)
+        end
+      end
+    end
+
+    context 'when on production environment' do
+      before do
+        allow(HostEnv).to receive(:production?).and_return(true)
+      end
+
+      let(:response) { double(code: 400, body: "Can't send to this recipient using a team-only API key") }
+
+      it 'raises error' do
+        expect { described_class.notify(submission).deliver_now }
+          .to raise_error(Notifications::Client::BadRequestError, "Can't send to this recipient using a team-only API key")
+      end
+
+      it 'logs the rescued error' do
+        described_class.notify(submission).deliver_now
+      rescue Notifications::Client::BadRequestError
+        expect(Rails.logger)
+          .to have_received(:warn)
+          .with(/Reraising exception Notifications::Client::BadRequestError with/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Swallow team-only notification client errors on DEV/UAT

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1319)

When testing we often use invalid/non-team-member email addresses
and we are not interested in sentry or other alerting that results
from this on pre-prod environments
