### PR TITLE
CRM457-1025: Allow deleting draft CRM7 claims

### DIFF
--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -32,6 +32,16 @@ module Nsm
       render 'index'
     end
 
+    def confirm_delete
+      @model = Claim.for(current_provider).find(params[:id])
+    end
+
+    def destroy
+      @model = Claim.for(current_provider).find(params[:id])
+      @model.destroy
+      redirect_to draft_nsm_applications_path
+    end
+
     private
 
     ORDERS = {

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -27,7 +27,7 @@ module PriorAuthority
     def destroy
       @model = PriorAuthorityApplication.for(current_provider).find(params[:id])
       @model.destroy
-      redirect_to prior_authority_applications_path(anchor: 'drafts')
+      redirect_to drafts_prior_authority_applications_path
     end
 
     def drafts

--- a/app/views/nsm/claims/confirm_delete.html.erb
+++ b/app/views/nsm/claims/confirm_delete.html.erb
@@ -1,0 +1,29 @@
+<% title t(".page_title") %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t(".page_title") %></h1>
+    <ul class="govuk-list">
+      <li>
+        <strong><%= t(".ufn_reference") %></strong>
+        <%= @model.ufn %>
+      </li>
+      <li>
+        <strong><%= t(".laa_reference") %></strong>
+        <%= @model.laa_reference %>
+      </li>
+    </ul>
+    <div class="govuk-button-group">
+      <%= govuk_button_to(
+        t(".yes_delete"),
+        nsm_application_path(@model),
+        warning: true,
+        method: :delete,
+      ) %>
+      <%= govuk_button_to(
+        t(".no_delete"),
+        draft_nsm_applications_path(@model),
+        method: :get,
+      ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -96,9 +96,8 @@
       </caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status', 'actions'].each_with_index do |key, index| %>
+          <% ['ufn', 'defendant', 'account', 'last_updated', 'laa_reference', 'status'].each_with_index do |key, index| %>
             <%= next if key == 'status' and %i[submitted draft].include?(@scope) %>
-            <%= next if key == 'actions' and %i[submitted reviewed].include?(@scope) %>
             <%= table_header(
               key,
               "nsm.claims.index.header",
@@ -107,6 +106,10 @@
               @sort_by,
               @sort_direction,
             ) %>
+          <% end %>
+
+          <% if @scope == :draft %>
+            <th scope="col" class="govuk-table__header" aria-sort="none"><%= t('prior_authority.applications.tabs.header.action') %></th>
           <% end %>
         </tr>
       </thead>
@@ -125,7 +128,7 @@
             <td class="govuk-table__cell"><%= claim.laa_reference %></td>
             <% if @scope == :draft %>
               <td class="govuk-table__cell">
-                <%= link_to t(".delete"), "#" %>
+                <%= link_to t(".delete"), confirm_delete_nsm_application_path(claim) %>
               </td>
             <% end %>
             <% if @scope == :reviewed %>

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -41,3 +41,9 @@ en:
           reviewed: Reviewed
           submitted: Submitted
           drafts: Drafts
+      confirm_delete:
+        page_title: Are you sure you want to delete this draft application?
+        laa_reference: "LAA reference:"
+        ufn_reference: "UFN reference:"
+        yes_delete: "Yes, delete it"
+        no_delete: "No, do not delete it"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       end
       member do
         get :delete
+        get :confirm_delete, path: 'confirm-delete'
       end
     end
 

--- a/spec/system/nsm/delete_claim_spec.rb
+++ b/spec/system/nsm/delete_claim_spec.rb
@@ -1,0 +1,29 @@
+require 'system_helper'
+
+RSpec.describe 'NSM application deletion' do
+  before do
+    visit provider_saml_omniauth_callback_path
+
+    create(:claim,
+           ufn: '120423/008',
+           laa_reference: 'LAA-DDDDD',
+           defendants: [build(:defendant, :valid_nsm, first_name: 'Zoe', last_name: 'Zeigler')],
+           status: 'draft',
+           updated_at: 4.days.ago)
+    visit draft_nsm_applications_path
+  end
+
+  it 'allows the user to delete an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'Yes, delete it'
+    expect(page).to have_no_content '120423/008'
+  end
+
+  it 'allows the user to cancel deleting an application' do
+    click_on 'Delete'
+    expect(page).to have_content 'Are you sure you want to delete this draft application?'
+    click_on 'No, do not delete it'
+    expect(page).to have_content '120423/008'
+  end
+end


### PR DESCRIPTION
## Description of change

Allows deletion of CRM7 claims.

Could potentially improve this by using the same view for both and passing in the URLs as a local.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1025)