### PR TITLE
CRM457-1747: Add task to fix applications with multiple primary quotes

### DIFF
--- a/app/jobs/submit_to_app_store.rb
+++ b/app/jobs/submit_to_app_store.rb
@@ -7,8 +7,8 @@ class SubmitToAppStore < ApplicationJob
     notify(submission)
   end
 
-  def submit(submission)
-    payload = PayloadBuilder.call(submission)
+  def submit(submission, include_events: true)
+    payload = PayloadBuilder.call(submission, include_events:)
     client = AppStoreClient.new
 
     if submission.is_a?(PriorAuthorityApplication)

--- a/app/services/fixes/multiple_primary_quote_fixer.rb
+++ b/app/services/fixes/multiple_primary_quote_fixer.rb
@@ -1,0 +1,53 @@
+module Fixes
+  class MultiplePrimaryQuoteFixer
+    # We discovered that by multi-clicking the primary quote submit screen, users
+    # could cause multiple primary quotes to be registered on our system
+    def identify
+      PriorAuthorityApplication.where(id: affected_application_ids).pluck(:id, :status, :laa_reference)
+    end
+
+    def fix
+      affected_application_ids.each do |id|
+        application = PriorAuthorityApplication.find(id)
+        application.quotes.where(primary: true).where.not(id: true_primary_quote_id(application)).find_each do |quote|
+          delete_upload(quote)
+          quote.destroy
+        end
+
+        update_app_store(application) unless application.draft?
+      end
+    end
+
+    private
+
+    def affected_application_ids
+      Quote.group(:prior_authority_application_id)
+           .having('COUNT(id) > 1')
+           .where(primary: true)
+           .pluck('prior_authority_application_id')
+    end
+
+    def true_primary_quote_id(application)
+      application.quotes.where(primary: true).detect { _1.total_cost.positive? }.id
+    end
+
+    def delete_upload(quote)
+      file_uploader.destroy(quote.document.file_path) if quote.document.file_path
+    end
+
+    def update_app_store(application)
+      old_status = application.status
+
+      # The app store will only allow updates from "sent_back" to "provider_updated"
+      # We assume that any affected submissions will be manually put into "sent_back"
+      #  before this job runs, and then put into their intended state after it runs.
+      application.provider_updated!
+      SubmitToAppStore.new.submit(application, include_events: false)
+      application.update(status: old_status)
+    end
+
+    def file_uploader
+      @file_uploader ||= FileUpload::FileUploader.new
+    end
+  end
+end

--- a/app/services/submit_to_app_store/payload_builder.rb
+++ b/app/services/submit_to_app_store/payload_builder.rb
@@ -1,11 +1,11 @@
 class SubmitToAppStore
   class PayloadBuilder
-    def self.call(submission)
+    def self.call(submission, include_events: true)
       case submission
       when Claim
         NsmPayloadBuilder.new(claim: submission).payload
       when PriorAuthorityApplication
-        PriorAuthorityPayloadBuilder.new(application: submission).payload
+        PriorAuthorityPayloadBuilder.new(application: submission, include_events: include_events).payload
       else
         raise 'Unknown submission type'
       end

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -1,7 +1,8 @@
 class SubmitToAppStore
   class PriorAuthorityPayloadBuilder
-    def initialize(application:)
+    def initialize(application:, include_events: true)
       @application = application
+      @include_events = include_events
     end
 
     def payload
@@ -11,7 +12,7 @@ class SubmitToAppStore
         application: data,
         application_type: 'crm4',
         application_risk: 'N/A',
-        events: PriorAuthority::EventBuilder.call(application, data) }
+        events: @include_events ? PriorAuthority::EventBuilder.call(application, data) : [] }
     end
 
     def data

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -1,0 +1,17 @@
+
+namespace :fixes do
+  namespace :multiple_primary_quotes do
+    desc "Identify historic instances where a PA application could get multiple primary quotes"
+    task identify: :environment do
+      puts "Application IDs where there are multiple primary quotes. " \
+           "These will need to be made provider-editable in the app store before they can be fixed, " \
+           "and then moved back to their original state after they are fixed"
+      puts Fixes::MultiplePrimaryQuoteFixer.new.identify
+    end
+
+    desc "Fix historic instances where a PA application could get multiple primary quotes"
+    task fix: :environment do
+      Fixes::MultiplePrimaryQuoteFixer.new.fix
+    end
+  end
+end

--- a/spec/jobs/submit_to_app_store_spec.rb
+++ b/spec/jobs/submit_to_app_store_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SubmitToAppStore do
 
     it 'generates a payload' do
       expect(described_class::PayloadBuilder).to receive(:call)
