### PR TITLE
CRM457-1861: Move office code question

### DIFF
--- a/app/presenters/nsm/check_answers/claim_type_card.rb
+++ b/app/presenters/nsm/check_answers/claim_type_card.rb
@@ -3,12 +3,13 @@
 module Nsm
   module CheckAnswers
     class ClaimTypeCard < Base
-      attr_reader :claim
+      attr_reader :claim, :firm_details_form
 
       def initialize(claim)
         @group = 'claim_type'
         @section = 'claim_type'
         @claim = claim
+        @firm_details_form = Nsm::Steps::FirmDetailsForm.build(claim)
       end
 
       def row_data
@@ -39,7 +40,12 @@ module Nsm
           {
             head_key: 'stage_reached',
             text: translate_table_key(section, claim.stage_reached)
-          }
+          },
+          {
+            head_key: 'firm_account_number',
+            text: check_missing(firm_details_form.application.office_code)
+          },
+
         ]
       end
 

--- a/app/presenters/nsm/check_answers/your_details_card.rb
+++ b/app/presenters/nsm/check_answers/your_details_card.rb
@@ -20,10 +20,6 @@ module Nsm
             text: check_missing(firm_details_form.firm_office.name)
           },
           {
-            head_key: 'firm_account_number',
-            text: check_missing(firm_details_form.application.office_code)
-          },
-          {
             head_key: 'firm_address',
             text: format_address(firm_details_form.firm_office)
           },

--- a/app/presenters/nsm/tasks/claim_type.rb
+++ b/app/presenters/nsm/tasks/claim_type.rb
@@ -14,10 +14,22 @@ module Nsm
       end
 
       def completed?
+        claim_type_questions_completed? && office_code_questions_completed? && office_area_questions_completed?
+      end
+
+      def claim_type_questions_completed?
+        application.claim_type.present?
+      end
+
+      def office_area_questions_completed?
         application.claim_type == ::ClaimType::BREACH_OF_INJUNCTION.to_s ||
           application.office_in_undesignated_area == false ||
           application.court_in_undesignated_area ||
           !application.transferred_from_undesignated_area.nil?
+      end
+
+      def office_code_questions_completed?
+        application.office_code.present?
       end
     end
   end

--- a/app/presenters/nsm/tasks/firm_details.rb
+++ b/app/presenters/nsm/tasks/firm_details.rb
@@ -10,8 +10,7 @@ module Nsm
 
       def completed?
         super &&
-          Nsm::Steps::ContactDetailsForm.build(application.solicitor, application:).valid? &&
-          application.office_code.present?
+          Nsm::Steps::ContactDetailsForm.build(application.solicitor, application:).valid?
       end
     end
   end

--- a/app/services/decisions/back_decision_tree.rb
+++ b/app/services/decisions/back_decision_tree.rb
@@ -4,13 +4,16 @@ module Decisions
     WRAPPER_CLASS = CustomWrapper
 
     # start_page - takes use back to previous page
-    from(DecisionTree::NSM_CASE_TRANSFER).goto(edit: DecisionTree::NSM_COURT_AREA)
+    from(DecisionTree::NSM_OFFICE_CODE).goto(edit: DecisionTree::NSM_CLAIM_TYPE)
+    from(DecisionTree::NSM_OFFICE_AREA)
+      .when(-> { application.submitter.multiple_offices? })
+      .goto(edit: DecisionTree::NSM_OFFICE_CODE)
+      .goto(edit: DecisionTree::NSM_CLAIM_TYPE)
     from(DecisionTree::NSM_COURT_AREA).goto(edit: DecisionTree::NSM_OFFICE_AREA)
-    from(DecisionTree::NSM_OFFICE_AREA).goto(edit: DecisionTree::NSM_CLAIM_TYPE)
+    from(DecisionTree::NSM_CASE_TRANSFER).goto(edit: DecisionTree::NSM_COURT_AREA)
 
     from(DecisionTree::NSM_FIRM_DETAILS).goto(show: DecisionTree::NSM_START_PAGE)
     from(DecisionTree::NSM_CONTACT_DETAILS).goto(edit: DecisionTree::NSM_FIRM_DETAILS)
