### PR TITLE
CRM457-1838: Add client side validation of single file uploads

### DIFF
--- a/app/javascript/single-file-upload-validator.js
+++ b/app/javascript/single-file-upload-validator.js
@@ -1,0 +1,30 @@
+// A basic file size validator to block single file uploads over
+// a specified size.
+//
+window.addEventListener("DOMContentLoaded", (event) => {
+  const fileUploader = document.querySelector('.govuk-file-upload');
+  const maxFileSize = fileUploader.dataset.maxSize;
+  const feedback = $(".single-file-upload__message");
+
+  if (fileUploader) {
+    fileUploader.addEventListener('change', function (event) {
+      event.preventDefault()
+      feedback.html('');
+      const file = event.target.files[0]
+
+      if (file && file.size > maxFileSize) {
+        event.target.value = null
+        feedback.html(getErrorHtml("The file " + file.name + " is too big. Unable to upload."));
+      }
+    })
+  }
+});
+
+function getErrorHtml (message) {
+  return `<div class="moj-banner moj-banner--warning" role="region" aria-label="Warning">
+            <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+              <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
+            </svg>
+          <div class="moj-banner__message">${message}</div>
+          </div>`;
+};

--- a/app/javascript/single-file-upload-validator.js
+++ b/app/javascript/single-file-upload-validator.js
@@ -4,27 +4,73 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const fileUploader = document.querySelector('.govuk-file-upload');
   const maxFileSize = fileUploader.dataset.maxSize;
+  const humanMaxFileSize = (maxFileSize / 1024 / 1024).toFixed(0)
   const feedback = $(".single-file-upload__message");
+  const saveButtons = document.querySelectorAll('button[type="submit"]');
 
-  if (fileUploader) {
-    fileUploader.addEventListener('change', function (event) {
-      event.preventDefault()
-      feedback.html('');
-      const file = event.target.files[0]
+  if (saveButtons) {
+    for(var i = 0; i < saveButtons.length; i++) {
+      saveButtons[i].addEventListener('click', function (event) {
 
-      if (file && file.size > maxFileSize) {
-        event.target.value = null
-        feedback.html(getErrorHtml("The file " + file.name + " is too big. Unable to upload."));
-      }
-    })
+        // error if an uploaded file is larger than permitted
+        if (fileUploader) {
+          feedback.html('');
+          const file = fileUploader.files[0]
+
+          if (file && file.size > maxFileSize) {
+            feedback.html(govukErrorSummary('link-todo', `The selected file must be smaller than ${humanMaxFileSize}MB`));
+            errorSummary = document.querySelector('.govuk-error-summary');
+            errorSummary.scrollIntoView();
+            errorSummary.focus();
+            event.preventDefault();
+            event.stopImmediatePropagation()
+          }
+        }
+      })
+    }
   }
 });
 
