### PR TITLE
Experiment: With minimal modsec config, is phase 4 still broken?

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -21,23 +21,11 @@ metadata:
     {{- include "laa-submit-crime-forms.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/custom-http-errors: "423"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecRequestBodyNoFilesLimit 524288
-      SecRequestBodyLimit 104857600
-      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team,status:423"
-      SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team,status:423"
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      SecRuleRemoveById 920120
-      SecRuleRemoveById 921110
-      SecRuleRemoveById 933210
-      SecRuleRemoveById 942230
-      SecRuleRemoveById 951120
-      SecRuleRemoveById 951220
-      SecRuleRemoveById 952100
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
+      SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Yes. https://crm457-1721-b-expl-nscc-provider-dev.cloud-platform.service.justice.gov.uk/assets/file-upload-a2e2c5e8.js.map triggers a false positive on rule 952100, and modsec thinks it is blocking it and replacing the status with a 403, but the body is still returned to the HTTP requester. The status code is coming across as either 200 or ERR_HTTP2_PROTOCOL_ERROR on the client-side, and the kibana logs list it as a 500.