### PR TITLE
CRM457-1349: Stop modsec rejecting large files

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -27,6 +27,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecRequestBodyNoFilesLimit 524288
+      SecRequestBodyLimit 104857600
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team,status:423"
       SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team,status:423"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"


### PR DESCRIPTION
Modsec is currently rejecting any file upload larger than 13MB. If the file is the PA primary quote attachment, the user sees a named nginx "403 forbidden" page. Not only is this a horrible UX, it is more horrible even than modsec's normal UX - in most cases when modsec false positives we can show a custom, descriptive error screen. But modsec treats files differently. Worst of all, when it intervenes like this, no logs are generated - neither ingress nor modsec logs, meaning we have no visibility of when it occurs.

We already have a user-friendly unhappy path for larger than 10MB file uploads. On top of that, we already have protections at ingress level for files larger than 50MB that kick in without waiting for the file to be uploaded and showing an error message screen that at least uses the phrase "too large" so that our application servers are not overwhelmed.

It is not modsec's place to reject large files, and the way that it intervenes is awful. This PR therefore increases the file size limit for modsec to 100MB so that it stops being an issue.