### PR TITLE
CRM457-1841: Use calculated stage instead of explicit 'in area' question

### DIFF
--- a/app/forms/nsm/steps/hearing_details_form.rb
+++ b/app/forms/nsm/steps/hearing_details_form.rb
@@ -4,7 +4,6 @@ module Nsm
       attribute :first_hearing_date, :multiparam_date
       attribute :number_of_hearing, :integer
       attribute :court, :string
-      attribute :in_area, :value_object, source: YesNoAnswer
       attribute :youth_court, :value_object, source: YesNoAnswer
       attribute :hearing_outcome, :string
       attribute :matter_type, :string
@@ -13,7 +12,6 @@ module Nsm
               multiparam_date: { allow_past: true, allow_future: false }
       validates :number_of_hearing, presence: true, numericality: { only_integer: true, greater_than: 0 }
       validates :court, presence: true
-      validates :in_area, presence: true, inclusion: { in: YesNoAnswer.values }
       validates :youth_court, presence: true, inclusion: { in: YesNoAnswer.values }
       validates :hearing_outcome, presence: true
       validates :matter_type, presence: true

--- a/app/forms/nsm/steps/work_item_form.rb
+++ b/app/forms/nsm/steps/work_item_form.rb
@@ -10,10 +10,8 @@ module Nsm
       attribute :fee_earner, :string
       attribute :uplift, :integer
 
-      # TODO: limit this to displayed WorkTypes - this could lead to issues if conditions
-      # are changed as the validation would fail without clearly showing on the summary
-      # page
       validates :work_type, presence: true, inclusion: { in: WorkTypes.values }
+      validate :work_type_allowed
       validates :time_spent, presence: true, time_period: true
       validates :completed_on, presence: true,
               multiparam_date: { allow_past: true, allow_future: false }
@@ -71,6 +69,13 @@ module Nsm
 
       def translate(key)
         I18n.t("nsm.steps.work_item.edit.#{key}")
+      end
+
+      def work_type_allowed
+        return unless work_type
+        return if WorkTypes::VALUES.detect { _1 == work_type }.display?(application)
+
+        errors.add(:work_type, :inclusion)
       end
     end
   end

--- a/app/models/concerns/stage_reached_calculatable.rb
+++ b/app/models/concerns/stage_reached_calculatable.rb
@@ -10,4 +10,8 @@ module StageReachedCalculatable
 
     transferred_from_undesignated_area ? :prog : :prom
   end
+
+  def prog_stage_reached?
+    stage_reached == :prog
+  end
 end

--- a/app/models/work_item.rb
+++ b/app/models/work_item.rb
@@ -32,4 +32,10 @@ class WorkItem < ApplicationRecord
   def position
     1
   end
+
+  def valid_work_type?
+    return false if work_type.blank?
+
+    WorkTypes::VALUES.detect { _1.to_s == work_type }.display?(application)
+  end
 end

--- a/app/presenters/nsm/check_answers/hearing_details_card.rb
+++ b/app/presenters/nsm/check_answers/hearing_details_card.rb
@@ -31,12 +31,6 @@ module Nsm
             end
           },
           {
-            head_key: 'in_area',
-            text: check_missing(hearing_details_form.in_area.present?) do
-              hearing_details_form.in_area.to_s.capitalize
-            end
-          },
-          {
             head_key: 'youth_court',
             text: check_missing(hearing_details_form.youth_court.present?) do
               hearing_details_form.youth_court.to_s.capitalize

--- a/app/value_objects/work_types.rb
+++ b/app/value_objects/work_types.rb
@@ -17,11 +17,7 @@ class WorkTypes < ValueObject
     ATTENDANCE_WITHOUT_COUNSEL = new(:attendance_without_counsel),
     PREPARATION = new(:preparation),
     ADVOCACY = new(:advocacy),
-    TRAVEL = new(:travel) do |application|
-      application.in_area == YesNoAnswer::NO.to_s
-    end,
-    WAITING = new(:waiting) do |application|
-      application.in_area == YesNoAnswer::NO.to_s
-    end,
+    TRAVEL = new(:travel, &:prog_stage_reached?),
+    WAITING = new(:waiting, &:prog_stage_reached?),
   ].freeze
 end

