### PR TITLE
CRM457-1021: Add sub-navigation to CRM7

### DIFF
--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -2,16 +2,34 @@ module Nsm
   class ClaimsController < ApplicationController
     layout 'nsm'
 
+    before_action :set_scope, only: %i[submitted draft reviewed]
     before_action :set_default_table_sort_options
 
     def index
-      @pagy, @claims = order_and_paginate(Claim.for(current_provider).where.not(ufn: nil))
+      @pagy, @claims = order_and_paginate(Claim.for(current_provider).reviewed.where.not(ufn: nil))
+      @scope = :reviewed
+      render 'index'
     end
 
     def create
       initialize_application do |claim|
         redirect_to edit_nsm_steps_claim_type_path(claim.id)
       end
+    end
+
+    def reviewed
+      @pagy, @claims = order_and_paginate(Claim.for(current_provider).reviewed.where.not(ufn: nil))
+      render 'index'
+    end
+
+    def submitted
+      @pagy, @claims = order_and_paginate(Claim.for(current_provider).submitted_or_resubmitted.where.not(ufn: nil))
+      render 'index'
+    end
+
+    def draft
+      @pagy, @claims = order_and_paginate(Claim.for(current_provider).draft.where.not(ufn: nil))
+      render 'index'
     end
 
     private
@@ -39,6 +57,10 @@ module Nsm
     def set_default_table_sort_options
       @sort_by = params.fetch(:sort_by, 'last_updated')
       @sort_direction = params.fetch(:sort_direction, 'descending')
+    end
+
+    def set_scope
+      @scope = params[:action].to_sym
     end
 
     def initialize_application(attributes = {}, &block)

--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -32,6 +32,16 @@ module Nsm
       render 'index'
     end
 
