### PR TITLE
CRM457-1808: Constrain long lines without whitespace in tables

### DIFF
--- a/app/assets/stylesheets/custom/govuk-table.scss
+++ b/app/assets/stylesheets/custom/govuk-table.scss
@@ -20,3 +20,8 @@
 .govuk-table .govuk-table__foot .govuk-table__row .govuk-table__footer:last-child {
   padding-right: 0;
 }
+
+.govuk-table .govuk-table__cell {
+  max-width: 4rem;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
## Description of change

`max-width` value was chosen arbitrarily, so can change if it's too small/large.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1808)

### Before changes:
![image](https://github.com/user-attachments/assets/ddd79089-0069-47f0-92a9-a800deedd5d7)

### After changes:
![image](https://github.com/user-attachments/assets/31ab5d32-5ee2-4c3d-ab67-b1fc7686cb61)

