### PR TITLE
CRM457-1705: Do not show links to documents on PDFs

### DIFF
--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -47,7 +47,7 @@ module PriorAuthority
     end
 
     def download
-      pdf = PdfService.prior_authority(application_locals, request.url)
+      pdf = PdfService.prior_authority(application_locals(skip_links: true), request.url)
 
       send_data pdf,
                 filename: "#{current_application.laa_reference}.pdf",
@@ -104,12 +104,12 @@ module PriorAuthority
       @sort_direction = params.fetch(:sort_direction, 'descending')
     end
 
-    def application_locals
+    def application_locals(skip_links: false)
       application = PriorAuthorityApplication.for(current_provider).find(params[:id])
       {
         application: application,
         primary_quote_summary: PriorAuthority::PrimaryQuoteSummary.new(application),
-        report: CheckAnswers::Report.new(application, verbose: true),
+        report: CheckAnswers::Report.new(application, verbose: true, skip_links: skip_links),
         allowance_type: { 'granted' => :original,
                           'part_grant' => :dynamic,
                           'rejected' => :na }[application.status]

--- a/app/presenters/prior_authority/check_answers/compact_further_information_card.rb
+++ b/app/presenters/prior_authority/check_answers/compact_further_information_card.rb
@@ -5,10 +5,11 @@ module PriorAuthority
     class CompactFurtherInformationCard < Base
       attr_reader :further_information
 
-      def initialize(further_information)
+      def initialize(further_information, skip_links: false)
         @group = 'about_request'
         @section = 'compact_further_information'
         @further_information = further_information
+        @skip_links = skip_links
         super()
       end
 
@@ -37,8 +38,12 @@ module PriorAuthority
 
       def supporting_documents
         links = further_information.supporting_documents.map do |document|
-          govuk_link_to(document.file_name,
-                        url_helper.prior_authority_download_path(document))
+          if @skip_links
+            document.file_name
+          else
+            govuk_link_to(document.file_name,
+                          url_helper.prior_authority_download_path(document))
+          end
         end
         response = simple_format(further_information.information_supplied)
         parts = [response] + links.flat_map { [tag.br, _1] }

--- a/app/presenters/prior_authority/check_answers/primary_quote_card.rb
+++ b/app/presenters/prior_authority/check_answers/primary_quote_card.rb
@@ -5,11 +5,12 @@ module PriorAuthority
     class PrimaryQuoteCard < Base
       attr_reader :application, :service_cost_form, :travel_detail_form, :verbose
 
-      def initialize(application, verbose: false)
+      def initialize(application, verbose: false, skip_links: false)
         @group = 'about_request'
         @section = 'primary_quote_summary'
         @application = application
         @verbose = verbose
+        @skip_links = skip_links
 
         @service_cost_form = PriorAuthority::Steps::ServiceCostForm.build(
           application.primary_quote,
@@ -91,8 +92,12 @@ module PriorAuthority
       end
 
       def document_link
-        govuk_link_to(primary_quote.document.file_name,
-                      url_helper.prior_authority_download_path(primary_quote.document))
+        if @skip_links
+          primary_quote.document.file_name
+        else
+          govuk_link_to(primary_quote.document.file_name,
+                        url_helper.prior_authority_download_path(primary_quote.document))
+        end
       end
 
       def related_to_post_mortem

--- a/app/presenters/prior_authority/check_answers/reason_why_card.rb
+++ b/app/presenters/prior_authority/check_answers/reason_why_card.rb
@@ -5,10 +5,11 @@ module PriorAuthority
     class ReasonWhyCard < Base
       attr_reader :application
 
-      def initialize(application)
+      def initialize(application, skip_links: false)
         @group = 'about_request'
         @section = 'reason_why'
         @application = application
+        @skip_links = skip_links
         super()
       end
 
@@ -36,8 +37,12 @@ module PriorAuthority
                                     I18n.t('prior_authority.generic.none')
                                   else
                                     links = application.supporting_documents.map do |document|
-                                      govuk_link_to(document.file_name,
-                                                    url_helper.prior_authority_download_path(document))
+                                      if @skip_links
+                                        document.file_name
+                                      else
+                                        govuk_link_to(document.file_name,
+                                                      url_helper.prior_authority_download_path(document))
+                                      end
                                     end
                                     sanitize(links.join(tag.br), tags: %w[a br])
                                   end

--- a/app/presenters/prior_authority/check_answers/report.rb
+++ b/app/presenters/prior_authority/check_answers/report.rb
@@ -8,11 +8,12 @@ module PriorAuthority
         about_request
       ].freeze
 
-      attr_reader :application
+      attr_reader :application, :skip_links, :verbose
 
-      def initialize(application, verbose: false)
+      def initialize(application, verbose: false, skip_links: false)
         @application = application
         @verbose = verbose
+        @skip_links = skip_links
       end
 
       def section_groups
@@ -58,9 +59,9 @@ module PriorAuthority
 
       def about_request_section
         [
-          PrimaryQuoteCard.new(application, verbose: @verbose),
-          AlternativeQuotesCard.new(application, verbose: @verbose),
-          ReasonWhyCard.new(application),
+          PrimaryQuoteCard.new(application, verbose:, skip_links:),
+          AlternativeQuotesCard.new(application, verbose:),
+          ReasonWhyCard.new(application, skip_links:),
           further_information_cards,
         ].flatten.compact
       end
@@ -73,7 +74,7 @@ module PriorAuthority
         if @verbose
           application.further_informations
                      .order(requested_at: :desc)
-                     .map { CompactFurtherInformationCard.new(_1) }
+                     .map { CompactFurtherInformationCard.new(_1, skip_links:) }
         else
           FurtherInformationCard.new(application)
         end

--- a/app/views/prior_authority/applications/_application_details.html.erb
+++ b/app/views/prior_authority/applications/_application_details.html.erb
@@ -1,4 +1,4 @@
-<% skip_buttons ||= false %>
+<% skip_links ||= false %>
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title"><%= t("prior_authority.applications.show.application_status") %></h2>
@@ -18,7 +18,7 @@
       <% if application.assessment_comment.present? || application.part_grant? %>
         <%= render "prior_authority/applications/response_summaries/assessed", application: %>
       <% elsif application.sent_back? %>
-        <%= render "prior_authority/applications/response_summaries/sent_back", application:, skip_buttons: %>
+        <%= render "prior_authority/applications/response_summaries/sent_back", application:, skip_links: %>
       <% elsif application.expired? %>
         <%= render "prior_authority/applications/response_summaries/expired", application: %>
       <% end %>
@@ -30,7 +30,7 @@
   <h2 class="govuk-heading-m"><%= section_group[:heading] %></h2>
   <% section_group[:sections].each do |section| %>
     <% if section.template %>
-      <%= render(section.template, section: section, show_actions: false, show_adjustments: allowance_type) %>
+      <%= render(section.template, section: section, show_actions: false, show_adjustments: allowance_type, skip_download_links: skip_links) %>
     <% else %>
       <%= govuk_summary_list(
             card: {

--- a/app/views/prior_authority/applications/pdf.html.erb
+++ b/app/views/prior_authority/applications/pdf.html.erb
@@ -5,6 +5,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl"><%= t('prior_authority.applications.show.page_title') %></h1>
-    <%= render "prior_authority/applications/application_details", application:, primary_quote_summary:, report:, allowance_type:, skip_buttons: true %>
+    <%= render "prior_authority/applications/application_details", application:, primary_quote_summary:, report:, allowance_type:, skip_links: true %>
   </div>
 </div>

--- a/app/views/prior_authority/applications/response_summaries/_sent_back.html.erb
+++ b/app/views/prior_authority/applications/response_summaries/_sent_back.html.erb
@@ -7,7 +7,7 @@
         deadline: tag.strong(application.resubmission_deadline.to_fs(:stamp))).each do |paragraph| %>
       <p><%= paragraph %></p>
     <% end %>
-    <% unless skip_buttons %>
+    <% unless skip_links %>
       <% if further_information_needed(application) %>
         <%= govuk_button_link_to(t('prior_authority.applications.show.update_application'),
                                 edit_prior_authority_steps_further_information_path(application)) %>

--- a/app/views/prior_authority/steps/alternative_quote_details/confirm_delete.html.erb
+++ b/app/views/prior_authority/steps/alternative_quote_details/confirm_delete.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
-    <%= render 'prior_authority/steps/alternative_quotes/quote_summary', alternative_quote: @form_object, links: false %>
+    <%= render 'prior_authority/steps/alternative_quotes/quote_summary', alternative_quote: @form_object, edit_links: false %>
     <div class="govuk-button-group">
       <%= govuk_button_to(t('.yes_delete'), prior_authority_steps_alternative_quote_detail_path(current_application, @form_object.id), warning: true, method: :delete) %>
       <%= govuk_button_to(t('.no_delete'), prior_authority_steps_alternative_quotes_path, method: :get) %>

--- a/app/views/prior_authority/steps/alternative_quotes/_quote_summary.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_quote_summary.html.erb
@@ -1,11 +1,12 @@
 <% counter ||= nil %>
+<% skip_download_links ||= false %>
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">
       <%= t('.alternative_quote') %>
       <%= counter %>
     </h2>
-    <% if links %>
+    <% if edit_links %>
       <ul class="govuk-summary-card__actions">
         <li class="govuk-summary-card__action">
           <%= govuk_link_to(t('.change'), edit_prior_authority_steps_alternative_quote_detail_path(current_application, alternative_quote.id)) %>
@@ -32,7 +33,11 @@
         <dt class="govuk-summary-list__key"><%= t('.quote_upload') %></dt>
         <dd class="govuk-summary-list__value">
           <% if alternative_quote.document&.file_name.present? %>
-            <%= govuk_link_to alternative_quote.document.file_name, prior_authority_download_path(alternative_quote.document) %>
+            <% if skip_download_links %>
+              <%= alternative_quote.document.file_name %>
+            <% else %>
+              <%= govuk_link_to alternative_quote.document.file_name, prior_authority_download_path(alternative_quote.document) %>
+            <% end %>
           <% else %>
             <%= t('.none') %>
           <% end %>

--- a/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/alternative_quotes/_with_alternative_quotes.html.erb
@@ -14,7 +14,7 @@
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= title_string %></h1>
     <% @form_object.alternative_quotes.each do |alternative_quote| %>
-      <%= render 'quote_summary', alternative_quote: alternative_quote, links: true %>
+      <%= render 'quote_summary', alternative_quote: alternative_quote, edit_links: true %>
     <% end %>
 
     <%= step_form @form_object do |form| %>

--- a/app/views/prior_authority/steps/check_answers/_alternative_quotes.html.erb
+++ b/app/views/prior_authority/steps/check_answers/_alternative_quotes.html.erb
@@ -1,6 +1,8 @@
+<% skip_download_links ||= false %>
 <% section.alternative_quote_forms.each_with_index do |quote, index| %>
   <%= render 'prior_authority/steps/alternative_quotes/quote_summary',
              alternative_quote: quote,
-             links: false,
-             counter: (index + 1) %>
+             edit_links: false,
+             counter: (index + 1),
+             skip_download_links: skip_download_links %>
 <% end %>

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'View reviewed applications' do
     let(:application) do
       create(:prior_authority_application,
              :full,
+             :with_alternative_quotes,
              status: 'rejected',
              app_store_updated_at: 1.day.ago,
              assessment_comment: 'You used the wrong form')
@@ -22,7 +23,6 @@ RSpec.describe 'View reviewed applications' do
 
     it 'shows rejection details' do
       expect(page).to have_content 'Rejected'
-      expect(page).to have_content '£155.00 requested'
       expect(page).to have_content '£0.00 allowed'
       expect(page).to have_content 'You used the wrong form'
       expect(page).to have_content 'If you want to appeal the rejection, email CRM4appeal@justice.gov.uk'


### PR DESCRIPTION
## Description of change
- PDF download was breaking because link generation to uploaded documents was failing
- It shouldn't have been failing, but also the PDFs shouldn't have links inside them anyway (because those links look ugly and will not work as they link to authenticated URLs)
- So this removes links to documents from PDFs

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1705)
