### PR TITLE
CRM457-1864: Wait for Clamby.safe? to actually succeed

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -14,7 +14,7 @@ class HealthcheckController < ApplicationController
     # and is known to be safe, we trigger an error if Clamby isn't ready,
     # causing this endpoint to return a 503, telling K8s that the pod
     # isn't ready yet.
-    Clamby.safe?(Rails.root.join('Gemfile'))
+    return head :service_unavailable unless Clamby.safe?(Rails.root.join('Gemfile'))
 
     render json: build_args, status: :ok
   rescue Clamby::ClamscanClientError

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -33,7 +33,16 @@ RSpec.describe HealthcheckController do
       end
     end
 
-    context 'when Clamby is not ready' do
+    context 'when Clamby is not ready and returns nil' do
+      before { allow(Clamby).to receive(:safe?).and_return(nil) }
+
+      it 'returns a 503' do
+        get :ready
+        expect(response).to have_http_status(:service_unavailable)
+      end
+    end
+
+    context 'when Clamby is not ready and raises an error' do
       before { allow(Clamby).to receive(:safe?).and_raise(Clamby::ClamscanClientError) }
 
       it 'returns a 503' do


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1864)

This does seem to be doing something - in the screenshot below, the readiness probe is briefly failing with a 503, which I'm not seeing happen on other branches, suggesting that the change is extending the period of unreadiness while Clamby is unavailable.
<img width="1321" alt="Screenshot 2024-08-28 at 12 46 41" src="https://github.com/user-attachments/assets/87f1894e-640c-4873-86c0-919dc2b42d78">


