### PR TITLE
CRM457-1696: Amend content for when no adjustments of type exist

### DIFF
--- a/app/views/nsm/steps/view_claim/allowed_work_items.html.erb
+++ b/app/views/nsm/steps/view_claim/allowed_work_items.html.erb
@@ -67,8 +67,6 @@
       work_items.group_by(&:completed_on).each do |completed_on, work_items_for_date| %>
       <%=
         rows = work_items_for_date.map do |work_item|
-          next unless work_item.adjustment_comment
-
           link = link_to(t('.view'), item_nsm_steps_view_claim_path(id: current_application.id, item_type: :work_item, item_id: work_item.id, page: pagy.page, section: 'adjustments'), data: { turbo: 'false' })
 
           [

--- a/app/views/nsm/steps/view_claim/allowed_work_items.html.erb
+++ b/app/views/nsm/steps/view_claim/allowed_work_items.html.erb
@@ -49,45 +49,49 @@
     %>
   <% end %>
 
-  <%
-    pagy, work_items = pagy(@work_items.where.not(adjustment_comment: nil))
-    head = [
-      { text: t('.item'), width: 'govuk-!-width-one-quarter' },
-      { text: t('.time'), numeric: true },
-      { text: t('.uplift'), numeric: true },
-      { text: t('.net_cost'), numeric: true },
-      { text: t('.allowed_time'), numeric: true },
-      { text: t('.allowed_uplift'), numeric: true },
-      { text: t('.allowed_net_cost'), numeric: true },
-      { text: t('.action'), numeric: true }
-    ]
-    work_items.group_by(&:completed_on).each do |completed_on, work_items_for_date| %>
-    <%=
-      rows = work_items_for_date.map do |work_item|
-        next unless work_item.adjustment_comment
+  <% pagy, work_items = pagy(@work_items.where.not(adjustment_comment: nil)) %>
+    <% if work_items.size.zero? %>
+      <p><%= t('.no_data') %></p>
+    <% else %>
+    <%
+      head = [
+        { text: t('.item'), width: 'govuk-!-width-one-quarter' },
+        { text: t('.time'), numeric: true },
+        { text: t('.uplift'), numeric: true },
+        { text: t('.net_cost'), numeric: true },
+        { text: t('.allowed_time'), numeric: true },
+        { text: t('.allowed_uplift'), numeric: true },
+        { text: t('.allowed_net_cost'), numeric: true },
+        { text: t('.action'), numeric: true }
+      ]
+      work_items.group_by(&:completed_on).each do |completed_on, work_items_for_date| %>
+      <%=
+        rows = work_items_for_date.map do |work_item|
+          next unless work_item.adjustment_comment
 
-        link = link_to(t('.view'), item_nsm_steps_view_claim_path(id: current_application.id, item_type: :work_item, item_id: work_item.id, page: pagy.page, section: 'adjustments'), data: { turbo: 'false' })
+          link = link_to(t('.view'), item_nsm_steps_view_claim_path(id: current_application.id, item_type: :work_item, item_id: work_item.id, page: pagy.page, section: 'adjustments'), data: { turbo: 'false' })
 
-        [
-          t("summary.nsm/cost_summary/work_items.#{work_item.work_type.to_s}"),
-          { text: format_period(work_item.time_spent), numeric: true },
-          { text: NumberTo.percentage(work_item.uplift.to_f, multiplier: 1), numeric: true },
-          { text: NumberTo.pounds(work_item.total_cost), numeric: true },
-          { text: format_period(work_item.allowed_time_spent || work_item.time_spent), numeric: true },
-          { text: NumberTo.percentage((work_item.allowed_uplift || work_item.uplift).to_f, multiplier: 1), numeric: true },
-          { text: NumberTo.pounds(work_item.allowed_total_cost), numeric: true },
-          { text: link, numeric: true }
-        ]
-      end
+          [
+            t("summary.nsm/cost_summary/work_items.#{work_item.work_type.to_s}"),
+            { text: format_period(work_item.time_spent), numeric: true },
+            { text: NumberTo.percentage(work_item.uplift.to_f, multiplier: 1), numeric: true },
+            { text: NumberTo.pounds(work_item.total_cost), numeric: true },
+            { text: format_period(work_item.allowed_time_spent || work_item.time_spent), numeric: true },
+            { text: NumberTo.percentage((work_item.allowed_uplift || work_item.uplift).to_f, multiplier: 1), numeric: true },
+            { text: NumberTo.pounds(work_item.allowed_total_cost), numeric: true },
+            { text: link, numeric: true }
+          ]
+        end
 
-      next if rows.none?
+        next if rows.none?
 
-      govuk_table do |table|
-        table.with_caption(text: completed_on.strftime('%-d %B %Y'), size: 's')
-        table.with_head(rows: [head])
-        table.with_body(rows: rows, first_cell_is_header: true)
-      end
-    %>
-  <% end %>
+        govuk_table do |table|
+          table.with_caption(text: completed_on.strftime('%-d %B %Y'), size: 's')
+          table.with_head(rows: [head])
+          table.with_body(rows: rows, first_cell_is_header: true)
+        end
+      %>
+    <% end %>
   <%= render "shared/pagination",  { pagy: pagy, item: t('.table_info_item') } %>
+<% end %>
 </turbo-frame>

--- a/config/locales/en/nsm/view_claim.yml
+++ b/config/locales/en/nsm/view_claim.yml
@@ -50,6 +50,7 @@ en:
           gross_cost: Total claimed
           table_info_item: work item
           total: Total
+          no_data: No work items have been adjusted
         letters_and_calls:
           page_title: Claim details
           letters_and_calls: Letters and calls
@@ -76,7 +77,7 @@ en:
           view: View
           letters: Letters
           calls: Calls
-          no_data: You do not have any letters or calls
+          no_data: No letters or calls have been adjusted
         disbursements:
           page_title: Claim details
           disbursements: Disbursements
@@ -101,7 +102,7 @@ en:
           action: Action
           view: View
           table_info_item: disbursement
-          no_data: You do not have any disbursements
+          no_data: No disbursements have been adjusted
         granted_response: The claim has been fully granted.
         # view pages
         work_item:


### PR DESCRIPTION
## Description of change
Amend content for when no adjustments of type exist

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1696)

## Notes for reviewer
Have brought the allowed work items partial inline with letters and calls, and disbursements equivalents. Prior to this it was rendering the pagy link, which had none to display so show "No work items" based on it's rendering logic. Now it explicitly checks for adjusted work items and displays specific text and no pagy links when there are none.
