### PR TITLE
CRM457-1529: Change snyk docker scanning approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,21 +303,28 @@ jobs:
 
   scan-docker-image:
     executor: test-executor
-    parallelism: 1
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - build-docker-image-for-scan
-      - snyk/scan:
+      - snyk/install:
           token-variable: SNYK_TOKEN
-          docker-image-name: app
-          target-file: ./Dockerfile
-          organization: 'legal-aid-agency'
-          project: ministryofjustice/laa-submit-crime-forms
-          severity-threshold: "high"
-          fail-on-issues: true
-          additional-arguments: --policy-path=.snyk
+      - run:
+          name: Run static code analysis
+          command: snyk code test --severity-threshold=high
+      - run:
+          name: Test open source dependencies
+          command: snyk test --all-projects --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor for open source vulnerabilities and license issues
+          command: snyk monitor --all-projects
+      - run:
+          name: Scan container image for vulnerabilities
+          command: snyk container test app --file=./Dockerfile --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor container image for vulnerabilities
+          command: snyk container monitor app
 
   build-to-ecr:
     executor: aws-ecr/default

--- a/app/controllers/nsm/steps/view_claim_controller.rb
+++ b/app/controllers/nsm/steps/view_claim_controller.rb
@@ -14,28 +14,39 @@ module Nsm
       def item
         @claim = current_application
 
-        render params[:item_type]
+        render report_params[:item_type]
       end
 
       def work_items
         @work_items = current_application.work_items
 
-        render "#{params[:prefix]}work_items"
+        render prefixed_view_for('work_items')
       end
 
       def letters_and_calls
         @claim = current_application
 
-        render "#{params[:prefix]}letters_and_calls"
+        render prefixed_view_for('letters_and_calls')
       end
 
       def disbursements
         @disbursements = current_application.disbursements.by_age
 
-        render "#{params[:prefix]}disbursements"
+        render prefixed_view_for('disbursements')
       end
 
       private
+
+      def prefixed_view_for(item_type)
+        "#{report_params[:prefix]}#{item_type}"
+      end
+
+      def report_params
+        params.permit(
+          :item_type,
+          :prefix,
+        )
+      end
 
       def validate_prefix
         raise "Invalid prefix: #{params[:prefix]}" unless params[:prefix].in?(['allowed_', '', nil])


### PR DESCRIPTION
## Description of change
Change snyk docker scanning approach

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1529)

## Notes for reviewer
This implements all but the IaC scan. The reason for not implementing IaC scanning now is:
- IaC needs rendered terraform or k8s manifests to scan, not helm templates
- attempts to render the manifests and pass them to the `snyk IaC test` hit various problems to do with helm install on test-executor (overcome), requiring k8s login for rendering the manifest (requiring cloud-platform-executor) or snyk install on cloud-platform-executor, and it has not been possible to test whether a helm upgrade --dry-run output would work. Certainly a `helm template blah` command as suggested by snyk docs is insufficient in our case. Ideally the cloud-platform-executor would have snyk installed so we can render manifests and then, hopefully these can be scanned by `snyk iac test`
