### PR TITLE
CRM457-1785: Stop looking at events in payload

### DIFF
--- a/app/services/nsm/assessment_syncer.rb
+++ b/app/services/nsm/assessment_syncer.rb
@@ -30,10 +30,7 @@ module Nsm
     private
 
     def sync_overall_comment
-      event_type = claim.sent_back? ? 'send_back' : 'decision'
-      comment_event = app_store_record['events'].select { _1['event_type'] == event_type }
-                                                .max_by { DateTime.parse(_1['created_at']) }
-      claim.assessment_comment = comment_event.dig('details', 'comment')
+      claim.assessment_comment = app_store_record.dig('application', 'assessment_comment').presence
     end
 
     def sync_letter_adjustments

--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -30,10 +30,7 @@ module PriorAuthority
     private
 
     def sync_overall_comment
-      comment_event = app_store_record['events'].select { _1['public'] && _1['event_type'] == 'decision' }
-                                                .max_by { DateTime.parse(_1['created_at']) }
-
-      application.update(assessment_comment: comment_event.dig('details', 'comment'))
+      application.update!(assessment_comment: app_store_record.dig('application', 'assessment_comment').presence)
     end
 
     def sync_allowances

--- a/spec/jobs/pull_updates_spec.rb
+++ b/spec/jobs/pull_updates_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PullUpdates do
     let(:id) { SecureRandom.uuid }
     let(:claim) do
       instance_double(Claim, id: id, status: 'submitted', save!: true, update!: true,
-                      provider_requested?: false, sent_back?: false)
+                      provider_requested?: false, sent_back?: false, 'assessment_comment=': nil, part_grant?: false)
     end
 
     before do
@@ -145,14 +145,7 @@ RSpec.describe PullUpdates do
                 'application_risk' => 'N/A',
                 'application_type' => application_type,
                 'updated_at' => arbitrary_fixed_date,
-                'events' => [
-                  {
-                    'details' => { 'comment' => 'All good, granting...' },
-                    'created_at' => '2024-03-26T16:56:27.039Z',
-                    'public' => true,
-                    'event_type' => 'decision'
-                  }
-                ]
+                'application' => { 'assessment_comment' => 'All good, granting...' },
               },
               {
                 'application_id' => paa_two.id,
@@ -161,14 +154,7 @@ RSpec.describe PullUpdates do
                 'application_risk' => 'N/A',
                 'application_type' => application_type,
                 'updated_at' => arbitrary_fixed_date,
-                'events' => [
-                  {
-                    'details' => { 'comment' => 'Sorry have to reject this because...' },
-                    'created_at' => '2024-03-26T16:56:27.039Z',
-                    'public' => true,
-                    'event_type' => 'decision'
-                  }
-                ],
+                'application' => { 'assessment_comment' => 'Sorry have to reject this because...' },
               },
             ]
         }

--- a/spec/services/nsm/assessment_syncer_spec.rb
+++ b/spec/services/nsm/assessment_syncer_spec.rb
@@ -8,17 +8,6 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
 
     let(:status) { 'granted' }
 
-    let(:events) do
-      [
-        {
-          event_type: 'decision',
-          created_at: 1.day.ago.to_s,
-          public: true,
-          details: { comment: 'Decision comment' }
-        },
-      ]
-    end
-
     let(:letters_and_calls) do
       [
         {
@@ -51,7 +40,6 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
     let(:record) do
       {
         application:,
-        events:
       }.deep_stringify_keys
     end
 
@@ -77,31 +65,15 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
       end
     end
 
-    context 'when status is from a decision event' do
-      let(:status) { 'rejected' }
-
-      it 'syncs the assessment_comment' do
-        expect(claim.assessment_comment).to eq 'Decision comment'
-      end
-    end
-
-    context 'when status is from a send_back event' do
+    context 'when there is an assessment comment' do
       let(:status) { 'sent_back' }
       let(:record) do
         {
-          application: application,
-          events: [
-            {
-              event_type: 'send_back',
-              created_at: 1.day.ago.to_s,
-              public: true,
-              details: { comment: 'More info needed' }
-            },
-          ]
-        }.deep_stringify_keys
+          'application' => application.merge('assessment_comment' => 'More info needed')
+        }
       end
 
-      it 'syncs the assessment_comment' do
+      it 'syncs the assessment comment' do
         expect(claim.assessment_comment).to eq 'More info needed'
       end
     end
@@ -141,15 +113,7 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
             ],
             work_items: [],
             disbursements: []
-          },
-          events: [
-            {
-              event_type: 'decision',
-              created_at: 1.day.ago.to_s,
-              public: true,
-              details: { comment: 'Part granted' }
-            },
-          ],
+          }
         }.deep_stringify_keys
       end
 
@@ -199,14 +163,6 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
             ],
             disbursements: []
           },
-          events: [
-            {
-              event_type: 'decision',
-              created_at: 1.day.ago.to_s,
-              public: true,
-              details: { comment: 'Part granted' }
-            },
-          ],
         }.deep_stringify_keys
       end
 
@@ -260,15 +216,7 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
                 total_cost_without_vat: 10
               }
             ]
-          },
-          events: [
-            {
-              event_type: 'decision',
-              created_at: 1.day.ago.to_s,
-              public: true,
-              details: { comment: 'Part granted' }
-            },
-          ],
+          }
         }.deep_stringify_keys
       end
 

--- a/spec/services/prior_authority/assessment_syncer_spec.rb
+++ b/spec/services/prior_authority/assessment_syncer_spec.rb
@@ -17,14 +17,6 @@ RSpec.describe PriorAuthority::AssessmentSyncer, :stub_oauth_token do
 
     let(:record) do
       {
-        events: [
-          {
-            event_type: 'decision',
-            created_at: 1.day.ago.to_s,
-            public: true,
-            details: { comment: 'Decision comment' }
-          },
-        ],
         application: {
           quotes: [
             {
@@ -68,6 +60,7 @@ RSpec.describe PriorAuthority::AssessmentSyncer, :stub_oauth_token do
           ],
           incorrect_information_explanation: 'This is incorrect',
           updates_needed: %w[further_information incorrect_information],
+          assessment_comment: 'Decision comment',
           resubmission_deadline: 14.days.from_now,
         }
       }.deep_stringify_keys


### PR DESCRIPTION
## Description of change
Stop looking at events in payloads and instead get assessment comments from the blob

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1785)
