### PR TITLE
CRM457-1947: More fixes to risk calculation

### DIFF
--- a/app/services/risk_assessment/low_risk_assessment.rb
+++ b/app/services/risk_assessment/low_risk_assessment.rb
@@ -2,8 +2,7 @@
 
 module RiskAssessment
   class LowRiskAssessment
-    EVIDENCE_MULTIPLIER = 4
-    PAGE_MULTIPLIER = 2
+    EVIDENCE_MULTIPLIER = 2
     WITNESS_MULTIPLIER = 30
     ADVOCACY_MULTIPLIER = 2
 
@@ -20,16 +19,15 @@ module RiskAssessment
     end
 
     def prep_low_enough?
-      total_prep_time <= multiplied_total_advocacy_time ||
-        alternative_prep_time <= multiplied_total_advocacy_time
+      total_prep_time - prep_allowances <= multiplied_total_advocacy_time
     end
 
-    def alternative_prep_time
-      prosecution_evidence = (@claim.prosecution_evidence || 0) * EVIDENCE_MULTIPLIER
-      number_of_pages = (@claim.defence_statement || 0) * PAGE_MULTIPLIER
-      number_of_witnesses = (@claim.number_of_witnesses || 0) * WITNESS_MULTIPLIER
-      length_of_video = @claim.time_spent || 0
-      prosecution_evidence + number_of_pages + length_of_video - number_of_witnesses
+    def prep_allowances
+      evidence_allowance = (@claim.prosecution_evidence || 0) * EVIDENCE_MULTIPLIER
+      statement_allowance = (@claim.defence_statement || 0) * EVIDENCE_MULTIPLIER
+      video_allowance = (@claim.time_spent || 0) * EVIDENCE_MULTIPLIER
+      witness_allowance = (@claim.number_of_witnesses || 0) * WITNESS_MULTIPLIER
+      evidence_allowance + statement_allowance + video_allowance + witness_allowance
     end
 
     def total_prep_time

--- a/spec/services/risk_assessment/low_risk_assessment_spec.rb
+++ b/spec/services/risk_assessment/low_risk_assessment_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe RiskAssessment::LowRiskAssessment do
   subject { described_class.new(claim) }
 
-  let(:claim) { create(:claim, work_items:, prosecution_evidence:) }
+  let(:claim) { create(:claim, work_items:, prosecution_evidence:, defence_statement:, time_spent:, number_of_witnesses:) }
   let(:work_items) { [attendance_work_item, advocacy_work_item, preparation_work_item] }
   let(:attendance_work_item) { build(:work_item, work_type: 'attendance_with_counsel', time_spent: attendance_time_spent) }
   let(:preparation_work_item) { build(:work_item, work_type: 'preparation', time_spent: preparation_time_spent) }
@@ -13,7 +13,10 @@ RSpec.describe RiskAssessment::LowRiskAssessment do
   let(:attendance_time_spent) { nil }
   let(:advocacy_time_spent) { nil }
   let(:preparation_time_spent) { nil }
-  let(:prosecution_evidence) { nil } # Multiplied by 4 to get alternative prep time
+  let(:prosecution_evidence) { nil }
+  let(:defence_statement) { nil }
+  let(:time_spent) { nil }
+  let(:number_of_witnesses) { nil }
 
   describe '#assess' do
     context 'when raw prep time is less than twice advocacy' do
@@ -63,48 +66,95 @@ RSpec.describe RiskAssessment::LowRiskAssessment do
     end
 
     context 'when raw prep time is greater than advocacy' do
-      let(:preparation_time_spent) { 41 }
+      let(:preparation_time_spent) { 80 }
       let(:advocacy_time_spent) { 20 }
 
       context 'when attendance is less than twice advocacy' do
         let(:attendance_time_spent) { 39 }
 
-        context 'when alternative prep time is less than twice advocacy' do
-          let(:prosecution_evidence) { 9 }
+        context 'when prosecution evidence allowance brings prep time down to below twice advocacy' do
+          let(:prosecution_evidence) { 21 }
 
           it { expect(subject.assess).to be_truthy }
         end
 
-        context 'when alternative prep time is equal to twice advocacy' do
-          let(:prosecution_evidence) { 10 }
+        context 'when prosecution evidence allowance brings prep time down to exactly twice advocacy' do
+          let(:prosecution_evidence) { 20 }
 
           it { expect(subject.assess).to be_truthy }
         end
 
-        context 'when alternative prep time is greater than twice advocacy' do
-          let(:prosecution_evidence) { 11 }
+        context 'when prosecution evidence is not enough to bring prep time down to below twice advocacy' do
+          let(:prosecution_evidence) { 19 }
 
           it { expect(subject.assess).to be_falsey }
