### PR TITLE
CRM457-1828: Validation message when decimal entered into items field

### DIFF
--- a/app/forms/prior_authority/quote_cost_validations.rb
+++ b/app/forms/prior_authority/quote_cost_validations.rb
@@ -10,7 +10,7 @@ module PriorAuthority
                 if: :variable_cost_type?
 
       with_options if: :per_item? do
-        validates :items, item_type_dependant: { pluralize: true }
+        validates :items, item_type_dependant: true
         validates :cost_per_item, cost_item_type_dependant: true
       end
 

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -1,7 +1,6 @@
 class CostItemTypeDependantValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     cost_item_type = cost_item_type_for(record)
-    cost_item_type = cost_item_type.pluralize if options[:pluralize]
     cost_type_translated = I18n.t("prior_authority.steps.service_cost.items.#{cost_item_type}")
 
     record.errors.add(attribute, :blank, item_type: cost_type_translated) if value.blank?

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -1,10 +1,12 @@
 class ItemTypeDependantValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    item_type = item_type_for(record)
-    item_type = item_type.pluralize if options[:pluralize]
+    item_type = item_type_for(record).pluralize
 
     record.errors.add(attribute, :blank, item_type:) if value.blank?
-    record.errors.add(attribute, :not_a_number, item_type:) if value.is_a?(String)
+    if value.is_a?(String)
+      error = value.to_f.to_s == value ? :not_a_whole_number : :not_a_number
+      record.errors.add(attribute, error, item_type:)
+    end
     record.errors.add(attribute, :greater_than, item_type:) if value.to_d <= 0
   end
 

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -4,6 +4,10 @@ class ItemTypeDependantValidator < ActiveModel::EachValidator
 
     record.errors.add(attribute, :blank, item_type:) if value.blank?
     if value.is_a?(String)
+      # The value will only be a string when the automatic type conversion in Type::FullyValidatableInteger has failed.
+      # This is because the value entered by the user is either:
+      # * not a number at all
+      # * a non-integer number. In this case, `.to_f.to_s should yield the original value`
       error = value.to_f.to_s == value ? :not_a_whole_number : :not_a_number
       record.errors.add(attribute, error, item_type:)
     end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -207,6 +207,7 @@ en:
               blank: Enter the number of %{item_type}
               greater_than: The number of %{item_type} must be more than 0
               not_a_number: The number of %{item_type} must be a number, like 25
+              not_a_whole_number: The number of %{item_type} must be a whole number, like 25
             cost_per_item:
               blank: Enter the cost per %{item_type}
               greater_than: The cost per %{item_type} must be more than 0

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CostItemTypeDependantValidator do
-  subject(:instance) { klass.new(items:, cost_per_item:) }
+  subject(:instance) { klass.new(cost_per_item:) }
 
   let(:klass) do
     Class.new do
@@ -12,16 +12,13 @@ RSpec.describe CostItemTypeDependantValidator do
         ActiveModel::Name.new(self, nil, 'temp')
       end
 
-      attribute :items
       attribute :cost_per_item, :gbp
 
-      validates :items, cost_item_type_dependant: { pluralize: true }
       validates :cost_per_item, cost_item_type_dependant: true
     end
   end
 
   context 'when attribute is a positive number' do
-    let(:items) { 1 }
     let(:cost_per_item) { 100 }
 
     it 'form object is valid' do
@@ -30,7 +27,6 @@ RSpec.describe CostItemTypeDependantValidator do
   end
 
   context 'when attribute is a positive number less than one' do
-    let(:items) { 1 }
     let(:cost_per_item) { 0.1 }
 
     it 'form object is valid' do
@@ -39,12 +35,10 @@ RSpec.describe CostItemTypeDependantValidator do
   end
 
   context 'when attribute is nil' do
-    let(:items) { nil }
     let(:cost_per_item) { nil }
 
     it 'adds blank error' do
       expect(instance).not_to be_valid
-      expect(instance.errors.of_kind?(:items, :blank)).to be(true)
       expect(instance.errors.of_kind?(:cost_per_item, :blank)).to be(true)
     end
 
@@ -55,29 +49,25 @@ RSpec.describe CostItemTypeDependantValidator do
   end
 
   context 'when attribute is a string' do
-    let(:items) { 'one' }
     let(:cost_per_item) { '100 hundred' }
 
     it 'adds not_a_number error' do
       expect(instance).not_to be_valid
-      expect(instance.errors.of_kind?(:items, :not_a_number)).to be(true)
       expect(instance.errors.of_kind?(:cost_per_item, :not_a_number)).to be(true)
     end
   end
 
   context 'when attribute is less zero or less' do
-    let(:items) { 0 }
     let(:cost_per_item) { 0 }
 
     it 'adds greater_than error' do
       expect(instance).not_to be_valid
-      expect(instance.errors.of_kind?(:items, :greater_than)).to be(true)
       expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
     end
   end
 
   context 'when model has an cost_item_type attribute' do
-    subject(:instance) { klass.new(items:, cost_per_item:, cost_item_type:) }
+    subject(:instance) { klass.new(cost_per_item:, cost_item_type:) }
 
     let(:klass) do
       Class.new do
@@ -90,22 +80,18 @@ RSpec.describe CostItemTypeDependantValidator do
 
         attribute :cost_item_type, :string
 
-        attribute :items
         attribute :cost_per_item, :gbp
 
-        validates :items, cost_item_type_dependant: { pluralize: true }
         validates :cost_per_item, cost_item_type_dependant: true
       end
     end
 
     context 'when attribute is nil' do
-      let(:items) { nil }
       let(:cost_per_item) { nil }
       let(:cost_item_type) { 'thousand_words' }
 
       it 'include item type option from model, pluralizing if option set' do
         instance.validate
-        expect(instance.errors.details[:items].flat_map(&:values)).to include('1000 words')
         expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('1000 words')
       end
     end


### PR DESCRIPTION
## Description of change
Add specific messaging for not-whole-numbers
Remove unused options (item_type_dependant is always pluralized, cost_item_type_dependant is never pluralized)
Remove redundant values in specs

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1828)
