### PR TITLE
CRM457-1721: Remove modsec false positives

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -34,6 +34,8 @@ metadata:
       SecRuleRemoveById 921110
       SecRuleRemoveById 933210
       SecRuleRemoveById 942230
+      SecRuleRemoveById 951220
+      SecRuleRemoveById 952100
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### 951220, "mssql SQL Information Leakage"
Redundant because we don't use mssql. False positives happening in the wild (so far only on the app store metabase)

### 952100, "Java Source Code Leakage"
Redundant because we don't use Java. False positives happening on our javascript sourcemaps