--- a/app/views/nsm/steps/hearing_details/edit.html.erb
+++ b/app/views/nsm/steps/hearing_details/edit.html.erb
@@ -12,19 +12,14 @@
       <%= suggestion_select f, :court, LaaMultiStepForms::Court.all, :name, :name, width: 20,
                               options: { include_blank: true }, label: { size: 's' }, data: { autoselect: false } %>
 
-      <%= f.govuk_radio_buttons_fieldset :in_area, legend: { size: 's' } do %>
-        <%= f.govuk_radio_button :in_area, YesNoAnswer::YES.to_s %>
-        <%= f.govuk_radio_button :in_area, YesNoAnswer::NO.to_s %>
-      <% end%>
       <%= f.govuk_radio_buttons_fieldset :youth_court, legend: { size: 's' } do %>
         <%= f.govuk_radio_button :youth_court, YesNoAnswer::YES.to_s %>
         <%= f.govuk_radio_button :youth_court, YesNoAnswer::NO.to_s %>
-      <% end%>
+      <% end %>
 
       <%= f.govuk_collection_select :hearing_outcome, OutcomeCode.all, :id, :name,
                               data: { module: 'accessible-autocomplete', autoselect: true }, width: 20,
                               options: { include_blank: true }, label: { size: 's' } %>
-
 
       <%= f.govuk_collection_select :matter_type, MatterType.all, :id, :name,
                               data: { module: 'accessible-autocomplete', autoselect: true }, width: 20,
@@ -34,5 +29,3 @@
     <% end %>
   </div>
 </div>
-
-

--- a/app/views/nsm/steps/work_items/edit.html.erb
+++ b/app/views/nsm/steps/work_items/edit.html.erb
@@ -22,7 +22,7 @@
         <tbody class="govuk-table__body">
           <% work_items.each do |work_item| %>
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= check_missing(work_item.work_type) { t("helpers.label.nsm_steps_work_item_form.work_type_options.#{work_item.work_type}") } %></td>
+              <td class="govuk-table__cell"><%= check_missing(work_item.valid_work_type? && work_item.work_type) { t("helpers.label.nsm_steps_work_item_form.work_type_options.#{work_item.work_type}") } %></td>
               <td class="govuk-table__cell"><%= check_missing(work_item.completed_on.present? && format_period(work_item.time_spent)) %></td>
               <td class="govuk-table__cell"><%= check_missing(work_item.fee_earner) %></td>
               <td class="govuk-table__cell govuk-table__nowrap">

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -381,8 +381,6 @@ en:
               blank: Number of hearings held cannot be blank
             court:
               blank: Count cannot be blank
-            in_area:
-              blank: Is this court in a designated area cannot be blank
             youth_court:
               blank: Is it a youth court cannot be blank
             hearing_outcome:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -458,7 +458,8 @@ en:
               invalid_period: Period must be greater than 0
               invalid: Period must be valid
             work_type:
-              blank: Type of work must be choosen
+              blank: Type of work must be chosen
+              inclusion: Type of work must be chosen
             uplift:
               blank: Uplift amount must be set
               less_than_or_equal_to: You can only apply an uplift from 1 to 100

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -26,7 +26,6 @@ en:
         cracked_trial_date: Date guilty plea indicated to solicitor
       nsm_steps_hearing_details_form:
         first_hearing_date: Date of first hearing
-        in_area: Is this court in a designated area of your firm?
         youth_court: Is this court a youth court?
       nsm_steps_reason_for_claim_form:
         representation_order_withdrawn_date: Withdrawn date
@@ -87,8 +86,6 @@ en:
       nsm_steps_hearing_details_form:
         first_hearing_date: For example, 27 3 2023
         court: Enter the name of a court, or select one from the suggestions that appear when you start to enter the name.
-        in_area_options:
-          'yes': You will not be able to claim for travel expenses and waiting time
         hearing_outcome: Select a hearing outcome from the suggestions that appear when you start to enter it, for example, Change of solicitor (CP02)
         matter_type: Select a matter type from the suggestions that appear when you start to enter it, for example, offences against the person
       nsm_steps_reason_for_claim_form:
@@ -205,9 +202,6 @@ en:
       nsm_steps_hearing_details_form:
         number_of_hearing: How many hearings were held for this case?
         court: Which court was the last case hearing heard at?
