### PR TITLE
CRM457-1905: Fix locking issues

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -13,16 +13,6 @@ module PriorAuthority
       def save!; end
 
       def persist!
-        updated = false
-        application.with_lock do
-          updated = update_application
-        end
-        SubmitToAppStore.perform_later(submission: application) if updated
-
-        updated
-      end
-
-      def update_application
         unless application.draft? || application.sent_back?
           errors.add(:base, :application_already_submitted)
           return false
@@ -30,6 +20,7 @@ module PriorAuthority
 
         application.update!(attributes.merge({ status: new_status }))
         update_incorrect_information if application.incorrect_information_explanation.present?
+        SubmitToAppStore.perform_later(submission: application)
 
         true
       end

--- a/app/jobs/submit_to_app_store.rb
+++ b/app/jobs/submit_to_app_store.rb
@@ -2,8 +2,15 @@ class SubmitToAppStore < ApplicationJob
   queue_as :default
 
   def perform(submission:)
-    submit(submission)
-    notify(submission)
+    # This job may have been enqueued while the submission was locked, before a DB
+    # transaction had been committed. So if we read from the DB straight away we
+    # may not receive the latest data. Waiting until we can acquire our own lock
+    # means waiting until the previous lock is released, at which point any
+    # modifications made as part of that transaction will have been committed
+    submission.with_lock do
+      submit(submission)
+      notify(submission)
+    end
   end
 
   def submit(submission, include_events: true)

--- a/spec/jobs/submit_to_app_store_spec.rb
+++ b/spec/jobs/submit_to_app_store_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SubmitToAppStore do
     allow(described_class::PayloadBuilder).to receive(:call)
       .and_return(payload)
     allow(SendNotificationEmail).to receive(:perform_later)
+    allow(submission).to receive(:with_lock).and_yield
   end
 
   describe '#perform' do


### PR DESCRIPTION
## Description of change
- Remove lock from CheckAnswersForm because there's now a lock higher up the call stack so putting another one in doesn't add value and just confuses us
- Add a lock to SubmitToAppStore so that the job can't run until the other lock has been released and its transaction has been committed, ensuring that the data the job is working with is up to date

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1905)