-function getErrorHtml (message) {
-  return `<div class="moj-banner moj-banner--warning" role="region" aria-label="Warning">
-            <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-              <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
-            </svg>
-          <div class="moj-banner__message">${message}</div>
-          </div>`;
+function govukErrorSummary (href, message) {
+  return `<div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert"><h2 class="govuk-error-summary__title">There is a problem on this page</h2>
+              <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                  <li>
+                    <a data-turbo="false" href="#${href}">${message}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>`
 };
+
+// function addErrorMessage (msg) {
+//   // this adds an error message to the gov uk error summary and shows the errors
+//   const errorSummary = document.querySelector('.govuk-error-summary')
+//   const ul = errorSummary.querySelector('ul')
+//   const li = document.createElement('li')
+//   const a = document.createElement('a')
+//   li.appendChild(a)
+//   ul.appendChild(li)
+
+//   // add text and link to field
+//   a.innerText += msg
+//   a.setAttribute('aria-label', msg)
+//   a.setAttribute('data-turbolinks', false) # NOT NEEDED?
+//   a.setAttribute('href', '#dz-upload-button') # TODO
+
+//   // show error message on the dropzone form field
+//   const dropzoneElem = document.querySelector('#dropzone-form-group')
+//   dropzoneElem.classList.add('govuk-form-group--error')
+//   const fieldErrorMsg = document.querySelector('#dropzone-file-error')
+//   const div = document.createElement('div')
+//   div.innerText = msg
+//   fieldErrorMsg.appendChild(div)
+//   fieldErrorMsg.classList.remove('hidden')
+
+//   // show the error summary and move focus to it
+//   errorSummary.classList.remove('hidden')
+//   errorSummary.scrollIntoView()
+//   errorSummary.focus()
+// }

--- a/app/javascript/single-file-upload-validator.js
+++ b/app/javascript/single-file-upload-validator.js
@@ -4,7 +4,8 @@
 window.addEventListener("DOMContentLoaded", (event) => {
   const fileUploader = document.querySelector('.govuk-file-upload');
   const maxFileSize = fileUploader.dataset.maxSize;
-  const humanMaxFileSize = (maxFileSize / 1024 / 1024).toFixed(0)
+  const errorHeading = fileUploader.dataset.errorHeading;
+  const errorMessage = fileUploader.dataset.sizeErrorMessage;
   const feedback = $(".single-file-upload__message");
   const saveButtons = document.querySelectorAll('button[type="submit"]');
 
@@ -12,13 +13,14 @@ window.addEventListener("DOMContentLoaded", (event) => {
     for(var i = 0; i < saveButtons.length; i++) {
       saveButtons[i].addEventListener('click', function (event) {
 
-        // error if an uploaded file is larger than permitted
         if (fileUploader) {
           feedback.html('');
+          removeInlineError(fileUploader);
           const file = fileUploader.files[0]
 
           if (file && file.size > maxFileSize) {
-            feedback.html(govukErrorSummary('link-todo', `The selected file must be smaller than ${humanMaxFileSize}MB`));
+            feedback.html(govukErrorSummary(fileUploader.id, errorMessage, errorHeading));
+            addInlineError(fileUploader, errorMessage)
             errorSummary = document.querySelector('.govuk-error-summary');
             errorSummary.scrollIntoView();
             errorSummary.focus();
@@ -31,46 +33,37 @@ window.addEventListener("DOMContentLoaded", (event) => {
   }
 });
 
-function govukErrorSummary (href, message) {
+function addInlineError(element, message) {
+  element.classList.add('govuk-file-upload--error');
+  const group = element.closest('.govuk-form-group');
+  group.classList.add('govuk-form-group--error')
+  group.insertBefore(govukInlineError(message), element);
+}
+
+function removeInlineError(element) {
+  element.classList.remove('govuk-file-upload--error');
+  const group = element.closest('.govuk-form-group');
+  group.classList.remove('govuk-form-group--error')
+  group.querySelector('.govuk-error-message')?.remove();
+}
+
+function govukInlineError(message) {
+  let messageElement = document.createElement('p')
+  messageElement.classList.add('govuk-error-message');
+  messageElement.innerHTML = `<span class="govuk-visually-hidden">Error:</span>${message}`
+  return messageElement;
+}
+
+function govukErrorSummary (anchor, message, heading) {
   return `<div class="govuk-error-summary" data-module="govuk-error-summary">
-            <div role="alert"><h2 class="govuk-error-summary__title">There is a problem on this page</h2>
+            <div role="alert"><h2 class="govuk-error-summary__title">${heading}</h2>
               <div class="govuk-error-summary__body">
                 <ul class="govuk-list govuk-error-summary__list">
                   <li>
-                    <a data-turbo="false" href="#${href}">${message}</a>
+                    <a data-turbo="false" href="#${anchor}">${message}</a>
                   </li>
                 </ul>
               </div>
             </div>
           </div>`
 };
-
-// function addErrorMessage (msg) {
-//   // this adds an error message to the gov uk error summary and shows the errors
-//   const errorSummary = document.querySelector('.govuk-error-summary')
-//   const ul = errorSummary.querySelector('ul')
-//   const li = document.createElement('li')
-//   const a = document.createElement('a')
-//   li.appendChild(a)
-//   ul.appendChild(li)
-
-//   // add text and link to field
-//   a.innerText += msg
-//   a.setAttribute('aria-label', msg)
-//   a.setAttribute('data-turbolinks', false) # NOT NEEDED?
-//   a.setAttribute('href', '#dz-upload-button') # TODO
-
-//   // show error message on the dropzone form field
-//   const dropzoneElem = document.querySelector('#dropzone-form-group')
-//   dropzoneElem.classList.add('govuk-form-group--error')
-//   const fieldErrorMsg = document.querySelector('#dropzone-file-error')
-//   const div = document.createElement('div')
-//   div.innerText = msg
-//   fieldErrorMsg.appendChild(div)
-//   fieldErrorMsg.classList.remove('hidden')
-
-//   // show the error summary and move focus to it
-//   errorSummary.classList.remove('hidden')
-//   errorSummary.scrollIntoView()
-//   errorSummary.focus()
-// }

--- a/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
@@ -22,7 +22,10 @@
                                 label: { text: t(".file_upload"), size: "s" },
                                 hint: { text: t(".file_upload_hint_html", size: FileUpload::FileUploader.human_readable_max_file_size) },
                                 accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(','),
-                                data: { 'max-size': ENV['MAX_UPLOAD_SIZE_BYTES'] }  %>
+                                data: { max_size: ENV['MAX_UPLOAD_SIZE_BYTES'],
+                                        error_heading: I18n.t('laa_multi_step_forms.errors.error_summary.heading'),
+                                        size_error_message: I18n.t('shared.shared_upload_errors.attachment_too_large',
+                                                                    size: FileUpload::FileUploader.human_readable_max_file_size) } %>
       <% if @form_object.document_already_uploaded? %>
         <%= render "prior_authority/steps/primary_quote/uploaded_file_summary", document: @form_object.document %>
       <% end %>

--- a/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
+++ b/app/views/prior_authority/steps/alternative_quote_details/edit.html.erb
@@ -1,9 +1,12 @@
+<%= javascript_include_tag 'single-file-upload-validator', nonce: true %>
+
 <% title t('.page_title') %>
 <% decision_step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
+    <div class=single-file-upload__message></div>
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
     <p><%= t(".hint") %></p>
@@ -18,7 +21,8 @@
       <%= form.govuk_file_field :file_upload,
                                 label: { text: t(".file_upload"), size: "s" },
                                 hint: { text: t(".file_upload_hint_html", size: FileUpload::FileUploader.human_readable_max_file_size) },
-                                accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(',') %>
+                                accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(','),
+                                data: { 'max-size': ENV['MAX_UPLOAD_SIZE_BYTES'] }  %>
       <% if @form_object.document_already_uploaded? %>
         <%= render "prior_authority/steps/primary_quote/uploaded_file_summary", document: @form_object.document %>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -28,7 +28,10 @@
                                 label: { text: t(".file_upload"), size: "m" },
                                 hint: { text: t(".file_upload_hint_html", size: FileUpload::FileUploader.human_readable_max_file_size) },
                                 accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(','),
-                                data: { 'max-size': ENV['MAX_UPLOAD_SIZE_BYTES'] } %>
+                                data: { max_size: ENV['MAX_UPLOAD_SIZE_BYTES'],
+                                        error_heading: I18n.t('laa_multi_step_forms.errors.error_summary.heading'),
+                                        size_error_message: I18n.t('shared.shared_upload_errors.attachment_too_large',
+                                                                    size: FileUpload::FileUploader.human_readable_max_file_size) } %>
       <% if @form_object.document_already_uploaded? %>
         <%= render "uploaded_file_summary", document: @form_object.document %>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -1,9 +1,12 @@
+<%= javascript_include_tag 'single-file-upload-validator', nonce: true %>
+
 <% title t(".page_title") %>
 <% decision_step_header %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_error_summary(@form_object) %>
+    <div class=single-file-upload__message></div>
     <span class="govuk-caption-xl"><%= t(".caption") %></span>
     <h1 class="govuk-heading-xl"><%= t(".page_title") %></h1>
 
@@ -24,7 +27,8 @@
       <%= form.govuk_file_field :file_upload,
                                 label: { text: t(".file_upload"), size: "m" },
                                 hint: { text: t(".file_upload_hint_html", size: FileUpload::FileUploader.human_readable_max_file_size) },
-                                accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(',') %>
+                                accept: SupportedFileTypes::SUPPORTED_FILE_TYPES.join(','),
+                                data: { 'max-size': ENV['MAX_UPLOAD_SIZE_BYTES'] } %>
       <% if @form_object.document_already_uploaded? %>
         <%= render "uploaded_file_summary", document: @form_object.document %>
       <% end %>

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
     expect(page).to have_content 'Your applications'
   end
 
-  it 'validates file size client side before uploading' do
+  it 'validates file size client side before attempting upload and save' do
     fill_in_until_step(:primary_quote)
     click_on 'Primary quote'
 
@@ -70,6 +70,7 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
       page.find('.govuk-file-upload').click
     end
 
-    expect(page).to have_content(/file.* is too big. unable to upload/i)
+    click_on 'Save and continue'
+    expect(page).to have_content(/The selected file must be smaller than \d+MB/i)
   end
 end

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -61,4 +61,15 @@ RSpec.describe 'Prior authority applications - add primary quote', :javascript, 
     click_on 'Save and come back later'
     expect(page).to have_content 'Your applications'
   end
+
+  it 'validates file size client side before uploading' do
+    fill_in_until_step(:primary_quote)
+    click_on 'Primary quote'
+
+    page.attach_file(file_fixture('1_byte_over_10_mb_exactly.png')) do
+      page.find('.govuk-file-upload').click
+    end
+
+    expect(page).to have_content(/file.* is too big. unable to upload/i)
+  end
 end


### PR DESCRIPTION
## Description of change
Add client side validation of single file uploads

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1838)

To provide early feedback to providers when
uploading single files over the limit and
to avoid "413 entity too big errors" for really
large files.

## Notes for reviewer
Multifile upload pages already do this, per file.

## Screenshot
<img width="402" alt="Screenshot 2024-08-12 at 10 37 58" src="https://github.com/user-attachments/assets/f97583b6-f6d1-45d3-9a3e-28913523d8c5">