-        in_area_options:
-          'yes': 'Yes'
-          'no': 'No'
         youth_court_options:
           'yes': 'Yes'
           'no': 'No'

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -58,7 +58,6 @@ en:
               conclusion: Proceedings concluded more than 3 months ago
               court: Magistrates court
               youth_court: Youth court
-              in_area: Court in designated area
               hearing_outcome: Hearing outcome
               matter_type: Matter type
             reason_for_claim:

--- a/db/migrate/20240808140456_remove_in_area_from_claims.rb
+++ b/db/migrate/20240808140456_remove_in_area_from_claims.rb
@@ -1,0 +1,5 @@
+class RemoveInAreaFromClaims < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :claims, :in_area, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_113029) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_140456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,7 +58,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_113029) do
     t.date "first_hearing_date"
     t.integer "number_of_hearing"
     t.string "court"
-    t.string "in_area"
     t.string "youth_court"
     t.string "hearing_outcome"
     t.string "matter_type"

--- a/gems/laa_multi_step_forms/app/views/laa_multi_step_forms/task_list/show.html.erb
+++ b/gems/laa_multi_step_forms/app/views/laa_multi_step_forms/task_list/show.html.erb
@@ -26,9 +26,9 @@
   <div class="govuk-grid-column-one-third">
     <aside class="aside-task-list" role="complementary" aria-labelledby="aside-title">
       <% if @application.is_a?(Claim) %>
-        <h3 id="aside-title" class="govuk-heading-s govuk-!-margin-bottom-4">
+        <h2 id="aside-title" class="govuk-heading-m govuk-!-margin-bottom-4">
           <%= t('.aside.nsm.title') %>
-        </h3>
+        </h2>
         <h3 class="govuk-heading-s govuk-!-margin-0">
           <%= t('.aside.ufn') %>
         </h3>

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -112,7 +112,6 @@ FactoryBot.define do
       first_hearing_date { date - rand(40) }
       number_of_hearing { 1 }
       youth_court { 'no' }
-      in_area { 'yes' }
       court { 'A Court' }
       hearing_outcome { OutcomeCode.all.sample.id }
       matter_type { '1' }

--- a/spec/factories/work_items.rb
+++ b/spec/factories/work_items.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     completed_on { Time.zone.today }
 
     trait :valid do
-      work_type { WorkTypes.values.sample.to_s }
+      work_type { [WorkTypes::ATTENDANCE_WITHOUT_COUNSEL, WorkTypes::PREPARATION, WorkTypes::ADVOCACY].sample.to_s }
       time_spent { 50 + (400**rand).to_i } # range: 50 -> 450 with logorithmic distribution
       completed_on { rand(40).days.ago.to_date }
       fee_earner { Faker::Name.name }

--- a/spec/forms/nsm/steps/hearing_details_form_spec.rb
+++ b/spec/forms/nsm/steps/hearing_details_form_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Nsm::Steps::HearingDetailsForm do
       first_hearing_date:,
       number_of_hearing:,
       court:,
-      in_area:,
       youth_court:,
       hearing_outcome:,
       matter_type:,
@@ -20,7 +19,6 @@ RSpec.describe Nsm::Steps::HearingDetailsForm do
   let(:first_hearing_date) { Date.yesterday }
   let(:number_of_hearing) { 1 }
   let(:court) { LaaMultiStepForms::Court.all.sample.name }
-  let(:in_area) { 'yes' }
   let(:youth_court) { 'no' }
   let(:hearing_outcome) { OutcomeCode.all.sample.id }
   let(:matter_type) { MatterType.all.sample.id }
@@ -36,7 +34,6 @@ RSpec.describe Nsm::Steps::HearingDetailsForm do
       first_hearing_date
       number_of_hearing
       court
-      in_area
       youth_court
       hearing_outcome
       matter_type

--- a/spec/forms/nsm/steps/work_items_add_form_spec.rb
+++ b/spec/forms/nsm/steps/work_items_add_form_spec.rb
@@ -127,6 +127,16 @@ RSpec.describe Nsm::Steps::WorkItemForm do
         end
       end
     end
+
+    describe 'invalid work item type' do
+      let(:work_type) { WorkTypes::TRAVEL }
+      let(:prog_stage_reached) { false }
+
+      it 'has an error' do
+        expect(subject).not_to be_valid
+        expect(subject.errors.of_kind?(:work_type, :inclusion)).to be(true)
+      end
+    end
   end
 
   describe '#allow_uplift?' do

