### PR TITLE
CRM457-1847: Remove 'retry_on'

### DIFF
--- a/app/jobs/submit_to_app_store.rb
+++ b/app/jobs/submit_to_app_store.rb
@@ -1,6 +1,5 @@
 class SubmitToAppStore < ApplicationJob
   queue_as :default
-  retry_on StandardError, wait: :polynomially_longer, attempts: 10
 
   def perform(submission:)
     submit(submission)


### PR DESCRIPTION
## Description of change
`retry_on` is part of the ActiveJob DSL that causes errors to be swallowed until a certain number of retries, after which the error is allowed to bubble up to the underlying mechanism (in our case Sidekiq, which will report the error to Sentry) This isn't actually the behaviour we want - if a job is failing we want Sentry to be informed immediately the first time it fails, on the grounds that _normally_ this is going to be the indication of a problem, not some harmless transient error, so we want as much heads up as possible.
