### PR TITLE
CRM457-1715: Add timestamps to PA payload on submission

### DIFF
--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -100,6 +100,8 @@ class SubmitToAppStore
       no_alternative_quote_reason
       confirm_excluding_vat
       confirm_travel_expenditure
+      created_at
+      updated_at
     ].freeze
   end
 end


### PR DESCRIPTION
## Description of change
CRM457-1715: Add timestamps to PA payload on submission

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1715)

So we can use for setting appstore application.last_updated_at
for submitted applications with no events. This prevents delays
in creation of the record due to sidekiq processing from impacting
search results that look for applications based on when the
applications was "last_updated_at" - which for new applications is 
should be set to be when the "application" blob was sent (i.e. pa record's updated_at 
at point of submission).

## Notes for reviewer
