### PR TITLE
CRM457-1936: Use find or create within the lock

### DIFF
--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -105,12 +105,10 @@ module PriorAuthority
     def sync_incorrect_info_request
       latest_incorrect_info = data['incorrect_information'].max_by { _1['requested_at'] }
 
-      application.incorrect_informations.create(
-        {
-          caseworker_id: latest_incorrect_info['caseworker_id'],
-          information_requested: latest_incorrect_info['information_requested'],
-          requested_at: latest_incorrect_info['requested_at']
-        }
+      application.incorrect_informations.find_or_create_by(
+        caseworker_id: latest_incorrect_info['caseworker_id'],
+        information_requested: latest_incorrect_info['information_requested'],
+        requested_at: latest_incorrect_info['requested_at']
       )
     end
 


### PR DESCRIPTION
## Description of change
Make sync_incorrect_info_request behave like sync_further_info_request

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1936)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