-    from(DecisionTree::NSM_OFFICE_CODE).goto(edit: DecisionTree::NSM_CONTACT_DETAILS)
     from('nsm/steps/defendant_details')
       .when(-> { application.defendants.exists? })
       .goto(edit: DecisionTree::NSM_DEFENDANT_SUMMARY)

--- a/app/services/decisions/decision_tree.rb
+++ b/app/services/decisions/decision_tree.rb
@@ -4,13 +4,13 @@ module Decisions
     WRAPPER_CLASS = CustomWrapper
 
     NSM_CLAIM_TYPE = 'nsm/steps/claim_type'.freeze
+    NSM_OFFICE_CODE = 'nsm/steps/office_code'.freeze
     NSM_OFFICE_AREA = 'nsm/steps/office_area'.freeze
     NSM_COURT_AREA = 'nsm/steps/court_area'.freeze
     NSM_CASE_TRANSFER = 'nsm/steps/case_transfer'.freeze
     NSM_START_PAGE = 'nsm/steps/start_page'.freeze
     NSM_FIRM_DETAILS = 'nsm/steps/firm_details'.freeze
     NSM_CONTACT_DETAILS = 'nsm/steps/contact_details'.freeze
-    NSM_OFFICE_CODE = 'nsm/steps/office_code'.freeze
     NSM_WORK_ITEMS = 'nsm/steps/work_items'.freeze
     NSM_WORK_ITEM = 'nsm/steps/work_item'.freeze
     NSM_DEFENDANT_SUMMARY = 'nsm/steps/defendant_summary'.freeze
@@ -22,6 +22,13 @@ module Decisions
     NSM_EQUALITY = 'nsm/steps/equality'.freeze
 
     from(:claim_type)
+      .when(-> { application.submitter.multiple_offices? })
+      .goto(edit: NSM_OFFICE_CODE)
+      .when(-> { application.claim_type == ClaimType::NON_STANDARD_MAGISTRATE.to_s })
+      .goto(edit: NSM_OFFICE_AREA)
+      .goto(show: NSM_START_PAGE)
+
+    from(:office_code)
       .when(-> { application.claim_type == ClaimType::NON_STANDARD_MAGISTRATE.to_s })
       .goto(edit: NSM_OFFICE_AREA)
       .goto(show: NSM_START_PAGE)
@@ -42,15 +49,10 @@ module Decisions
     # start_page to firm_details is a hard coded link as show page
     from(:firm_details).goto(edit: NSM_CONTACT_DETAILS)
     from(:contact_details)
-      .when(-> { application.submitter.multiple_offices? })
-      .goto(edit: NSM_OFFICE_CODE)
       .when(-> { application.defendants.none? })
       .goto(edit: 'nsm/steps/defendant_details', defendant_id: Nsm::StartPage::NEW_RECORD)
       .goto(edit: NSM_DEFENDANT_SUMMARY)
-    from(:office_code)
-      .when(-> { application.defendants.none? })
-      .goto(edit: 'nsm/steps/defendant_details', defendant_id: Nsm::StartPage::NEW_RECORD)
-      .goto(edit: NSM_DEFENDANT_SUMMARY)
+
     from(:defendant_details).goto(edit: NSM_DEFENDANT_SUMMARY)
     from(:defendant_delete).goto(edit: NSM_DEFENDANT_SUMMARY)
     from(:defendant_summary)

--- a/app/views/nsm/steps/office_code/edit.html.erb
+++ b/app/views/nsm/steps/office_code/edit.html.erb
@@ -8,7 +8,7 @@
       <%= f.govuk_collection_radio_buttons :office_code, @form_object.options, :to_s, :to_s,
                                            legend: { tag: 'h1', size: 'xl', text: t('.page_title') },
                                            hint: { text: t('.subheading') } %>
-      <%= f.continue_button %>
+      <%= f.continue_button(secondary: false) %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -26,9 +26,9 @@ en:
               stage_reached: Stage reached
               prog: PROG
               prom: PROM
+              firm_account_number: Firm office account number
             firm_details:
               firm_name: Firm name
-              firm_account_number: Firm office account number
               firm_address: Firm address
               vat_registered: Firm VAT registered
               solicitor_first_name: Solicitor first name

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -140,7 +140,7 @@ en:
 
           claim_type:
             claim_type:
-              title: Claim details
+              title: Claim summary
           about_you:
             heading: About you
             firm_details:

--- a/spec/presenter/nsm/steps/claim_type_presenter_spec.rb
+++ b/spec/presenter/nsm/steps/claim_type_presenter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Nsm::Tasks::ClaimType, type: :system do
       office_in_undesignated_area:,
       transferred_from_undesignated_area:,
       claim_type:,
+      office_code:,
     }
   end
   let(:id) { SecureRandom.uuid }
@@ -22,6 +23,7 @@ RSpec.describe Nsm::Tasks::ClaimType, type: :system do
   let(:office_in_undesignated_area) { nil }
   let(:transferred_from_undesignated_area) { nil }
   let(:claim_type) { nil }
+  let(:office_code) { '12356' }
 
   describe '#path' do
     it { expect(subject.path).to eq("/non-standard-magistrates/applications/#{id}/steps/claim_type") }
@@ -42,6 +44,12 @@ RSpec.describe Nsm::Tasks::ClaimType, type: :system do
       let(:claim_type) { 'breach_of_injunction' }
 
       it { expect(subject).to be_completed }
+
+      context 'when office code not selected' do
+        let(:office_code) { nil }
+
+        it { expect(subject).not_to be_completed }
+      end
     end
 
     context 'when court payment' do

--- a/spec/presenter/nsm/steps/firm_details_presenter_spec.rb
+++ b/spec/presenter/nsm/steps/firm_details_presenter_spec.rb
@@ -45,11 +45,5 @@ RSpec.describe Nsm::Tasks::FirmDetails, type: :system do
 
       it { expect(subject).not_to be_completed }
     end
-
-    context 'when office code has not saved' do
-      let(:office_code) { nil }
-
-      it { expect(subject).not_to be_completed }
-    end
   end
 end

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
     let(:claim) { build(:claim) }
 
     it 'shows correct title' do
-      expect(subject.title).to eq('Claim details')
+      expect(subject.title).to eq('Claim summary')
     end
   end
 

--- a/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/claim_type_card_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             {
               head_key: 'stage_reached',
               text: 'PROM'
-            }
+            },
+            { head_key: 'firm_account_number', text: '1A123B' }
           ]
         )
       end
@@ -86,7 +87,7 @@ RSpec.describe Nsm::CheckAnswers::ClaimTypeCard do
             {
               head_key: 'stage_reached',
               text: 'PROG'
-            }
+            }, { head_key: 'firm_account_number', text: '1A123B' }
           ]
         )
       end

--- a/spec/presenters/nsm/check_answers/your_details_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/your_details_card_spec.rb
@@ -28,10 +28,6 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'Firm A'
             },
             {
-              head_key: 'firm_account_number',
-              text: '1A123B'
-            },
-            {
               head_key: 'firm_address',
               text: '2 Laywer Suite<br>Unit B<br>Lawyer Town<br>CR0 1RE'
             },
