### PR TITLE
CRM457-1714: Better dummy data

### DIFF
--- a/app/controllers/prior_authority/steps/start_page_controller.rb
+++ b/app/controllers/prior_authority/steps/start_page_controller.rb
@@ -16,7 +16,7 @@ module PriorAuthority
       end
 
       def start_page_tasklist
-        if further_information_needed
+        if current_application.further_information_needed?
           @tasklist || StartPage::FurtherInformationTaskList.new(
             view_context, application: current_application
           )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,15 +14,6 @@ module ApplicationHelper
     ApplicationController.helpers.sanitize(string.gsub("\n", '<br>'), tags: %w[br])
   end
 
-  def further_information_needed(application = current_application)
-    if application.further_informations.empty?
-      false
-    else
-      last_further_info = application.further_informations.order(:created_at).last.created_at
-      application.sent_back? && (last_further_info >= application.app_store_updated_at)
-    end
-  end
-
   def relevant_prior_authority_list_anchor(prior_authority_application)
     case prior_authority_application.status
     when 'submitted'

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -60,4 +60,13 @@ class PriorAuthorityApplication < ApplicationRecord
   def total_cost_gbp
     total_cost ? NumberTo.pounds(total_cost) : nil
   end
+
+  def further_information_needed?
+    if further_informations.empty?
+      false
+    else
+      last_further_info = further_informations.order(:created_at).last.created_at
+      sent_back? && (last_further_info >= app_store_updated_at)
+    end
+  end
 end

--- a/app/views/prior_authority/applications/response_summaries/_sent_back.html.erb
+++ b/app/views/prior_authority/applications/response_summaries/_sent_back.html.erb
@@ -8,7 +8,7 @@
       <p><%= paragraph %></p>
     <% end %>
     <% unless skip_links %>
-      <% if further_information_needed(application) %>
+      <% if application.further_information_needed? %>
         <%= govuk_button_link_to(t('prior_authority.applications.show.update_application'),
                                 edit_prior_authority_steps_further_information_path(application)) %>
       <% else %>

--- a/lib/tasks/submit_dummy_data.rake
+++ b/lib/tasks/submit_dummy_data.rake
@@ -18,6 +18,16 @@ namespace :submit_dummy_data do
     end
   end
 
+  desc "Resubmit a proportion of sent-back prior authority applications"
+  task :prior_authority_rfi, [:percentage] => :environment do |_task, args|
+    STDOUT.print "Will resubmit #{args[:percentage]}% of PA/CRM4's in the sent_back state: Are you sure? (y/n): "
+    input = STDIN.gets.strip
+
+    if input.downcase.in?(['yes','y'])
+      TestData::PaResubmitter.new.resubmit(args[:percentage].to_i)
+    end
+  end
+
   desc "Submit bulk dummy NSM data to the app store for a given year"
   task :bulk_nsm, [:bulk, :large, :year] => :environment do |_task, args|
     args.with_defaults(bulk: 100, large: 4, year: 2023)

--- a/lib/test_data/nsm_builder.rb
+++ b/lib/test_data/nsm_builder.rb
@@ -27,7 +27,7 @@ module TestData
     def build(**options)
       ActiveRecord::Base.transaction do
         args, kwargs = *options(**options).values.sample
-        claim = FactoryBot.create(*args, kwargs.call)
+        claim = FactoryBot.create(*args, :randomised, kwargs.call)
         claim.update!(status: :submitted, updated_at: claim.updated_at + 1.minute)
 
         invalid_tasks = check_tasks(claim)

--- a/lib/test_data/pa_builder.rb
+++ b/lib/test_data/pa_builder.rb
@@ -16,7 +16,7 @@ module TestData
       ActiveRecord::Base.transaction do
         args, kwfct = *options(**options).values.sample
         kwargs = kwfct.call
-        paa = FactoryBot.create(*args, further_informations: [], incorrect_informations: [], **kwargs)
+        paa = FactoryBot.create(*args, :randomised, further_informations: [], incorrect_informations: [], **kwargs)
         paa.update!(status: :submitted, updated_at: paa.updated_at + 1.minute)
 
         invalid_tasks = check_tasks(paa)

--- a/lib/test_data/pa_resubmitter.rb
+++ b/lib/test_data/pa_resubmitter.rb
@@ -1,0 +1,40 @@
+module TestData
+  class PaResubmitter
+    def resubmit(percentage)
+      total = PriorAuthorityApplication.sent_back.count
+
+      PriorAuthorityApplication.sent_back.order('RANDOM()').limit(percentage * total / 100).find_each do |application|
+        add_further_information(application) if application.further_information_needed?
+        make_changes(application) if application.incorrect_information_explanation.present?
+        update(application)
+      end
+    end
+
+    def add_further_information(application)
+      further_information = application.further_informations.order(:created_at).last
+      further_information.supporting_documents << FactoryBot.build(:supporting_document,
+                                                                   file_name: "#{SecureRandom.uuid}.pdf")
+      further_information.update!(information_supplied: Faker::Lorem.paragraph)
+    end
+
+    def make_changes(application)
+      application.defendant.update!(
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name
+      )
+
+      application.firm_office.update!(
+        name: Faker::Company.name,
+        town: Faker::Address.city,
+      )
+
+      latest_incorrect_info = application.incorrect_informations.order(requested_at: :desc).first
+      latest_incorrect_info.update!(sections_changed: %w[case_contact client_detail])
+    end
+
+    def update(application)
+      application.provider_updated!
+      SubmitToAppStore.new.submit(application)
+    end
+  end
+end