+    def confirm_delete
+      @model = Claim.for(current_provider).find(params[:id])
+    end
+
+    def destroy
+      @model = Claim.for(current_provider).find(params[:id])
+      @model.destroy
+      redirect_to draft_nsm_applications_path
+    end
+
     private
 
     ORDERS = {

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -27,7 +27,7 @@ module PriorAuthority
     def destroy
       @model = PriorAuthorityApplication.for(current_provider).find(params[:id])
       @model.destroy
-      redirect_to prior_authority_applications_path(anchor: 'drafts')
+      redirect_to drafts_prior_authority_applications_path
     end
 
     def drafts

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -19,6 +19,9 @@ class Claim < ApplicationRecord
            class_name: 'SupportingDocument',
            as: :documentable
 
+  scope :reviewed, -> { where(status: %i[granted part_grant rejected sent_back expired further_info]) }
+  scope :submitted_or_resubmitted, -> { where(status: %i[submitted provider_updated]) }
+
   scope :for, ->(provider) { where(office_code: provider.office_codes).or(where(office_code: nil, submitter: provider)) }
 
   enum status: { draft: 'draft', submitted: 'submitted', granted: 'granted', part_grant: 'part_grant',

--- a/app/views/nsm/claims/confirm_delete.html.erb
+++ b/app/views/nsm/claims/confirm_delete.html.erb
@@ -1,0 +1,29 @@
+<% title t(".page_title") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+    <ul class="govuk-list">
+      <li>
+        <strong><%= t(".ufn_reference") %></strong>
+        <%= @model.ufn %>
+      </li>
+      <li>
+        <strong><%= t(".laa_reference") %></strong>
+        <%= @model.laa_reference %>
+      </li>
+    </ul>
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        t(".yes_delete"),
+        nsm_application_path(@model),
+        warning: true,
+        method: :delete,
+      ) %>
+      <%= govuk_button_to(
+        t(".no_delete"),
+        draft_nsm_applications_path(@model),
+        method: :get,
+      ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -96,9 +96,8 @@
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status', 'actions'].each_with_index do |key, index| %>
+          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>
             <%= next if key == 'status' and %i[submitted draft].include?(@scope) %>
-            <%= next if key == 'actions' and %i[submitted reviewed].include?(@scope) %>
             <%= table_header(
               key,
               "nsm.claims.index.header",
@@ -107,6 +106,10 @@
               @sort_by,
               @sort_direction,
             ) %>
+          <% end %>
+
+          <% if @scope == :draft %>
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('prior_authority.applications.tabs.header.action') %></th>
           <% end %>
         </tr>
       </thead>
@@ -125,7 +128,7 @@
             <td class="govuk-table__cell"><%= claim.laa_reference %></td>
             <% if @scope == :draft %>
               <td class="govuk-table__cell">
-                <%= link_to t(".delete"), "#" %>
+                <%= link_to t(".delete"), confirm_delete_nsm_application_path(claim) %>
               </td>
             <% end %>
             <% if @scope == :reviewed %>

--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -65,19 +65,48 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <nav class="moj-sub-navigation" aria-label="Sub navigation">
+      <ul class="moj-sub-navigation__list">
+        <li class="moj-sub-navigation__item">
+          <%= link_to t(".tabs.reviewed"),
+          nsm_applications_path(),
+          "aria-current": %i[submitted draft].include?(@scope) ? nil : "page",
+          class: "moj-sub-navigation__link" %>
+        </li>
+
+        <li class="moj-sub-navigation__item">
+          <%= link_to t(".tabs.submitted"),
+          submitted_nsm_applications_path(),
+          "aria-current": @scope == :submitted ? "page" : nil,
+          class: "moj-sub-navigation__link" %>
+        </li>
+
+        <li class="moj-sub-navigation__item">
+          <%= link_to t(".tabs.drafts"),
+          draft_nsm_applications_path(),
+          "aria-current": @scope == :draft ? "page" : nil,
+          class: "moj-sub-navigation__link" %>
+        </li>
+      </ul>
+    </nav>
+
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-visually-hidden">
         <%= t('.heading') %>
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>
-            <%= table_header(key,
-                            'nsm.claims.index.header',
-                            index,
-                            nsm_applications_path,
-                            @sort_by,
-                            @sort_direction) %>
+          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status', 'actions'].each_with_index do |key, index| %>
+            <%= next if key == 'status' and %i[submitted draft].include?(@scope) %>
+            <%= next if key == 'actions' and %i[submitted reviewed].include?(@scope) %>
+            <%= table_header(
+              key,
+              "nsm.claims.index.header",
+              index,
+              polymorphic_path([@scope, :nsm_applications]),
+              @sort_by,
+              @sort_direction,
+            ) %>
           <% end %>
         </tr>
       </thead>
@@ -94,11 +123,18 @@
             <td class="govuk-table__cell"><%= claim.office_code.presence || I18n.t('helpers.missing_data') %></td>
             <td class="govuk-table__cell"><%= claim.updated_at.to_fs(:stamp) %></td>
             <td class="govuk-table__cell"><%= claim.laa_reference %></td>
-            <td class="govuk-table__cell">
-              <strong class="govuk-tag <%= t(".status_colour.#{claim.status}") %>">
-                <%= t(".status.#{claim.status}") %>
-              </strong>
-            </td>
+            <% if @scope == :draft %>
+              <td class="govuk-table__cell">
+                <%= link_to t(".delete"), "#" %>
+              </td>
+            <% end %>
+            <% if @scope == :reviewed %>
+              <td class="govuk-table__cell">
+                <strong class="govuk-tag <%= t(".status_colour.#{claim.status}") %>">
+                  <%= t(".status.#{claim.status}") %>
+                </strong>
+              </td>
+            <% end %>
           </tr>
         <% end %>
       </tbody>

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -41,3 +41,9 @@ en:
           reviewed: Reviewed
           submitted: Submitted
           drafts: Drafts
+      confirm_delete:
+        page_title: Are you sure you want to delete this draft application?
+        laa_reference: "LAA reference:"
+        ufn_reference: "UFN reference:"
+        yes_delete: "Yes, delete it"
+        no_delete: "No, do not delete it"

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -8,6 +8,7 @@ en:
         heading: Your claims
         start_claim: Start a new claim
         table_info_item: claims
+        delete: Delete
         header:
           ufn: UFN
           defendant: Defendant
@@ -36,3 +37,7 @@ en:
           sent_back: govuk-tag--yellow
           provider_requested: govuk-tag--yellow
           review: govuk-tag--yellow
+        tabs:
+          reviewed: Reviewed
+          submitted: Submitted
+          drafts: Drafts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,11 @@ Rails.application.routes.draw do
 
   namespace :nsm, path: 'non-standard-magistrates' do
     resources :claims, except: [:edit, :show, :new, :update], as: :applications do
+      collection do
+        get :draft
+        get :submitted
+        get :reviewed
+      end
       member do
         get :delete
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       end
       member do
         get :delete
+        get :confirm_delete, path: 'confirm-delete'
       end
     end
 

--- a/spec/system/nsm/claims_list_spec.rb
+++ b/spec/system/nsm/claims_list_spec.rb
@@ -54,7 +54,28 @@ RSpec.describe 'NSM claims lists' do
            office_code: 'OTHER',
            submitter: create(:provider, :other))
 
-    visit nsm_applications_path
+    visit submitted_nsm_applications_path
+  end
+
+  it 'only shows reviewed claims on reviewed tab' do
+    visit reviewed_nsm_applications_path
+
+    expect(page).to have_content(%r{120423/006.*120423/005.*120423/004.*120423/003}m)
+    expect(page).to have_content('Showing 4 of 4 claims')
+  end
+
+  it 'only shows submitted claims on submitted tab' do
+    visit submitted_nsm_applications_path
+
+    expect(page).to have_content(%r{120423/001.*120423/002}m)
+    expect(page).to have_content('Showing 2 of 2 claims')
+  end
+
+  it 'only shows draft claims on draft tab' do
+    visit draft_nsm_applications_path
+
+    expect(page).to have_content('120423/008')
+    expect(page).to have_content('Showing 1 of 1 claims')
   end
 
   it 'shows most recently updated at the top by default' do
@@ -75,7 +96,7 @@ RSpec.describe 'NSM claims lists' do
 
     click_on 'UFN'
     within top_row_selector do
-      expect(page).to have_content('120423/008')
+      expect(page).to have_content('120423/002')
     end
   end
 
@@ -87,7 +108,7 @@ RSpec.describe 'NSM claims lists' do
 
     click_on 'Defendant'
     within top_row_selector do
-      expect(page).to have_content('Zoe Zeigler')
+      expect(page).to have_content('Jim Bob')
     end
   end
 
@@ -99,7 +120,7 @@ RSpec.describe 'NSM claims lists' do
 
     click_on 'Account'
     within top_row_selector do
-      expect(page).to have_content('9A123B')
+      expect(page).to have_content('1A123B')
     end
   end
 
@@ -111,19 +132,21 @@ RSpec.describe 'NSM claims lists' do
 
     click_on 'LAA reference'
     within top_row_selector do
-      expect(page).to have_content('DDDDD')
+      expect(page).to have_content('BBBBB')
     end
   end
 
-  it 'allows sorting by Status' do
+  it 'allows sorting by Status in "Reviewed"' do
+    visit nsm_applications_path
+
     click_on 'Status'
     within top_row_selector do
-      expect(page).to have_content('Draft')
+      expect(page).to have_content('Granted')
     end
 
     click_on 'Status'
     within top_row_selector do
-      expect(page).to have_content('Submitted')
+      expect(page).to have_content('Update needed')
     end
   end
 

--- a/spec/system/nsm/delete_claim_spec.rb
+++ b/spec/system/nsm/delete_claim_spec.rb
@@ -1,0 +1,29 @@
+require 'system_helper'
+
+RSpec.describe 'NSM application deletion' do
+  before do
+    visit provider_saml_omniauth_callback_path
+
+    create(:claim,
+           ufn: '120423/008',
+           laa_reference: 'LAA-DDDDD',
+           defendants: [build(:defendant, :valid_nsm, first_name: 'Zoe', last_name: 'Zeigler')],
+           status: 'draft',
+           updated_at: 4.days.ago)
+    visit draft_nsm_applications_path
+  end
+
+  it 'allows the user to delete an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'Yes, delete it'
+    expect(page).to have_no_content '120423/008'
+  end
+
+  it 'allows the user to cancel deleting an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'No, do not delete it'
+    expect(page).to have_content '120423/008'
+  end
+end


### PR DESCRIPTION
## Description of change

Add [sub-navigation](https://design-patterns.service.justice.gov.uk/components/sub-navigation/) to CRM7 as per the requirements listed on the ticket.

The delete action on the page just links to `#` as that work is meant to be part of [this ticket](https://dsdmoj.atlassian.net/browse/CRM457-1025).

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1021)

## Screenshots of changes (if applicable)
![image](https://github.com/user-attachments/assets/6d1b15eb-d73d-44b0-89e7-35284b60d99e)
![image](https://github.com/user-attachments/assets/c1255668-0182-4488-a254-63a805d52930)
![image](https://github.com/user-attachments/assets/08ac2c24-d47a-4a55-ad4c-a1ab9ef17977)

