### PR TITLE
CRM457-1885: Make rake tasks work with current year

### DIFF
--- a/lib/test_data/nsm_builder.rb
+++ b/lib/test_data/nsm_builder.rb
@@ -85,7 +85,8 @@ module TestData
     private
 
     def date_for(year)
-      (Date.new(year, 1, 1) + rand(350)).next_weekday
+      last_day = year == Date.current.year ? Date.current.yday - 7 : 350
+      (Date.new(year, 1, 1) + rand(last_day)).next_weekday
     end
 
     # rubocop:disable Rails/Output

--- a/lib/test_data/pa_builder.rb
+++ b/lib/test_data/pa_builder.rb
@@ -81,7 +81,8 @@ module TestData
     private
 
     def date_for(year)
-      (Date.new(year, 1, 1) + rand(350)).next_weekday
+      last_day = year == Date.current.year ? [Date.current.yday - 7, 0].max : 350
+      (Date.new(year, 1, 1) + rand(last_day)).next_weekday
     end
 
     # rubocop:disable Rails/Output

--- a/spec/lib/test_data/nsm_builder_spec.rb
+++ b/spec/lib/test_data/nsm_builder_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe TestData::NsmBuilder do
           updated_at: (Date.new(2023, 1, 1)..Date.new(2023, 12, 31))
         )
       end
+
+      context 'when year is set to the current year' do
+        subject(:options) { described_class.new.options(year: 2024)[key] }
+
+        before { travel_to Date.new(2024, 8, 1) }
+
+        it 'uses appropriate date ranges' do
+          expect(options[1].call).to match(
+            date: (Date.new(2024, 1, 1)...Date.current),
+            updated_at: (Date.new(2024, 1, 1)...Date.current),
+            disbursements_count: (0..25),
+            work_items_count: (1..50),
+          )
+        end
+      end
     end
 
     context 'breach' do

--- a/spec/lib/test_data/pa_builder_spec.rb
+++ b/spec/lib/test_data/pa_builder_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe TestData::PaBuilder do
           service_type_cost_type: be_one_of(:per_item, :per_hour)
         )
       end
+
+      context 'when year is set to the current year' do
+        subject(:options) { described_class.new.options(year: 2024)[key] }
+
+        before { travel_to Date.new(2024, 8, 1) }
+
+        it 'uses appropriate date ranges' do
+          expect(options[1].call).to match(
+            date: (Date.new(2024, 1, 1)...Date.current),
+            updated_at: (Date.new(2024, 1, 1)...Date.current),
+            service_type_cost_type: be_one_of(:per_item, :per_hour),
+          )
+        end
+      end
     end
 
     context 'simple_prision' do


### PR DESCRIPTION
## Description of change
Add logic so if year is current year, dates should be in the past

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1885)
