### PR TITLE
CRM457-1783: Multiple FIs

### DIFF
--- a/spec/controllers/nsm/steps/defendants_delete_controller_spec.rb
+++ b/spec/controllers/nsm/steps/defendants_delete_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nsm::Steps::DefendantDeleteController, type: :controller do
     # Needed because some specs that include these examples stub current_application,
     # which is undesirable for this particular test
     allow(controller).to receive(:current_application).and_return(current_application)
-    allow(current_application).to receive(:with_lock).and_yield
+    allow(current_application).to receive(:with_lock).and_yield if current_application
   end
 
   describe '#edit' do

--- a/spec/controllers/nsm/steps/disbursements_delete_controller_spec.rb
+++ b/spec/controllers/nsm/steps/disbursements_delete_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nsm::Steps::DisbursementDeleteController, type: :controller do
     # Needed because some specs that include these examples stub current_application,
     # which is undesirable for this particular test
     allow(controller).to receive(:current_application).and_return(current_application)
-    allow(current_application).to receive(:with_lock).and_yield
+    allow(current_application).to receive(:with_lock).and_yield if current_application
   end
 
   describe '#edit' do

--- a/spec/controllers/nsm/steps/work_items_delete_controller_spec.rb
+++ b/spec/controllers/nsm/steps/work_items_delete_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nsm::Steps::WorkItemDeleteController, type: :controller do
     # Needed because some specs that include these examples stub current_application,
     # which is undesirable for this particular test
     allow(controller).to receive(:current_application).and_return(current_application)
-    allow(current_application).to receive(:with_lock).and_yield
+    allow(current_application).to receive(:with_lock).and_yield if current_application
   end
 
   describe '#edit' do


### PR DESCRIPTION
## Description of change
Currently transient errors etc can lead to FIs being duplicated. This ensures that each FI is only created once in the DB.
Also removes some warnings from the tests by stopping `allow`ing on nil.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1783)
