### PR TITLE
CRM457-1660: Use internal hostname to bypass modsec

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -45,7 +45,6 @@ CLAMBY_ENABLED=true
 
 # ingress and protocol for webhook subscription to app store - must match local apps's rails server
 HOSTS=localhost:3001
-PROTOCOL=http
 
 # Can generate your own test key here or use dev key here to send to team members emails
 # see https://www.notifications.service.gov.uk/

--- a/app/services/app_store_subscriber.rb
+++ b/app/services/app_store_subscriber.rb
@@ -6,11 +6,12 @@ class AppStoreSubscriber
   end
 
   def subscribe
-    return if ENV['HOSTS'].blank?
+    hostname = ENV.fetch('INTERNAL_HOST_NAME', ENV.fetch('HOSTS', nil)&.split(',')&.first)
+    return if hostname.blank?
 
     url = app_store_webhook_url(
-      host: ENV.fetch('HOSTS', nil),
-      protocol: ENV.fetch('PROTOCOL', 'https')
+      host: hostname,
+      protocol: 'http'
     )
 
     AppStoreClient.new.post(

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts = ENV["HOSTS"]&.split(',') || []
+  config.hosts = (ENV["HOSTS"]&.split(',') || []) + [ENV.fetch('INTERNAL_HOST_NAME', nil)].compact
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == '/ping' } }
 

--- a/helm_deploy/templates/_helpers.tpl
+++ b/helm_deploy/templates/_helpers.tpl
@@ -70,3 +70,10 @@ If branch name contains "redis" then the redis-release-name appends "-master", o
   {{- $redis_fullName := (include "common.names.fullname" .Subcharts.redis) -}}
   {{- printf "%s-master.%s.svc.cluster.local" $redis_fullName .Release.Namespace -}}
 {{- end -}}
+
+{{/*
+Function to return the internal host name of the current service
+*/}}
+{{- define "helm_deploy.internalHostName" -}}
+  {{- printf "%s.%s.svc.cluster.local" .Values.nameOverride .Release.Namespace -}}
+{{- end -}}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -209,6 +209,8 @@ spec:
               value: {{ .Values.variables.eolUrl }}
             - name: HOSTS
               value: {{ range $index, $hostObject := .Values.ingress.hosts }}{{ if ne $index 0 }},{{ end }}{{ $hostObject.host }}{{ end }}
+            - name: INTERNAL_HOST_NAME
+              value: {{ template "helm_deploy.internalHostName" . }}
             - name: ENABLE_SYNC_TRIGGER_ENDPOINT
               value: '{{ .Values.variables.enableSyncTriggerEndpoint }}'
             - name: ALLOW_INDEXING

--- a/spec/services/app_store_subscriber_spec.rb
+++ b/spec/services/app_store_subscriber_spec.rb
@@ -2,6 +2,13 @@ require 'rails_helper'
 
 RSpec.describe AppStoreSubscriber do
   describe '.call' do
+    let(:client) { instance_double(AppStoreClient) }
+
+    before do
+      allow(AppStoreClient).to receive(:new).and_return(client)
+      allow(client).to receive(:post)
+    end
+
     context 'when there is no defined host' do
       it 'does not make a request' do
         expect(AppStoreClient).not_to receive(:new)
@@ -10,23 +17,16 @@ RSpec.describe AppStoreSubscriber do
     end
 
     context 'when there is a host' do
-      let(:client) { instance_double(AppStoreClient) }
-
       around do |example|
         ENV['HOSTS'] = 'example.com'
         example.run
         ENV['HOSTS'] = nil
       end
 
-      before do
-        allow(AppStoreClient).to receive(:new).and_return(client)
-        allow(client).to receive(:post)
-      end
-
       it 'makes a request' do
         described_class.call
         expect(client).to have_received(:post).with(
-          { webhook_url: 'https://example.com/app_store_webhook', subscriber_type: :provider },
+          { webhook_url: 'http://example.com/app_store_webhook', subscriber_type: :provider },
           path: 'v1/subscriber'
         )
       end
@@ -41,6 +41,38 @@ RSpec.describe AppStoreSubscriber do
           expect { described_class.call }.not_to raise_error
           expect(Sentry).to have_received(:capture_exception)
         end
+      end
+    end
+
+    context 'when there are multiple hosts' do
+      around do |example|
+        ENV['HOSTS'] = 'other.com,example.com'
+        example.run
+        ENV['HOSTS'] = nil
+      end
+
+      it 'picks the first one' do
+        described_class.call
+        expect(client).to have_received(:post).with(
+          { webhook_url: 'http://other.com/app_store_webhook', subscriber_type: :provider },
+          path: 'v1/subscriber'
+        )
+      end
+    end
+
+    context 'when there is an internal host' do
+      around do |example|
+        ENV['INTERNAL_HOST_NAME'] = 'internal.svc.local'
+        example.run
+        ENV['INTERNAL_HOST_NAME'] = nil
+      end
+
+      it 'uses that' do
+        described_class.call
+        expect(client).to have_received(:post).with(
+          { webhook_url: 'http://internal.svc.local/app_store_webhook', subscriber_type: :provider },
+          path: 'v1/subscriber'
+        )
       end
     end
   end


### PR DESCRIPTION
## Description of change
By using the service URL instead of the host name associated with the ingress to construct our webhook url, we allow our app store -> provider HTTP requests to bypass modsec, which is good because modsec is notorious for false positives, and these requests should never be treated as a modsec positive.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1660)

## Notes for reviewer
I have adjusted our Cloud Platform permissions to allow internal network requests from the app store namespaces to the provider namespaces.
