### PR TITLE
put update_and_advance method in transaction to lock application whil…

### DIFF
--- a/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
+++ b/gems/laa_multi_step_forms/app/controllers/steps/base_step_controller.rb
@@ -31,25 +31,27 @@ module Steps
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def update_and_advance(form_class, opts = {})
-      hash = permitted_params(form_class).to_h
-      record = opts.fetch(:record, current_application)
-      @form_object = form_class.new(
-        hash.merge(application: current_application, record: record)
-      )
+      current_application.transaction do
+        hash = permitted_params(form_class).to_h
+        record = opts.fetch(:record, current_application)
+        @form_object = form_class.new(
+          hash.merge(application: current_application, record: record)
+        )
 
-      if params.key?(:commit_draft)
-        # Validations will not be run when saving a draft
-        @form_object.save!
-        redirect_to opts[:after_commit_redirect_path] || nsm_after_commit_path(id: current_application.id)
-      elsif params.key?(:reload)
-        reload
-      elsif params.key?(:save_and_refresh)
-        @form_object.save!
-        redirect_to_current_object
-      elsif @form_object.save
-        redirect_to decision_tree_class.new(@form_object, as: opts.fetch(:as)).destination, flash: opts[:flash]
-      else
-        render opts.fetch(:render, :edit)
+        if params.key?(:commit_draft)
+          # Validations will not be run when saving a draft
+          @form_object.save!
+          redirect_to opts[:after_commit_redirect_path] || nsm_after_commit_path(id: current_application.id)
+        elsif params.key?(:reload)
+          reload
+        elsif params.key?(:save_and_refresh)
+          @form_object.save!
+          redirect_to_current_object
+        elsif @form_object.save
+          redirect_to decision_tree_class.new(@form_object, as: opts.fetch(:as)).destination, flash: opts[:flash]
+        else
+          render opts.fetch(:render, :edit)
+        end
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION

## Description of change

[Provider: Fast Submit Clicks Can Wrongly Create Multiple Records](https://dsdmoj.atlassian.net/browse/CRM457-1746)

## Notes for reviewer
This is just part 1 of the bug fix - also need to lock button once form is submitted, this can be done in separate PR