### PR TITLE
Add additional helm chart and yaml linting/verifying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,14 @@ references:
     attach_workspace:
       at: ~/repo/tmp
 
+  _install-yamllint: &install-yamllint
+    run:
+      name: Install yamllint to use to check yaml formatting issues
+      command: |
+        sudo apt update
+        sudo apt install -y python3-pip
+        pip install yamllint
+
 # ------------------
 # COMMANDS
 # ------------------
@@ -127,6 +135,26 @@ commands:
       - run:
           name: Run rubocop
           command: bundle exec rubocop
+
+  # using a more recent version of yamllink so we can use the key_duplicates rule
+  # https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.key_duplicates
+
+  lint-and-verify-helm-config:
+      description:
+      parameters:
+        environment:
+          description: Name of environment to check helm template of
+          type: string
+      steps:
+        - helm/install_helm_client:
+            version: 3.7.2
+        - *install-yamllint
+        - run:
+            name: Lint helm chart for <<parameters.environment>>
+            command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
+        - run:
+            name: Check helm template for <<parameters.environment>>
+            command: helm template --debug helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml | yamllint -
 
   db-setup:
     steps:
@@ -255,6 +283,12 @@ jobs:
       - checkout
       - install-gems
       - rubocop
+      - lint-and-verify-helm-config:
+          environment: dev
+      - lint-and-verify-helm-config:
+          environment: uat
+      - lint-and-verify-helm-config:
+          environment: prod
 
   rspec-tests:
     parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,9 +146,6 @@ commands:
           description: Name of environment to check helm template of
           type: string
       steps:
-        - helm/install_helm_client:
-            version: 3.7.2
-        - *install-yamllint
         - run:
             name: Lint helm chart for <<parameters.environment>>
             command: helm lint helm_deploy --values helm_deploy/values-<<parameters.environment>>.yaml
@@ -283,6 +280,9 @@ jobs:
       - checkout
       - install-gems
       - rubocop
+      - helm/install_helm_client:
+        version: 3.7.2
+      - *install-yamllint
       - lint-and-verify-helm-config:
           environment: dev
       - lint-and-verify-helm-config:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  trailing-spaces: disable
+  indentation: disable
+  brackets: disable
+  comments: disable
+  comments-indentation: disable
+  key-duplicates:
+    forbid-duplicated-merge-keys: true

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "yarn": "^1.22.22"
   },
   "resolutions": {
-    "sass/**/braces": "^3.0.3"
+    "sass/**/braces": "^3.0.3",
+    "micromatch": "^4.0.6"
   },
   "scripts": {
     "unit-test": "jest",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "yarn": "^1.22.22"
   },
   "resolutions": {
-    "sass/**/braces": "^3.0.3",
+    "braces": "^3.0.3",
     "micromatch": "^4.0.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "sass": "^1.77.8",
     "yarn": "^1.22.22"
   },
+  "resolutions": {
+    "sass/**/braces": "^3.0.3"
+  },
   "scripts": {
     "unit-test": "jest",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,14 +2138,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
-  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
-  dependencies:
-    fill-range "^7.0.1"
-
-braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2685,13 +2678,6 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
-
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,7 +2138,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2, braces@^3.0.3, braces@~3.0.2:
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -3572,12 +3572,12 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-micromatch@^4.0.4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
-  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+micromatch@^4.0.4, micromatch@^4.0.6:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.7.tgz#33e8190d9fe474a9895525f5618eee136d46c2e5"
+  integrity sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==
   dependencies:
-    braces "^3.0.2"
+    braces "^3.0.3"
     picomatch "^2.3.1"
 
 mime-db@1.52.0:


### PR DESCRIPTION
## Description of change

[Last outcome for this ticket](https://dsdmoj.atlassian.net/browse/CRM457-1547)

Note: this runs helm lint AND helm template (debug) because from my experience helm lint won't always necessarily catch issues that can break a chart (I tested helm lint on some misconfigurations and it didn't catch some of them) where helm template will AND helm template doesn't give us warning level suggestions like helm lint does - so both in tandem covers all bases for breaking changes and suggestions

Also including yamllint to check for things like duplicate keys upon suggestion from @elken[ in this PR](https://github.com/ministryofjustice/laa-submit-crime-forms/pull/1013)
