### PR TITLE
cCRM457-1909: Add rake task for correcting contact emails

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -14,4 +14,20 @@ namespace :fixes do
       Fixes::MultiplePrimaryQuoteFixer.new.fix
     end
   end
+
+  desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"
+  task :update_contact_email, [:id, :new_contact_email] => :environment do |_, args|
+    submission = PriorAuthorityApplication.find_by(id: args[:id]) || Claim.find_by(id: args[:id])
+
+    STDOUT.print "This will update #{submission.class} #{submission.laa_reference}'s contact email, \"#{submission.solicitor.contact_email || 'nil'}\", to \"#{args[:new_contact_email]}\": Are you sure? (y/n): "
+    input = STDIN.gets.strip
+
+    if input.downcase.in?(['yes','y'])
+      print 'updating...'
+      submission.solicitor.contact_email = args[:new_contact_email]
+      submission.solicitor.save!(touch: false)
+      submission.reload.solicitor.reload
+      puts "#{submission.laa_reference}'s contact email is now #{submission.solicitor.contact_email}"
+    end
+  end
 end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -29,4 +29,35 @@ describe 'fixes:', type: :task do
       end
     end
   end
+
+  describe 'update_contact_email' do
+    subject(:run) do
+      Rake::Task['fixes:update_contact_email'].execute(arguments)
+    end
+
+    let(:arguments) { Rake::TaskArguments.new [:id, :new_contact_email], [submission.id, 'correct@email.address'] }
+    let(:solicitor) { Solicitor.create(contact_email: 'wrong@email.address') }
+
+    before { allow($stdin).to receive_message_chain(:gets, :strip).and_return('y') }
+
+    context 'with a claim' do
+      let(:submission) { create(:claim, solicitor:) }
+
+      it 'amends contact email' do
+        expect { run }.to change { submission.solicitor.reload.contact_email }
+          .from('wrong@email.address')
+          .to('correct@email.address')
+      end
+    end
+
+    context 'with a prior authority application' do
+      let(:submission) { create(:prior_authority_application, solicitor:) }
+
+      it 'amends contact email' do
+        expect { run }.to change { submission.solicitor.reload.contact_email }
+          .from('wrong@email.address')
+          .to('correct@email.address')
+      end
+    end
+  end
 end


### PR DESCRIPTION

## Description of change
Add rake task for correcting contact emails

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1909)

For situations where a provider has entered a valid
format of email but which is nonetheless undeliverable.

## Notes for reviewer