--- a/spec/forms/nsm/steps/work_items_add_form_spec.rb
+++ b/spec/forms/nsm/steps/work_items_add_form_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Nsm::Steps::WorkItemForm do
 
   let(:application) do
     instance_double(Claim, work_items: work_items, update!: true, date: date, assigned_counsel: assigned_counsel,
-   in_area: in_area, reasons_for_claim: reasons_for_claim)
+   prog_stage_reached?: prog_stage_reached, reasons_for_claim: reasons_for_claim)
   end
   let(:work_items) { [double(:record), record] }
   let(:date) { Date.new(2023, 1, 1) }
@@ -32,7 +32,7 @@ RSpec.describe Nsm::Steps::WorkItemForm do
   let(:apply_uplift) { 'true' }
   let(:uplift) { 10 }
   let(:assigned_counsel) { 'yes' }
-  let(:in_area) { 'no' }
+  let(:prog_stage_reached) { true }
   let(:reasons_for_claim) { [ReasonForClaim::ENHANCED_RATES_CLAIMED.to_s] }
 
   describe '#validations' do
@@ -267,8 +267,8 @@ RSpec.describe Nsm::Steps::WorkItemForm do
         end
       end
 
-      context 'when in_area is yes' do
-        let(:in_area) { 'yes' }
+      context 'when prog stage not reached' do
+        let(:prog_stage_reached) { false }
 
         it 'does not include TRAVEL or WAITING' do
           expect(subject.work_types_with_pricing).to eq([
@@ -307,8 +307,8 @@ RSpec.describe Nsm::Steps::WorkItemForm do
         end
       end
 
-      context 'when in_area is yes' do
-        let(:in_area) { 'yes' }
+      context 'when prog stage not reached' do
+        let(:prog_stage_reached) { false }
 
         it 'does not include TRAVEL or WAITING' do
           expect(subject.work_types_with_pricing).to eq([

--- a/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/hearing_details_card_spec.rb
@@ -36,10 +36,6 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
             text: 'A Court'
           },
           {
-            head_key: 'in_area',
-            text: 'Yes'
-          },
-          {
             head_key: 'youth_court',
             text: 'No'
           },
@@ -71,10 +67,6 @@ RSpec.describe Nsm::CheckAnswers::HearingDetailsCard do
             },
             {
               head_key: 'court',
-              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
-            },
-            {
-              head_key: 'in_area',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {

--- a/spec/presenters/nsm/check_answers/work_items_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/work_items_card_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Nsm::CheckAnswers::WorkItemsCard do
   subject { described_class.new(claim) }
 
-  let(:claim) { build(:claim, :firm_details, work_items:) }
+  let(:claim) { build(:claim, :case_type_magistrates, :firm_details, work_items:) }
   let(:work_items) do
     [
       build(:work_item, work_type: WorkTypes::ADVOCACY.to_s, time_spent: 180),
@@ -64,7 +64,7 @@ RSpec.describe Nsm::CheckAnswers::WorkItemsCard do
     end
 
     context 'when not vat registered' do
-      let(:claim) { build(:claim, :full_firm_details, work_items:) }
+      let(:claim) { build(:claim, :case_type_magistrates, :full_firm_details, work_items:) }
 
       it 'generates work items rows' do
         expect(subject.row_data).to eq(

--- a/spec/presenters/nsm/cost_summary/disbursements_spec.rb
+++ b/spec/presenters/nsm/cost_summary/disbursements_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Nsm::CostSummary::Disbursements do
   subject { described_class.new(disbursements, claim) }
 
-  let(:claim) { instance_double(Claim, assigned_counsel:, in_area:) }
+  let(:claim) { instance_double(Claim, assigned_counsel: assigned_counsel, prog_stage_reached?: prog_stage_reached) }
   let(:assigned_counsel) { 'no' }
-  let(:in_area) { 'yes' }
+  let(:prog_stage_reached) { false }
   let(:disbursements) do
     [
       instance_double(Disbursement, translated_disbursement_type: 'Car', other_type: nil, total_cost: 100.0,

--- a/spec/presenters/nsm/cost_summary/work_items_spec.rb
+++ b/spec/presenters/nsm/cost_summary/work_items_spec.rb
@@ -3,10 +3,16 @@ require 'rails_helper'
 RSpec.describe Nsm::CostSummary::WorkItems do
   subject { described_class.new(work_items, claim) }
 
-  let(:claim) { instance_double(Claim, assigned_counsel:, in_area:, date:, firm_office:) }
+  let(:claim) do
+    instance_double(Claim,
+                    assigned_counsel: assigned_counsel,
+                    prog_stage_reached?: prog_stage_reached,
+                    date: date,
+                    firm_office: firm_office)
+  end
   let(:firm_office) { build(:firm_office, :valid) }
   let(:assigned_counsel) { 'no' }
-  let(:in_area) { 'yes' }
+  let(:prog_stage_reached) { false }
   let(:date) { Date.new(2008, 11, 22) }
   let(:work_items) do
     [
@@ -50,8 +56,8 @@ RSpec.describe Nsm::CostSummary::WorkItems do
       end
     end
 
-    context 'when in area is false' do
-      let(:in_area) { 'no' }
+    context 'when prog stage reached' do
+      let(:prog_stage_reached) { true }
 
       it 'includes WAITING and TRAVEL in data' do
         row_keys = subject.rows.map(&:first).pluck(:text)

--- a/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/nsm_payload_builder_spec.rb
@@ -76,7 +76,6 @@ RSpec.describe SubmitToAppStore::NsmPayloadBuilder do
             en: an_instance_of(String)
           },
           'id' => claim.id,
-          'in_area' => 'yes',
           'is_other_info' => 'no',
           'laa_reference' => 'LAA-n4AohV',
           'letters_and_calls' => [

--- a/spec/system/nsm/hearing_details_spec.rb
+++ b/spec/system/nsm/hearing_details_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'User can fill in claim type details', type: :system do
 
     select 'Aberconwy PSD - C3237', from: 'Which court was the last case hearing heard at?'
 
-    find('.govuk-form-group', text: 'Is this court in a designated area of your firm?').choose 'Yes'
     find('.govuk-form-group', text: 'Is this court a youth court?').choose 'No'
 
     select 'CP03 - Representation order withdrawn', from: 'Hearing outcome'
@@ -33,7 +32,6 @@ RSpec.describe 'User can fill in claim type details', type: :system do
       first_hearing_date: Date.new(2023, 4, 20),
       number_of_hearing: 2,
       court: 'Aberconwy PSD - C3237',
-      in_area: 'yes',
       youth_court: 'no',
       hearing_outcome: 'CP03',
       matter_type: '1',

--- a/spec/system/nsm/work_items_spec.rb
+++ b/spec/system/nsm/work_items_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'User can manage work items', type: :system do
 
   it 'can add additional work items' do
     claim.work_items.create!(
-      work_type: 'waiting',
+      work_type: 'preparation',
       time_spent: 122,
       completed_on: Date.new(2022, 4, 20),
       fee_earner: 'BJB',
@@ -102,7 +102,7 @@ RSpec.describe 'User can manage work items', type: :system do
 
     expect(claim.reload.work_items).to contain_exactly(
       have_attributes(
-        work_type: 'waiting',
+        work_type: 'preparation',
         time_spent: 122,
         completed_on: Date.new(2022, 4, 20),
         fee_earner: 'BJB',
@@ -173,8 +173,6 @@ RSpec.describe 'User can manage work items', type: :system do
 
     visit edit_nsm_steps_work_item_path(id: claim.id, work_item_id: work_item.id)
 
-    choose 'Advocacy'
-
     fill_in 'Hours', with: 1
     fill_in 'Minutes', with: 1
 
@@ -189,6 +187,8 @@ RSpec.describe 'User can manage work items', type: :system do
     expect(page).to have_content 'You cannot save and continue if any work items are incomplete'
 
     click_on 'Change'
+
+    choose 'Advocacy'
 
     within('.govuk-fieldset', text: 'Completion date') do
       fill_in 'Day', with: '20'


### PR DESCRIPTION
## Description of change
'in_area' has now been replaced by the prog/prom questions.
Also, add a check so that if prog-prom changes, invalid work item types will be flagged as invalid and the user will be forced to change to a valid type.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1841)