--- a/spec/controllers/prior_authority/start_page_controller_spec.rb
+++ b/spec/controllers/prior_authority/start_page_controller_spec.rb
@@ -13,16 +13,18 @@ RSpec.describe PriorAuthority::Steps::StartPageController, type: :controller do
       let(:current_application) { create(:prior_authority_application, status: 'draft') }
 
       it 'creates an instance of TaskList presenter' do
-        expect(controller.further_information_needed).to be_falsey
+        expect(controller.instance_values['tasklist']).to be_a PriorAuthority::StartPage::TaskList
       end
     end
 
     context 'a sent back application' do
       let(:app_store_updated_at) { DateTime.current - 1.day }
-      let(:current_application) { create(:prior_authority_application, :with_further_information, app_store_updated_at:) }
+      let(:current_application) do
+        create(:prior_authority_application, :with_further_information_request, app_store_updated_at:)
+      end
 
       it 'creates an instance of FurtherInformationTaskList presenter' do
-        expect(controller.further_information_needed).to be_truthy
+        expect(controller.instance_values['tasklist']).to be_a PriorAuthority::StartPage::FurtherInformationTaskList
       end
     end
 
@@ -30,7 +32,7 @@ RSpec.describe PriorAuthority::Steps::StartPageController, type: :controller do
       let(:current_application) { create(:prior_authority_application, status: 'sent_back') }
 
       it 'creates an instance of TaskList presenter' do
-        expect(controller.further_information_needed).to be_falsey
+        expect(controller.instance_values['tasklist']).to be_a PriorAuthority::StartPage::TaskList
       end
     end
   end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -279,5 +279,14 @@ FactoryBot.define do
     trait :with_assessment_comment do
       assessment_comment { 'this is a comment' }
     end
+
+    trait :randomised do
+      laa_reference { "LAA-#{SecureRandom.alphanumeric(6)}" }
+      ufn do
+        random_date = Faker::Date.between(from: 10.years.ago, to: 1.day.ago)
+        "#{random_date.strftime('%d%m%y')}/#{SecureRandom.rand(1000).to_s.rjust(3, '0')}"
+      end
+      firm_office factory: %i[firm_office valid randomised]
+    end
   end
 end

--- a/spec/factories/firm_offices.rb
+++ b/spec/factories/firm_offices.rb
@@ -13,5 +13,9 @@ FactoryBot.define do
       address_line_2 { 'Unit B' }
       vat_registered { 'no' }
     end
+
+    trait :randomised do
+      name { Faker::Company.name }
+    end
   end
 end

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -145,6 +145,10 @@ FactoryBot.define do
 
     trait :with_further_information_request do
       further_informations { [build(:further_information)] }
+      status { 'sent_back' }
+      app_store_updated_at { 1.minute.ago }
+      resubmission_deadline { 14.days.from_now }
+      resubmission_requested { DateTime.current }
     end
 
     trait :with_further_information_supplied do
@@ -285,11 +289,10 @@ FactoryBot.define do
       end
     end
 
-    trait :with_further_information do
-      status { 'sent_back' }
-      after(:create) do |paa|
-        create(:further_information, prior_authority_application_id: paa.id)
-      end
+    trait :randomised do
+      laa_reference { "LAA-#{SecureRandom.alphanumeric(6)}" }
+      ufn { "#{date.strftime('%d%m%y')}/#{SecureRandom.rand(1000).to_s.rjust(3, '0')}" }
+      firm_office factory: %i[firm_office valid randomised]
     end
   end
 end

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -291,7 +291,10 @@ FactoryBot.define do
 
     trait :randomised do
       laa_reference { "LAA-#{SecureRandom.alphanumeric(6)}" }
-      ufn { "#{date.strftime('%d%m%y')}/#{SecureRandom.rand(1000).to_s.rjust(3, '0')}" }
+      ufn do
+        random_date = Faker::Date.between(from: 10.years.ago, to: 1.day.ago)
+        "#{random_date.strftime('%d%m%y')}/#{SecureRandom.rand(1000).to_s.rjust(3, '0')}"
+      end
       firm_office factory: %i[firm_office valid randomised]
     end
   end

--- a/spec/lib/tasks/submit_dummy_data_spec.rb
+++ b/spec/lib/tasks/submit_dummy_data_spec.rb
@@ -60,4 +60,19 @@ describe 'submit_dummy_data:', type: :task do
       expect(builder).to have_received(:build_many).with(bulk: 300, large: 30, year: 2020)
     end
   end
