### PR TITLE
[CRM457-789] letters calls validation if uplift apply true

### DIFF
--- a/app/forms/nsm/steps/letters_calls_form.rb
+++ b/app/forms/nsm/steps/letters_calls_form.rb
@@ -10,7 +10,11 @@ module Nsm
       attribute :calls_uplift, :integer
 
       validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
+      validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: false },
+        if: :apply_letters_uplift
       validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
+      validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: false },
+        if: :apply_calls_uplift
       validates :letters_uplift, presence: true,
         numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
         if: :apply_letters_uplift

--- a/app/forms/nsm/steps/letters_calls_form.rb
+++ b/app/forms/nsm/steps/letters_calls_form.rb
@@ -10,14 +10,12 @@ module Nsm
       attribute :calls_uplift, :integer
 
       validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
-      validates :letters, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: false },
-        if: :apply_letters_uplift
       validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_blank: true }
-      validates :calls, numericality: { only_integer: true, greater_than_or_equal_to: 1, allow_blank: false },
-        if: :apply_calls_uplift
+      validate :zero_letters_uplift_applied
       validates :letters_uplift, presence: true,
         numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
         if: :apply_letters_uplift
+      validate :zero_calls_uplift_applied
       validates :calls_uplift, presence: true,
         numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 },
         if: :apply_calls_uplift
@@ -88,6 +86,14 @@ module Nsm
           'letters_uplift' => apply_letters_uplift ? letters_uplift : nil,
           'calls_uplift' => apply_calls_uplift ? calls_uplift : nil,
         )
+      end
+
+      def zero_letters_uplift_applied
+        errors.add(:letters_uplift, :uplift_on_zero) if apply_letters_uplift && letters.to_i.zero?
+      end
+
+      def zero_calls_uplift_applied
+        errors.add(:calls_uplift, :uplift_on_zero) if apply_calls_uplift && calls.to_i.zero?
       end
     end
   end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -469,20 +469,20 @@ en:
           attributes:
             letters:
               blank: Set the number of letters
-              less_than_or_equal_to: You cannot add an uplift if there are 0 letters
-              greater_than_or_equal_to: You cannot add an uplift if there are 0 letters
+              greater_than_or_equal_to: You cannot apply an uplift if there are 0 letters
             calls:
               blank: Set the number of calls
-              less_than_or_equal_to: You cannot add an uplift if there are 0 calls
-              greater_than_or_equal_to: You cannot add an uplift if there are 0 calls
+              greater_than_or_equal_to: You cannot apply an uplift if there are 0 calls
             letters_uplift:
-              blank: Letters uplift percentage must be set
+              blank: Letters uplift percentage must be from 1 to 100
               less_than_or_equal_to: Letters uplift percentage must be from 1 to 100
               greater_than_or_equal_to: Letters uplift percentage must be from 1 to 100
+              uplift_on_zero: You cannot add an uplift if there are 0 letters
             calls_uplift:
-              blank: Calls uplift percentage must be set
+              blank: Phone calls uplift percentage must be from 1 to 100
               less_than_or_equal_to: Phone calls uplift percentage must be from 1 to 100
               greater_than_or_equal_to: Phone calls uplift percentage must be from 1 to 100
+              uplift_on_zero: You cannot add an uplift if there are 0 phone calls
         nsm/steps/disbursement_type_form:
           attributes:
             disbursement_date: *shared_date_errors

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -469,16 +469,20 @@ en:
           attributes:
             letters:
               blank: Set the number of letters
+              less_than_or_equal_to: You cannot add an uplift if there are 0 letters
+              greater_than_or_equal_to: You cannot add an uplift if there are 0 letters
             calls:
               blank: Set the number of calls
+              less_than_or_equal_to: You cannot add an uplift if there are 0 calls
+              greater_than_or_equal_to: You cannot add an uplift if there are 0 calls
             letters_uplift:
               blank: Letters uplift percentage must be set
-              less_than_or_equal_to: You can only apply an uplift from 1 to 100
-              greater_than_or_equal_to: You can only apply an uplift from 1 to 100
+              less_than_or_equal_to: Letters uplift percentage must be from 1 to 100
+              greater_than_or_equal_to: Letters uplift percentage must be from 1 to 100
             calls_uplift:
               blank: Calls uplift percentage must be set
-              less_than_or_equal_to: You can only apply an uplift from 1 to 100
-              greater_than_or_equal_to: You can only apply an uplift from 1 to 100
+              less_than_or_equal_to: Phone calls uplift percentage must be from 1 to 100
+              greater_than_or_equal_to: Phone calls uplift percentage must be from 1 to 100
         nsm/steps/disbursement_type_form:
           attributes:
             disbursement_date: *shared_date_errors

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -276,8 +276,8 @@ en:
           'true': Apply an uplift to this work
         apply_calls_uplift_options:
           'true': Apply an uplift to this work
-        letters_uplift: For example, from any percentage from 1 to 100
-        calls_uplift: For example, from any percentage from 1 to 100
+        letters_uplift: Enter a letters uplift percentage from 1 to 100
+        calls_uplift: Enter a calls uplift percentage from 1 to 100
       nsm_steps_disbursement_add_form:
         has_disbursements_options:
           'yes': 'Yes'

--- a/spec/forms/nsm/steps/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/steps/letters_calls_form_spec.rb
@@ -38,16 +38,16 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
 
       context 'is blank' do
         let(:letters) { '' }
