### PR TITLE
CRM457-1905b: Remove redundant code

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -28,7 +28,7 @@ module PriorAuthority
           return false
         end
 
-        application.update!(attributes.merge({ status: new_status }))
+        application.update!(status: new_status)
         update_incorrect_information if application.incorrect_information_explanation.present?
 
         true

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -24,9 +24,6 @@ class PriorAuthorityApplication < ApplicationRecord
   has_many :further_informations, dependent: :destroy, inverse_of: :prior_authority_application
   has_many :incorrect_informations, dependent: :destroy, inverse_of: :prior_authority_application
 
-  attribute :confirm_excluding_vat, :boolean
-  attribute :confirm_travel_expenditure, :boolean
-
   enum :status, {
     pre_draft: 'pre_draft',
     draft: 'draft',

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -98,8 +98,6 @@ class SubmitToAppStore
       custom_service_name
       prior_authority_granted
       no_alternative_quote_reason
-      confirm_excluding_vat
-      confirm_travel_expenditure
       created_at
       updated_at
     ].freeze

--- a/gems/laa_multi_step_forms/Gemfile.lock
+++ b/gems/laa_multi_step_forms/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     laa_multi_step_forms (0.1.0)
       devise (~> 4.8)
       govuk-components (>= 5.0.0)
-      govuk_design_system_formbuilder (>= 5.4, < 5.5)
+      govuk_design_system_formbuilder (>= 5.4, < 5.6)
       omniauth-rails_csrf_protection (~> 1.0.1)
       omniauth-saml (~> 2.1.0)
       rails (>= 7.0.4.3)

--- a/gems/laa_multi_step_forms/app/forms/steps/base_form_object.rb
+++ b/gems/laa_multi_step_forms/app/forms/steps/base_form_object.rb
@@ -15,7 +15,7 @@ module Steps
       raise ArgumentError, "expected `ApplicationRecord`, got `#{record.class}`" unless record.is_a?(ApplicationRecord)
 
       attrs = record.slice(
-        attribute_names
+        attribute_names & record.attribute_names
       ).merge!(
         application: application || record,
         record: record

--- a/gems/laa_multi_step_forms/spec/forms/steps/base_form_object_spec.rb
+++ b/gems/laa_multi_step_forms/spec/forms/steps/base_form_object_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Steps::BaseFormObject do
     context 'for an active record argument' do
       let(:record) { FooBarRecord.new(favourite_meal: 'pizza') }
 
+      before do
+        allow(record).to receive(:attribute_names).and_return(['favourite_meal'])
+      end
+
       it 'instantiates the form object using the declared attributes' do
         form = FavouriteMealForm.build(record)
 

--- a/gems/laa_multi_step_forms/spec/forms/steps/has_one_association_spec.rb
+++ b/gems/laa_multi_step_forms/spec/forms/steps/has_one_association_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe Steps::HasOneAssociation do
       let(:child) { FooBarRecord.new(favourite_meal: 'fast') }
       let(:record) { FooBarRecord.new(favourite_meal: 'pizza', child: child) }
 
+      before do
+        allow(child).to receive(:attribute_names).and_return(['favourite_meal'])
+      end
+
       context 'when child exixts' do
         it 'overrides the record to be the child' do
           form = FavouriteMealForm.build(record)

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -96,11 +96,6 @@ FactoryBot.define do
       primary_quote factory: %i[quote primary_per_item], strategy: :build
     end
 
-    trait :with_confirmations do
-      confirm_excluding_vat { true }
-      confirm_travel_expenditure { true }
-    end
-
     trait :full do
       with_firm_and_solicitor
       with_defendant

--- a/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
         custom_service_name: nil,
         prior_authority_granted: false,
         no_alternative_quote_reason: 'a reason',
-        confirm_excluding_vat: true,
-        confirm_travel_expenditure: true,
         defendant: {
           first_name: 'bob',
           last_name: 'jim',

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -32,8 +32,6 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
         custom_service_name: nil,
         prior_authority_granted: false,
         no_alternative_quote_reason: 'a reason',
-        confirm_excluding_vat: true,
-        confirm_travel_expenditure: true,
         defendant: hash_including(
           first_name: application.defendant.first_name,
           last_name: application.defendant.last_name,
@@ -176,7 +174,7 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
     }
   end
   let(:provider) { create(:provider) }
-  let(:application) { create(:prior_authority_application, :full, :with_confirmations, status: :submitted) }
+  let(:application) { create(:prior_authority_application, :full, status: :submitted) }
   let(:fixed_arbitrary_date) { DateTime.new(2024, 1, 15, 0, 0, 0) }
 
   before do


### PR DESCRIPTION
## Description of change
We don't save confirmation fields to the DB, so in production we never actually send them to the app store. But the tests act like we do. Since we don't, and we don't need to, we can clear out a bunch of redundant code that misleadingly makes it look like we persist this stuff and send it to the app store.


[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1905)