+
+  describe 'prior_authority_rfi' do
+    let(:resubmitter) { instance_double(TestData::PaResubmitter, resubmit: true) }
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+      allow($stdin).to receive(:gets).and_return 'y'
+      allow(TestData::PaResubmitter).to receive(:new).and_return(resubmitter)
+    end
+
+    it 'passes arguments to the resubmitter' do
+      Rake::Task['submit_dummy_data:prior_authority_rfi'].invoke('50')
+      expect(resubmitter).to have_received(:resubmit).with(50)
+    end
+  end
 end

--- a/spec/lib/test_data/nsm_builder_spec.rb
+++ b/spec/lib/test_data/nsm_builder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TestData::NsmBuilder do
       expect(data.count).to eq(2)
 
       data.each do |ufn, rep_order_date, cntp_date|
-        expect(ufn).to match(%r{\A\d{4}20/00\d\z})
+        expect(ufn).to match(%r{\A\d{6}/\d{3}\z})
         date = rep_order_date || cntp_date
         expect(date.year).to eq(2020)
       end

--- a/spec/lib/test_data/pa_builder_spec.rb
+++ b/spec/lib/test_data/pa_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TestData::PaBuilder do
       expect(data.count).to eq(2)
 
       data.all? do |ufn|
-        expect(ufn).to match(%r{\A\d{4}20/\d{3}\z})
+        expect(ufn).to match(%r{\A\d{6}/\d{3}\z})
       end
     end
 

--- a/spec/lib/test_data/pa_resubmitter_spec.rb
+++ b/spec/lib/test_data/pa_resubmitter_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe TestData::PaResubmitter do
+  describe '#resubmit' do
+    let(:client) { double(AppStoreClient, put: true, get: old_payload) }
+
+    let(:old_payload) { SubmitToAppStore::PriorAuthorityPayloadBuilder.new(application:).payload.deep_stringify_keys }
+
+    before do
+      allow(AppStoreClient).to receive(:new).and_return(client)
+    end
+
+    context 'when there is a further information needed app' do
+      let(:application) { create :prior_authority_application, :full, :with_further_information_request }
+
+      it 'can resubmit it' do
+        subject.resubmit(100)
+        expect(application.reload).to be_provider_updated
+        expect(client).to have_received(:put)
+      end
+    end
+
+    context 'when there is a corrections needed app' do
+      let(:application) { create :prior_authority_application, :full, :sent_back_for_incorrect_info }
+
+      it 'can resubmit it' do
+        subject.resubmit(100)
+        expect(application.reload).to be_provider_updated
+        expect(client).to have_received(:put)
+      end
+    end
+
+    context 'when there is a normal app' do
+      let(:application) { create :prior_authority_application, :full, status: :submitted }
+
+      it 'does not touch it' do
+        subject.resubmit(100)
+        expect(application.reload).to be_submitted
+        expect(client).not_to have_received(:put)
+      end
+    end
+
+    context 'when there is are multiple apps' do
+      let(:application) { create :prior_authority_application, :full, :with_further_information_request }
+      let(:other_application) { create :prior_authority_application, :full, :with_further_information_request }
+
+      before { other_application }
+
+      it 'respects percentages' do
+        subject.resubmit(50)
+        expect(client).to have_received(:put).exactly(1).time
+        expect(PriorAuthorityApplication.provider_updated.count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/models/prior_authority_application_spec.rb
+++ b/spec/models/prior_authority_application_spec.rb
@@ -39,4 +39,28 @@ RSpec.describe PriorAuthorityApplication do
       end
     end
   end
+
+  describe '#further_information_needed?' do
+    context 'a draft application' do
+      subject(:prior_authority_application) { create(:prior_authority_application, status: 'draft') }
+
+      it { expect(prior_authority_application).not_to be_further_information_needed }
+    end
+
+    context 'a sent back application' do
+      subject(:prior_authority_application) do
+        create(:prior_authority_application, :with_further_information_request, app_store_updated_at:)
+      end
+
+      let(:app_store_updated_at) { DateTime.current - 1.day }
+
+      it { expect(prior_authority_application).to be_further_information_needed }
+    end
+
+    context 'a sent back application with no further information' do
+      subject(:prior_authority_application)  { create(:prior_authority_application, status: 'sent_back') }
+
+      it { expect(prior_authority_application).not_to be_further_information_needed }
+    end
+  end
 end

--- a/spec/system/accessibility_spec.rb
+++ b/spec/system/accessibility_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Accessibility', :accessibility do
 
   context 'when viewing PA further information screen' do
     describe 'edit_prior_authority_steps_further_information screen' do
-      let(:application) { create(:prior_authority_application, :with_further_information) }
+      let(:application) { create(:prior_authority_application, :with_further_information_request) }
 
       before { visit send(:edit_prior_authority_steps_further_information_path, application) }
 


### PR DESCRIPTION
## Description of change
- Randomise dummy PA and NSM data
- Allow randomised resubmitting of RFI'd

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
