### PR TITLE
Give dummy prod user access to crm7/NSM

### DIFF
--- a/config/gatekeeper_crm7.yml
+++ b/config/gatekeeper_crm7.yml
@@ -55,7 +55,8 @@ uat:
 production:
   office_codes:
     # dummy user/office
-    # - 2N232W
+    - 2N232W
+
     # First CRM7 onboarding tranche - 19/08/24
     - 0W160B
     - 2M075N


### PR DESCRIPTION

## Description of change
Give dummy prod user access to crm7/NSM

[came out of](https://dsdmoj.atlassian.net/browse/CRM457-1907)

For sanity testing. Inline we what we had/have for crm4
and crm5 already.

## Notes for reviewer

