### PR TITLE
Swallow output to stdout during tests for rake tasks

### DIFF
--- a/spec/lib/tasks/submit_dummy_data_spec.rb
+++ b/spec/lib/tasks/submit_dummy_data_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 describe 'submit_dummy_data:', type: :task do
-  before do
-    allow($stdout).to receive(:print)
-  end
-
   describe 'prior_authority' do
     let(:dummy_client) { instance_double(AppStoreClient) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
   config.before(:each, type: :controller) { sign_in }
   # Use the faster rack test by default for system specs if possible
   config.before(:each, type: :system) { driven_by :rack_test }
+  # swallow sdtdout to keep output from rspec clean
+  config.before(:each, type: :task) { allow($stdout).to receive(:write) }
 
   config.expect_with :rspec do |c|
     c.max_formatted_output_length = nil


### PR DESCRIPTION
## Description of change
Silence output to console from testing of rake tasks

Rake tasks often having stdout output but this comes
out when running rspec and clutters the console.

## Notes for reviewer
