### PR TITLE
DO NOT MERGE: Testing ClamAV Client Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,6 @@ We have a default [k8s security context ](https://kubernetes.io/docs/reference/g
 - allowPrivilegeEscalation - AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. Currently defaults to false, this limits the level of access for bad actors/destructive processes
 - seccompProfile.type - The Secure Computing Mode (Linux kernel feature that limits syscalls that processes can run) options to use by this container. Currenly defaults to RuntimeDefault which is the [widely accepted default profile](https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile)
 - capabilities - The POSIX capabilities to add/drop when running containers. Currently defaults to drop["ALL"] which means all of these capabilities will be dropped - since this doesn't cause any issues, it's best to keep as is for security reasons until there's a need for change
+
+
+


### PR DESCRIPTION
Using this PR to test if we reliably get Clamby::ClamscanClientError when Clamby attempts to do a Clam AV scan before the first `instream(local): OK` log