### PR TITLE
CRM457-1858: Move perform_laters out of transactions

### DIFF
--- a/app/forms/nsm/steps/solicitor_declaration_form.rb
+++ b/app/forms/nsm/steps/solicitor_declaration_form.rb
@@ -11,9 +11,9 @@ module Nsm
           application.status = :submitted
           application.update_disbursement_positions!
           application.update!(attributes)
-          SubmitToAppStore.perform_later(submission: application)
-          true
         end
+        SubmitToAppStore.perform_later(submission: application)
+        true
       end
     end
   end

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -19,7 +19,7 @@ module PriorAuthority
         end
         SubmitToAppStore.perform_later(submission: application) if updated
 
-        true
+        updated
       end
 
       def update_application

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -13,15 +13,15 @@ module PriorAuthority
       def save!; end
 
       def persist!
+        updated = false
         application.with_lock do
-          update_application
+          updated = update_application
         end
+        SubmitToAppStore.perform_later(submission: application) if updated
+
+        true
       end
 
-      # NOTE: POtential race condition when `SubmitToAppStore` started before the lock is released
-      # have resolved this by retrying in AppStoreClient#post when existing ID, due to risk
-      # moving the sidekiq caller out of the transaction as unsure if this would introduce other
-      # errors
       def update_application
         unless application.draft? || application.sent_back?
           errors.add(:base, :application_already_submitted)
@@ -30,7 +30,7 @@ module PriorAuthority
 
         application.update!(attributes.merge({ status: new_status }))
         update_incorrect_information if application.incorrect_information_explanation.present?
-        SubmitToAppStore.perform_later(submission: application)
+
         true
       end
 

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -9,9 +9,6 @@ class AppStoreClient
     when 200..204
       :success
     when 409
-      # Changed from a warning to an error due to race condition when updating from sent_back to provider_updated
-      # which can result in incorrectly trying to POST the data - Changing to an error here will allow a retry
-      # using a PUT
       raise "Application ID already exists in AppStore for '#{message[:application_id]}'"
     else
       raise "Unexpected response from AppStore - status #{response.code} for '#{message[:application_id]}'"


### PR DESCRIPTION
## Description of change
Calling `perform_later` inside a transaction (including a lock) risks a race condition where the job might run before the transaction has been committed so uses stale DB data. This could cause incorrect data to be sent to the app store.  We've previously just lived with this, which is a high-risk strategy, as it relies on the app store always spotting and rejecting incorrect data. This PR moves the perform_laters until after the transactions have been committed.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1858)

