### PR TITLE
[CRM457-1547] Add linting for the output helm template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,15 @@ jobs:
     executor: test-executor
     steps:
       - checkout
+      - helm/install_helm_client:
+          version: 3.7.2
+      - run:
+          name: Ensure that the template chart doesn't contain any issues
+          command: |
+            sudo apt update
+            sudo apt install -y python3-pip
+            pip install yamllint
+            helm template --debug helm_deploy --values helm_deploy/values-prod.yaml | yamllint -
       - setup_remote_docker:
           docker_layer_caching: true
       - build-docker-image-for-scan
@@ -326,8 +335,6 @@ jobs:
       - run:
           name: Monitor container image for vulnerabilities
           command: snyk container monitor app
-      - helm/install_helm_client:
-          version: 3.7.2
       - run:
           name: Test IaC files
           command: |

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  trailing-spaces: disable
+  indentation: disable
+  brackets: disable
+  comments: disable
+  comments-indentation: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true


### PR DESCRIPTION
## Description of change

Mostly setup to catch issues with duplicate keys, there are a number of other rules that can be found below.

https://yamllint.readthedocs.io/en/stable/rules.html

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1547)

Started from a [conversation](https://mojdt.slack.com/archives/C06HFRK36KY/p1721746330169129) on Slack