-        .with(submission)
+        .with(submission, include_events: true)
 
       subject.perform(submission:)
     end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'fixes:', type: :task do
+  describe 'multiple_primary_quotes:' do
+    let(:service) { instance_double(Fixes::MultiplePrimaryQuoteFixer, identify: output, fix: true) }
+    let(:output) { 'HERE IS SOME DATA' }
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+      allow(Fixes::MultiplePrimaryQuoteFixer).to receive(:new).and_return(service)
+      allow($stdout).to receive(:puts)
+    end
+
+    describe 'identify' do
+      subject { Rake::Task['fixes:multiple_primary_quotes:identify'].execute }
+
+      it 'calls the right service and prints the output' do
+        subject
+        expect($stdout).to have_received(:puts).with(output)
+      end
+    end
+
+    describe 'fix' do
+      subject { Rake::Task['fixes:multiple_primary_quotes:fix'].execute }
+
+      it 'calls the right service and prints the output' do
+        subject
+        expect(service).to have_received(:fix)
+      end
+    end
+  end
+end

--- a/spec/services/fixes/multiple_primary_quote_fixer_spec.rb
+++ b/spec/services/fixes/multiple_primary_quote_fixer_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Fixes::MultiplePrimaryQuoteFixer do
+  describe '#identify' do
+    let(:application) { create :prior_authority_application }
+    let(:other_application) { create :prior_authority_application, :with_complete_prison_law }
+    let(:first_primary) { create :quote, :primary, prior_authority_application: application }
+    let(:second_primary) { create :quote, :primary, prior_authority_application: application }
+
+    before do
+      other_application
+      first_primary
+      second_primary
+    end
+
+    it 'correctly identifies' do
+      expect(described_class.new.identify).to eq([[application.id, application.status, application.laa_reference]])
+    end
+  end
+
+  describe '#fix' do
+    let(:application) { create :prior_authority_application, :with_complete_prison_law, quotes: [], status: status }
+    let(:status) { 'submitted' }
+    let(:first_primary) { create :quote, :primary, prior_authority_application: application }
+
+    let(:second_primary) do
+      create :quote, :per_hour, :primary, period: nil, cost_per_hour: nil, prior_authority_application: application
+    end
+
+    let(:uploader) { instance_double(FileUpload::FileUploader, destroy: true) }
+    let(:client) { instance_double(AppStoreClient, put: :success) }
+
+    before do
+      first_primary
+      second_primary
+      allow(FileUpload::FileUploader).to receive(:new).and_return(uploader)
+      allow(AppStoreClient).to receive(:new).and_return(client)
+
+      described_class.new.fix
+    end
+
+    it 'deletes the incomplete quote' do
+      expect(application.quotes.where(primary: true).count).to eq 1
+      expect(application.reload.primary_quote).to eq first_primary
+    end
+
+    it 'preserves the status' do
+      expect(application.reload).to be_submitted
+    end
+
+    it 'deletes the incomplete quote uploaded file' do
+      expect(uploader).to have_received(:destroy).with(second_primary.document.file_path)
+    end
+
+    it 'triggers a PUT to the app store with a status the app store will accept' do
+      expect(client).to have_received(:put) do |args|
+        expect(args[:application_id]).to eq application.id
+        expect(args[:application_state]).to eq 'provider_updated'
+      end
+    end
+
+    context 'when status is draft' do
+      let(:status) { 'draft' }
+
+      it 'does not bother the app store' do
+        expect(client).not_to have_received(:put)
+      end
+    end
+
+    context 'when second quote has no document' do
+      let(:second_primary) do
+        create :quote, :per_hour,
+               :primary, period: nil, cost_per_hour: nil, prior_authority_application: application,
+               document: build(:quote_document, file_path: nil)
+      end
+
+      it 'does not try to delete the incomplete quote uploaded file' do
+        expect(uploader).not_to have_received(:destroy)
+      end
+    end
+  end
+end

--- a/spec/services/submit_to_app_store/payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/payload_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmitToAppStore::PayloadBuilder do
 
     it 'delegates to NsmPayloadBuilder' do
       expect(SubmitToAppStore::PriorAuthorityPayloadBuilder).to(
-        receive(:new).with(application: submission).and_return(builder)
+        receive(:new).with(application: submission, include_events: true).and_return(builder)
       )
       subject
     end


### PR DESCRIPTION
## Description of change
Intended usage:
- First run `identify` to find applications that need fixing
- Run the new app store task to temporarily set those to `sent_back`
- Then run `fix` to correct the data and send a new version to the app store
- Run the new app store task to set the applications back to their correct state and notify caseworker so it syncs everything correctly.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1747)