+        let(:apply_letters_uplift) { 'false' }
 
-        it 'have an error' do
-          expect(subject).not_to be_valid
-        end
+        it { expect(subject).to be_valid }
       end
 
       context 'is zero' do
         let(:letters) { 0 }
+        let(:apply_letters_uplift) { 'false' }
 
-        it { expect(subject).not_to be_valid }
+        it { expect(subject).to be_valid }
       end
 
       context 'is positive' do
@@ -69,10 +69,9 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
 
       context 'is blank' do
         let(:calls) { '' }
+        let(:apply_calls_uplift) { 'false' }
 
-        it 'have an error' do
-          expect(subject).not_to be_valid
-        end
+        it { expect(subject).to be_valid }
       end
 
       context 'is zero and apply_calls_uplift false' do
@@ -90,7 +89,7 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
 
         it 'has an error' do
           expect(subject).not_to be_valid
-          expect(subject.errors.of_kind?(:calls, :greater_than_or_equal_to)).to be(true)
+          expect(subject.errors.of_kind?(:calls_uplift, :uplift_on_zero)).to be(true)
         end
       end
 
@@ -136,7 +135,7 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
 
           it 'has an error' do
             expect(subject).not_to be_valid
-            expect(subject.errors.of_kind?(:letters, :greater_than_or_equal_to)).to be(true)
+            expect(subject.errors.of_kind?(:letters_uplift, :uplift_on_zero)).to be(true)
           end
         end
 

--- a/spec/forms/nsm/steps/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/steps/letters_calls_form_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         let(:letters) { '' }
 
         it 'have an error' do
-          expect(subject).to be_valid
+          expect(subject).not_to be_valid
         end
       end
 
       context 'is zero' do
         let(:letters) { 0 }
 
-        it { expect(subject).to be_valid }
+        it { expect(subject).not_to be_valid }
       end
 
       context 'is positive' do
@@ -71,14 +71,14 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         let(:calls) { '' }
 
         it 'have an error' do
-          expect(subject).to be_valid
+          expect(subject).not_to be_valid
         end
       end
 
       context 'is zero' do
         let(:calls) { 0 }
 
-        it { expect(subject).to be_valid }
+        it { expect(subject).not_to be_valid }
       end
 
       context 'is positive' do

--- a/spec/forms/nsm/steps/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/steps/letters_calls_form_spec.rb
@@ -75,10 +75,23 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         end
       end
 
-      context 'is zero' do
+      context 'is zero and apply_calls_uplift false' do
         let(:calls) { 0 }
+        let(:apply_calls_uplift) { 'false' }
 
-        it { expect(subject).not_to be_valid }
+        it 'has no error' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'is zero and apply_calls_uplift is true' do
+        let(:calls) { 0 }
+        let(:apply_calls_uplift) { 'true' }
+
+        it 'has an error' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:calls, :greater_than_or_equal_to)).to be(true)
+        end
       end
 
       context 'is positive' do
@@ -108,10 +121,23 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
           end
         end
 
-        context 'is zero' do
-          let(:letters_uplift) { 0 }
+        context 'is zero and apply_letter_uplift false' do
+          let(:letters) { 0 }
+          let(:apply_letters_uplift) { 'false' }
 
-          it { expect(subject).not_to be_valid }
+          it 'has no error' do
+            expect(subject).to be_valid
+          end
+        end
+
+        context 'is zero and apply_letter_uplift is true' do
+          let(:letters) { 0 }
+          let(:apply_letters_uplift) { 'true' }
+
+          it 'has an error' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:letters, :greater_than_or_equal_to)).to be(true)
+          end
         end
 
         context 'is positive' do

--- a/spec/system/nsm/letters_calls_spec.rb
+++ b/spec/system/nsm/letters_calls_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe 'User can fill in claim type details', type: :system do
 
     within '[data-cy=apply-letters-uplift]' do
       check 'Apply an uplift to this work'
-      fill_in 'For example, from any percentage from 1 to 100', with: 10
+      fill_in 'Enter a letters uplift percentage from 1 to 100', with: 10
     end
 
     within '[data-cy=apply-calls-uplift]' do
       check 'Apply an uplift to this work'
-      fill_in 'For example, from any percentage from 1 to 100', with: 20
+      fill_in 'Enter a calls uplift percentage from 1 to 100', with: 20
     end
 
     click_on 'Save and continue'


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-789)

## Notes for reviewer
adds validation to catch 0 or blank uplifts on letter and calls form in CRM7 

## Screenshots of changes (if applicable)
<img width="1221" alt="Screenshot 2024-07-23 at 09 15 19" src="https://github.com/user-attachments/assets/3985e2f3-98ac-4032-a24e-1389c60303ab">

<img width="1037" alt="Screenshot 2024-07-23 at 09 15 40" src="https://github.com/user-attachments/assets/0819da12-e8f0-4549-a4c7-9c2ff35a1416">

### Before changes:
<img width="973" alt="Screenshot 2024-07-23 at 09 18 30" src="https://github.com/user-attachments/assets/f5e9a6ff-55e0-4e2f-aefe-b6dc140378ca">

Provider could enter 0 or leave blank and apply an uplift percentage to that

### After changes:
Validation catches uplift applied to 0 or blank and feebacks warning message to provider on save

## How to manually test the feature
- create a CRM7 and on letters and calls form enter a blank or 0 for either/both letter or calls and apply and uplift
- save for will respond with expected validation errors