@@ -72,10 +68,6 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
           [
             {
               head_key: 'firm_name',
-              text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
-            },
-            {
-              head_key: 'firm_account_number',
               text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
             {
@@ -123,10 +115,6 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
               text: 'Firm A'
             },
             {
-              head_key: 'firm_account_number',
-              text: '1A123B'
-            },
-            {
               head_key: 'firm_address',
               text: '2 Laywer Suite<br><strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
             },
@@ -169,10 +157,6 @@ RSpec.describe Nsm::CheckAnswers::YourDetailsCard do
             {
               head_key: 'firm_name',
               text: 'Firm A'
-            },
-            {
-              head_key: 'firm_account_number',
-              text: '1A123B'
             },
             {
               head_key: 'firm_address',

--- a/spec/system/nsm/office_code_spec.rb
+++ b/spec/system/nsm/office_code_spec.rb
@@ -4,27 +4,21 @@ RSpec.describe 'Office code selection', type: :system do
   let(:office_code_question) { 'Which firm office account number is this claim for?' }
   let(:provider) { Provider.first }
 
-  context 'when I complete the firm and contact details screen' do
+  before do
+    visit provider_saml_omniauth_callback_path
+    provider.update(office_codes:)
+    visit edit_nsm_steps_claim_type_path(claim.id)
+  end
+
+  context 'when I complete claim type screen as NSM' do
     before do
-      visit provider_saml_omniauth_callback_path
-      provider.update(office_codes:)
-      visit edit_nsm_steps_firm_details_path(claim.id)
-      fill_in 'Firm name', with: 'Lawyers'
-      fill_in 'Address line 1', with: 'home'
-      fill_in 'Town or city', with: 'hometown'
-      fill_in 'Postcode', with: 'AA1 1AA'
-
-      choose 'nsm-steps-firm-details-form-firm-office-attributes-vat-registered-yes-field'
-
-      fill_in 'Solicitor first name', with: 'James'
-      fill_in 'Solicitor last name', with: 'Robert'
-      fill_in 'Solicitor reference number', with: '2222'
-
-      click_on 'Save and continue'
-
-      fill_in 'First name', with: 'Jim'
-      fill_in 'Last name', with: 'Bob'
-      fill_in 'Email address', with: 'jim@bob.com'
+      fill_in 'What is your unique file number (UFN)?', with: '121212/001'
+      choose "Non-standard magistrates' court payment"
+      within('.govuk-radios__conditional', text: 'Representation order date') do
+        fill_in 'Day', with: '01'
+        fill_in 'Month', with: '02'
+        fill_in 'Year', with: '2003'
+      end
 
       click_on 'Save and continue'
     end
@@ -48,24 +42,8 @@ RSpec.describe 'Office code selection', type: :system do
       it 'Saves my choice' do
         choose '1A123B'
         click_on 'Save and continue'
-        expect(page).to have_content 'Defendant details'
+        expect(page).to have_content 'Was this case worked on in an office in an undesignated area?'
         expect(claim.reload.office_code).to eq '1A123B'
-      end
-
-      it 'Allows me to save and come back later' do
-        click_on 'Save and come back later'
-        expect(page.find(:id, 'nsm/firm_details-status').text).to eq 'In progress'
-        expect(claim.reload.office_code).to be_nil
-      end
-
-      context 'when the claim already has a defendant' do
-        let(:defendants) { [build(:defendant, :valid)] }
-
-        it 'Takes me to the defendant summary path' do
-          choose '1A123B'
-          click_on 'Save and continue'
-          expect(page).to have_content 'You\'ve added 1 defendant'
-        end
       end
     end
 
@@ -73,8 +51,45 @@ RSpec.describe 'Office code selection', type: :system do
       let(:claim) { create(:claim, office_code: '1A123B', submitter: provider) }
       let(:office_codes) { %w[1A123B] }
 
-      it 'skips the office code screen' do
-        expect(page).to have_no_content office_code_question
+      it 'skips the office code screen and goes straight to office area' do
+        expect(page).to have_content 'Was this case worked on in an office in an undesignated area?'
+      end
+    end
+  end
+
+  context 'when I complete claim type screen as BOI' do
+    before do
+      fill_in 'What is your unique file number (UFN)?', with: '121212/001'
+      choose 'Breach of injunction'
+      fill_in 'Clients CNTP (contempt) number', with: 'CNTP1234'
+      within('.govuk-radios__conditional', text: 'Date the CNTP rep order was issued') do
+        fill_in 'Day', with: '01'
+        fill_in 'Month', with: '02'
+        fill_in 'Year', with: '2003'
+      end
+
+      click_on 'Save and continue'
+    end
+
+    context 'when the provider has multiple office codes' do
+      let(:claim) { create(:claim, office_code: nil, submitter: provider, defendants: defendants) }
+      let(:defendants) { [] }
+      let(:office_codes) { %w[1A123B 1K022G] }
+
+      it 'saves my answer and forwards me on to the task list' do
+        choose '1A123B'
+        click_on 'Save and continue'
+        expect(page).to have_content 'Your claim progress'
+        expect(claim.reload.office_code).to eq '1A123B'
+      end
+    end
+
+    context 'when provider has a single office code that has been pre-selected' do
+      let(:claim) { create(:claim, office_code: '1A123B', submitter: provider) }
+      let(:office_codes) { %w[1A123B] }
+
+      it 'skips the office code screen and goes straight to task list' do
+        expect(page).to have_content 'Your claim progress'
       end
     end
   end


### PR DESCRIPTION
## Description of change
- Move the office code question to a different point in the flow
- And the answer to a different check answers card
- The office code question now doesn't have 'save and come back later' because it's in the initial flow of questions before you reach the task list

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1861)

