### PR TITLE
CRM457-1758: Fix table links aria label Ids

### DIFF
--- a/app/helpers/sortable_table_helper.rb
+++ b/app/helpers/sortable_table_helper.rb
@@ -8,13 +8,13 @@ module SortableTableHelper
     end
   end
 
-  def reorder_form(path, column, next_direction, i18n_stem, index)
+  def reorder_form(path, column, next_direction, i18n_stem, index, options = {})
     tag.form(action: path, method: 'get') do
       safe_join([
                   tag.input(type: 'hidden', name: 'prefix', value: params['prefix']),
                   tag.input(type: 'hidden', name: 'sort_by', value: column),
                   tag.input(type: 'hidden', name: 'sort_direction', value: next_direction),
-                  tag.button(type: 'submit', 'data-index': index) do
+                  tag.button(type: 'submit', 'data-index': index, id: options[:button_id]) do
                     I18n.t(column, scope: i18n_stem)
                   end
                 ])

--- a/app/views/nsm/steps/disbursements/edit.html.erb
+++ b/app/views/nsm/steps/disbursements/edit.html.erb
@@ -23,9 +23,9 @@
           <% header_row.map.with_index do |(column_key, attributes), index| %>
             <% aria_sort, next_direction = sort_variable(column_key, @sort_by, @sort_direction) %>
             <%= row.with_cell(
-                  text: reorder_form(edit_nsm_steps_disbursements_path(current_application), column_key, next_direction, "nsm.steps.disbursements.edit.headers", index),
+                  text: reorder_form(edit_nsm_steps_disbursements_path(current_application), column_key, next_direction, "nsm.steps.disbursements.edit.headers", index, button_id: attributes[:id] ),
                   numeric:  attributes[:numeric],
-                  html_attributes: attributes[:id] ? { 'aria-sort': aria_sort, id: attributes[:id] } : { 'aria-sort': aria_sort }
+                  html_attributes: { 'aria-sort': aria_sort },
                 ) %>
           <% end %>
           <%= row.with_cell(text: t('.headers.action'), numeric: true) %>


### PR DESCRIPTION

## Description of change
 Fix table links aria label Ids

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1758)

Handles accessibility failings for links in table rows.

Alternative link text is contructed by the browser for any links
in a table row. For example, "Item 1 Car mileage", "Duplicate Item 1 Car mileage"
or "Delete Item 1 Car mileage". Previously the "Item"
text was not being found as the id `itemTitle` was on the header cell `th`
containg the form with a button with the text 'Item'. This may be a bug
with the accessibility tooling or browser itself (firefox), but nonetheless
we can fix this by moving the id to the button of the form.

## Notes for reviewer
