### PR TITLE
Freeze puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
       - run:
           name: Install Puppeteer with Chromium
           command: |
-            yarn add puppeteer
+            yarn add puppeteer@22.15.0
 
   build-base:
     steps:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/"
+  ignore:
+    - dependency-name: "puppeteer"
+    - dependency-name: "puppeteer-core"
   schedule:
     interval: weekly
     day: wednesday


### PR DESCRIPTION
## Description of change

Per a discussion in [slack](https://mojdt.slack.com/archives/C05212WRK5J/p1723021539555329), ensure that the version of puppeteer doesn't change.

Looks like the issue wasn't the fact we bumped a minor version, the circleci step was installing a whole different version to the one used in the app. Whatever the change to major version 23 is, it looks like it breaks quite a lot so I've proposed we freeze the version that we have