### PR TITLE
CRM457-1840: firm office account content changes

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -116,7 +116,7 @@ en:
         prior_authority/steps/office_code_form:
           attributes:
             office_code:
-              inclusion: Select a firm account number
+              inclusion: Select a firm office account number
         prior_authority/steps/hearing_detail_form:
           attributes:
             next_hearing:
@@ -331,7 +331,7 @@ en:
         nsm/steps/office_code_form:
           attributes:
             office_code:
-              inclusion: Select your firm account number
+              inclusion: Select your firm office account number
         nsm/steps/defendant_details_form:
           attributes:
             first_name:

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -28,7 +28,7 @@ en:
               prom: PROM
             firm_details:
               firm_name: Firm name
-              firm_account_number: Firm account number
+              firm_account_number: Firm office account number
               firm_address: Firm address
               vat_registered: Firm VAT registered
               solicitor_first_name: Solicitor first name

--- a/config/locales/en/nsm/steps.yml
+++ b/config/locales/en/nsm/steps.yml
@@ -30,8 +30,8 @@ en:
           vat_registered: Is your firm VAT registered?
       office_code:
         edit:
-          page_title: Which firm account number is this claim for?
-          subheading: Your sign in details give you access to these firm account numbers. To get access to a different firm account number contact your firm's LAA account administrator.
+          page_title: Which firm office account number is this claim for?
+          subheading: Your sign in details give you access to these firm office account numbers. To get access to a different firm office account number contact your firm's LAA account administrator.
       case_details:
         edit:
           page_title: Case details

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -18,8 +18,8 @@ en:
       office_code:
         edit:
           caption: Contact details
-          page_title: Which firm account number is this application for?
-          subheading: Your sign in details give you access to these firm account numbers. To get access to a different firm account number contact your firm's LAA account administrator.
+          page_title: Which firm office account number is this application for?
+          subheading: Your sign in details give you access to these firm office account numbers. To get access to a different firm office account number contact your firm's LAA account administrator.
       case_detail:
         edit:
           caption: About the case

--- a/spec/system/nsm/office_code_spec.rb
+++ b/spec/system/nsm/office_code_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Office code selection', type: :system do
 
       it "validates if I don't make a selection" do
         click_on 'Save and continue'
-        expect(page).to have_content 'Select your firm account number'
+        expect(page).to have_content 'Select your firm office account number'
       end
 
       it 'Saves my choice' do

--- a/spec/system/nsm/office_code_spec.rb
+++ b/spec/system/nsm/office_code_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Office code selection', type: :system do
-  let(:office_code_question) { 'Which firm account number is this claim for?' }
+  let(:office_code_question) { 'Which firm office account number is this claim for?' }
   let(:provider) { Provider.first }
 
   context 'when I complete the firm details screen' do

--- a/spec/system/prior_authority/case_contact_spec.rb
+++ b/spec/system/prior_authority/case_contact_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe 'Prior authority applications - add case contact' do
       end
 
       it 'shows me the office code selection screen' do
-        expect(page).to have_content 'Which firm account number is this application for?'
+        expect(page).to have_content 'Which firm office account number is this application for?'
       end
 
       it 'validates the selection' do
         click_on 'Save and continue'
-        expect(page).to have_content 'Select a firm account number'
+        expect(page).to have_content 'Select a firm office account number'
       end
 
       it 'saves the selection' do
@@ -92,7 +92,7 @@ RSpec.describe 'Prior authority applications - add case contact' do
       end
 
       it 'allows save and come back later' do
-        expect(page).to have_content 'Which firm account number is this application for?'
+        expect(page).to have_content 'Which firm office account number is this application for?'
         click_on 'Save and come back later'
 
         expect(page).to have_title 'Your applications'


### PR DESCRIPTION
## Description of change
Change "firm account" to "firm office account"

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1840)

Content changes inline with content designers because:
- Each account number is for a specific office but ‘office’ is not included in this question or on this page.
- This team has always talked interchangeably about ‘office account number’ and ‘firm account number’
- After this question, we’ll be asking about whether the office is in an undesignated area and keeping ‘office’ in both questions should make the flow more smooth.

## Notes for reviewer

Second commit changes crm4 too and needs confirming with content design