+        end
+
+        context 'when defence statement allowance brings prep time down to below twice advocacy' do
+          let(:defence_statement) { 21 }
+
+          it { expect(subject.assess).to be_truthy }
+        end
+
+        context 'when defence statement is not enough to bring prep time down to below twice advocacy' do
+          let(:defence_statement) { 19 }
+
+          it { expect(subject.assess).to be_falsey }
+        end
+
+        context 'when video allowance brings prep time down to below twice advocacy' do
+          let(:time_spent) { 21 }
+
+          it { expect(subject.assess).to be_truthy }
+        end
+
+        context 'when video is not enough to bring prep time down to below twice advocacy' do
+          let(:time_spent) { 19 }
+
+          it { expect(subject.assess).to be_falsey }
+        end
+
+        context 'when witness allowance brings prep time down to below twice advocacy' do
+          let(:number_of_witnesses) { 2 }
+
+          it { expect(subject.assess).to be_truthy }
+        end
+
+        context 'when witness is not enough to bring prep time down to below twice advocacy' do
+          let(:number_of_witnesses) { 1 }
+
+          it { expect(subject.assess).to be_falsey }
+        end
+
+        context 'when multiple allowances bring prep time down to below twice advocacy' do
+          let(:number_of_witnesses) { 1 } # 30 minute allowance
+          let(:time_spent) { 2 } # 4 minute allowance
+          let(:defence_statement) { 2 } # 4 minute allowance
+          let(:prosecution_evidence) { 2 } # 4 minute allowance
+          # 42 minutes of allowances subtracted from 80 minutes of preparation time,
+          # should be less than 2 * 20 minutes of advocacy
+
+          it { expect(subject.assess).to be_truthy }
         end
       end
 
       context 'when attendance is equal to twice advocacy' do
         let(:attendance_time_spent) { 40 }
 
-        context 'when alternative prep time is less than twice advocacy' do
-          let(:prosecution_evidence) { 9 }
+        context 'when allowances bring prep time to less than twice advocacy' do
+          let(:prosecution_evidence) { 21 }
 
           it { expect(subject.assess).to be_truthy }
         end
 
-        context 'when alternative prep time is equal to twice advocacy' do
-          let(:prosecution_evidence) { 10 }
+        context 'when allowances bring prep time to exactly twice advocacy' do
+          let(:prosecution_evidence) { 20 }
 
           it { expect(subject.assess).to be_truthy }
         end
 
-        context 'when alternative prep time is greater than twice advocacy' do
-          let(:prosecution_evidence) { 11 }
+        context 'when allowances leave prep time greater than twice advocacy' do
+          let(:prosecution_evidence) { 19 }
 
           it { expect(subject.assess).to be_falsey }
         end
@@ -113,20 +163,20 @@ RSpec.describe RiskAssessment::LowRiskAssessment do
       context 'when attendance is more than twice advocacy' do
         let(:attendance_time_spent) { 41 }
 
-        context 'when alternative prep time is less than twice advocacy' do
-          let(:prosecution_evidence) { 9 }
+        context 'when allowances bring prep time to less than twice advocacy' do
+          let(:prosecution_evidence) { 21 }
 
           it { expect(subject.assess).to be_falsey }
         end
 
-        context 'when alternative prep time is equal to twice advocacy' do
-          let(:prosecution_evidence) { 10 }
+        context 'when allowances bring prep time to exactly twice advocacy' do
+          let(:prosecution_evidence) { 20 }
 
           it { expect(subject.assess).to be_falsey }
         end
 
-        context 'when alternative prep time is greater than twice advocacy' do
-          let(:prosecution_evidence) { 11 }
+        context 'when allowances leave prep time greater than twice advocacy' do
+          let(:prosecution_evidence) { 19 }
 
           it { expect(subject.assess).to be_falsey }
         end


### PR DESCRIPTION
## Description of change
This PR brings our low/medium risk calculation in line with:
* [The spreadsheet the caseworkers actually use](https://docs.google.com/spreadsheets/d/1P1E9JPcmAgxDcy7NWIq4IckQPzL-bPg1/edit?gid=1493704751#gid=1493704751)
* [The Miro board that describes the logic](https://miro.com/app/board/uXjVO21KiPg=/?moveToWidget=3458764529879393901&cot=14)
* [The flowchart from the confluence board Emma wrote up 2 years ago](https://dsdmoj.atlassian.net/wiki/spaces/CRM457/pages/4108943555/Risk+Based+Billing+Assessment)

The logic is also consistent with [this Google doc](https://docs.google.com/document/d/1SDzpK5ApQU-zTjpygmeCgiErJhDdFYbR/edit) describing the risk logic and [this walk-through of the logic](https://mojdt.slack.com/archives/C034YPREUSF/p1724776493722329?thread_ts=1724760197.910909&cid=C034YPREUSF) by a caseworker. The only thing this new behaviour is inconsistent with is [this other Google doc](https://docs.google.com/document/d/12HYIKEROd0kdiQ1SR086Rq0Otlr-DJEJU0hlfJAfOpY/edit#heading=h.1a2756py1cf6) which appears to be a write-up of our team's original misunderstanding of the requirements.

The crucial changes are:
* Allowances based on time-consuming preparation activities are now subtracted from the overall preparation time, not used instead of the preparation time
* We apply a standard 2-minutes-per-page and 2-minutes-per-minute-of-video, instead of sometimes using 4 minutes per page and only allowing 1 minute per minute of video

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1947)
