### PR TITLE
CRM457-1950: show granted adjustments

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -120,6 +120,11 @@ class Claim < ApplicationRecord
     end
   end
 
+  def cost_summary
+    @cost_summary ||= Nsm::CheckAnswers::CostSummaryCard.new(self, show_adjustments: true)
+  end
+  delegate :total_gross_adjusted?, to: :cost_summary
+
   private
 
   def sorted_work_item_ids

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -123,7 +123,7 @@ class Claim < ApplicationRecord
   def cost_summary
     @cost_summary ||= Nsm::CheckAnswers::CostSummaryCard.new(self, show_adjustments: true)
   end
-  delegate :total_gross_adjusted?, to: :cost_summary
+  delegate :show_adjusted?, to: :cost_summary
 
   private
 

--- a/app/presenters/nsm/check_answers/application_status_card.rb
+++ b/app/presenters/nsm/check_answers/application_status_card.rb
@@ -55,7 +55,7 @@ module Nsm
         @cost_summary ||= Nsm::CheckAnswers::CostSummaryCard.new(claim, show_adjustments: true)
       end
 
-      delegate :total_gross, :total_gross_allowed, to: :cost_summary
+      delegate :total_gross, :total_gross_allowed, :total_gross_adjusted?, to: :cost_summary
 
       def translate(key)
         I18n.t("nsm.steps.check_answers.groups.#{group}.#{section}.#{key}")
@@ -123,7 +123,7 @@ module Nsm
 
       def allowed_amount
         return '£0.00 allowed' if claim.rejected?
-        return "#{NumberTo.pounds(total_gross_allowed)} allowed" if claim.part_grant?
+        return "#{NumberTo.pounds(total_gross_allowed)} allowed" if total_gross_adjusted?
 
         "#{NumberTo.pounds(total_gross)} allowed"
       end

--- a/app/presenters/nsm/check_answers/application_status_card.rb
+++ b/app/presenters/nsm/check_answers/application_status_card.rb
@@ -54,8 +54,7 @@ module Nsm
       def cost_summary
         @cost_summary ||= Nsm::CheckAnswers::CostSummaryCard.new(claim, show_adjustments: true)
       end
-
-      delegate :total_gross, :total_gross_allowed, :total_gross_adjusted?, to: :cost_summary
+      delegate :total_gross, :total_gross_allowed, :show_adjusted?, to: :cost_summary
 
       def translate(key)
         I18n.t("nsm.steps.check_answers.groups.#{group}.#{section}.#{key}")
@@ -123,7 +122,7 @@ module Nsm
 
       def allowed_amount
         return '£0.00 allowed' if claim.rejected?
-        return "#{NumberTo.pounds(total_gross_allowed)} allowed" if total_gross_adjusted?
+        return "#{NumberTo.pounds(total_gross_allowed)} allowed" if show_adjusted?
 
         "#{NumberTo.pounds(total_gross)} allowed"
       end

--- a/app/presenters/nsm/check_answers/cost_summary_card.rb
+++ b/app/presenters/nsm/check_answers/cost_summary_card.rb
@@ -67,7 +67,7 @@ module Nsm
         sum_allowed(data_for_footer, :allowed_gross_cost)
       end
 
-      def total_gross_adjusted?
+      def show_adjusted?
         return false unless claim.granted? || claim.part_grant?
 
         total_gross_allowed != total_gross

--- a/app/presenters/nsm/check_answers/cost_summary_card.rb
+++ b/app/presenters/nsm/check_answers/cost_summary_card.rb
@@ -67,6 +67,12 @@ module Nsm
         sum_allowed(data_for_footer, :allowed_gross_cost)
       end
 
+      def total_gross_adjusted?
+        return false unless claim.granted? || claim.part_grant?
+
+        total_gross_allowed != total_gross
+      end
+
       private
 
       def data_for_footer

--- a/app/services/nsm/assessment_syncer.rb
+++ b/app/services/nsm/assessment_syncer.rb
@@ -13,7 +13,8 @@ module Nsm
 
     def call
       sync_overall_comment
-      if claim.part_grant?
+
+      if claim.part_grant? || claim.granted?
         Claim.transaction do
           sync_letter_adjustments
           sync_call_adjustments

--- a/app/views/nsm/steps/view_claim/show.html.erb
+++ b/app/views/nsm/steps/view_claim/show.html.erb
@@ -21,7 +21,7 @@
         <li class="moj-sub-navigation__item">
           <%= link_to t('.tabs.claimed_costs'), claimed_costs_work_items_nsm_steps_view_claim_path(@claim, anchor: 'claim_nav'), class: 'moj-sub-navigation__link', 'aria-current': (@section == :claimed_costs ? "page" : nil) %>
         </li>
-        <% if @claim.part_grant? %>
+        <% if @claim.total_gross_adjusted? %>
           <li class="moj-sub-navigation__item">
             <%= link_to t('.tabs.adjustments'), adjustments_work_items_nsm_steps_view_claim_path(@claim, anchor: 'claim_nav'), class: 'moj-sub-navigation__link', 'aria-current': (@section == :adjustments ? "page" : nil) %>
           </li>

--- a/app/views/nsm/steps/view_claim/show.html.erb
+++ b/app/views/nsm/steps/view_claim/show.html.erb
@@ -21,7 +21,7 @@
         <li class="moj-sub-navigation__item">
           <%= link_to t('.tabs.claimed_costs'), claimed_costs_work_items_nsm_steps_view_claim_path(@claim, anchor: 'claim_nav'), class: 'moj-sub-navigation__link', 'aria-current': (@section == :claimed_costs ? "page" : nil) %>
         </li>
-        <% if @claim.total_gross_adjusted? %>
+        <% if @claim.show_adjusted? %>
           <li class="moj-sub-navigation__item">
             <%= link_to t('.tabs.adjustments'), adjustments_work_items_nsm_steps_view_claim_path(@claim, anchor: 'claim_nav'), class: 'moj-sub-navigation__link', 'aria-current': (@section == :adjustments ? "page" : nil) %>
           </li>

--- a/spec/jobs/pull_updates_spec.rb
+++ b/spec/jobs/pull_updates_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe PullUpdates do
                                            .and_return(http_response)
   end
 
-  context 'when mocking claim' do
+  context 'with a mocked claim' do
     let(:id) { SecureRandom.uuid }
     let(:claim) do
       instance_double(Claim, id: id, state: 'submitted',
-                      save!: true, update!: true,
-                      sent_back?: false, 'assessment_comment=': nil, part_grant?: false)
+                      save!: true, update!: true, 'assessment_comment=': nil,
+                      sent_back?: false, part_grant?: false, granted?: false)
     end
 
     before do

--- a/spec/presenters/nsm/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/application_status_card_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
   describe '#row data' do
     let(:assessment_comment) { "this is a comment\n2nd line" }
 
-    context 'submitted' do
+    context 'when in submitted state' do
       let(:claim) { create(:claim, :completed_state, :firm_details, :build_associates, :updated_at, work_items_count: 1) }
 
       it 'generates submitted rows' do
-        expect(subject.row_data).to match(
+        expect(card.row_data).to match(
           [
             {
               head_key: 'application_status',
@@ -32,19 +32,23 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
       end
     end
 
-    context 'granted' do
-      let(:claim) { create(:claim, :granted_state, :firm_details, :build_associates, :updated_at, work_items_count: 1) }
+    context 'when in granted state' do
+      let(:claim) do
+        create(:claim, :granted_state, :firm_details, :build_associates, :updated_at,
+               assessment_comment: 'The claim has been fully granted.')
+      end
 
       it 'generates granted rows' do
-        expect(subject.row_data).to match(
+        expect(card.row_data).to match(
           [
             {
               head_key: 'application_status',
               text: Regexp.new('<p><strong class="govuk-tag govuk-tag--green">Granted</strong></p>' \
-                               '<p>1 December 2023</p><br><p>£(\d+\.\d\d) claimed</p><p>£\1 allowed</p>')
+                               '<p>1 December 2023</p><br><p>£[\d,\.]+ claimed</p><p>£[\d,\.]+ allowed</p>')
             },
             {
-              head_key: 'laa_response', text: '<p>The claim has been fully granted.</p>'
+              head_key: 'laa_response',
+              text: '<p>The claim has been fully granted.</p>'
             }
           ]
         )
@@ -54,12 +58,12 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
         before { claim.update(assessment_comment: "Foo\n<b>Bar</b>") }
 
         it 'shows the comment, escaped appropriately' do
-          expect(subject.row_data[1][:text]).to eq('<p>Foo</p><p>&lt;b&gt;Bar&lt;/b&gt;</p>')
+          expect(card.row_data[1][:text]).to eq('<p>Foo</p><p>&lt;b&gt;Bar&lt;/b&gt;</p>')
         end
       end
     end
 
-    context 'part granted' do
+    context 'when in part granted state' do
       let(:claim) do
         create(
           :claim,
@@ -71,7 +75,7 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
       end
 
       it 'generates part granted rows' do
-        expect(subject.row_data).to match(
+        expect(card.row_data).to match(
           [
             {
               head_key: 'application_status',
@@ -94,7 +98,7 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
         let(:claim) { create(:claim, :part_granted_state, :firm_details, :updated_at, assessment_comment:) }
 
         it 'generates no links in text' do
-          expect(subject.row_data).to match(
+          expect(card.row_data).to match(
             [
               {
                 head_key: 'application_status',
@@ -122,7 +126,7 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
         let(:claim) { create(:claim, :part_granted_state, :firm_details, :updated_at, assessment_comment:) }
 
         it 'generates no links in text' do
-          expect(subject.row_data).to match(
+          expect(card.row_data).to match(
             [
               {
                 head_key: 'application_status',
@@ -174,13 +178,13 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
       end
     end
 
-    context 'provider requested' do
+    context 'when in provider update requested state' do
       let(:claim) do
         create(:claim, :sent_back_state, :firm_details, :build_associates, :updated_at, work_items_count: 1, assessment_comment: assessment_comment)
       end
 
       it 'generates sent back rows' do
-        expect(subject.row_data).to match(
+        expect(card.row_data).to match(
           [
             {
               head_key: 'application_status',
@@ -199,13 +203,13 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
       end
     end
 
-    context 'rejected' do
+    context 'when in rejected state' do
       let(:claim) do
         create(:claim, :rejected_state, :firm_details, :build_associates, :updated_at, work_items_count: 1, assessment_comment: assessment_comment)
       end
 
       it 'generates rejected rows' do
-        expect(subject.row_data).to match(
+        expect(card.row_data).to match(
           [
             {
               head_key: 'application_status',

--- a/spec/presenters/nsm/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/application_status_card_spec.rb
@@ -33,12 +33,9 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
     end
 
     context 'when in granted state' do
-      let(:claim) do
-        create(:claim, :granted_state, :firm_details, :build_associates, :updated_at,
-               assessment_comment: 'The claim has been fully granted.')
-      end
+      let(:claim) { create(:claim, :granted_state, :firm_details, :build_associates, :updated_at, work_items_count: 1) }
 
-      it 'generates granted rows' do
+      it 'generates granted rows with fallback comment' do
         expect(card.row_data).to match(
           [
             {

--- a/spec/services/nsm/assessment_syncer_spec.rb
+++ b/spec/services/nsm/assessment_syncer_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
 
     context 'when there is an assessment comment' do
       let(:state) { 'sent_back' }
+
       let(:record) do
         {
           'application' => application.merge('assessment_comment' => 'More info needed')
@@ -84,6 +85,7 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
       end
 
       let(:state) { 'part_grant' }
+
       let(:record) do
         {
           application: {
@@ -236,6 +238,174 @@ RSpec.describe Nsm::AssessmentSyncer, :stub_oauth_token do
           allowed_total_cost_without_vat: 0,
           allowed_miles: 100,
           allowed_apply_vat: 'false'
+        )
+      end
+
+      it 'does not sync non adjusted disbursement' do
+        expect(disbursement_no_vat).to have_attributes(
+          allowed_vat_amount: nil,
+          adjustment_comment: nil,
+          allowed_total_cost_without_vat: nil,
+          allowed_miles: nil,
+          allowed_apply_vat: nil
+        )
+      end
+    end
+
+    context 'when granted with letters and calls adjusted' do
+      let(:claim) do
+        create(:claim, :complete, :letters_calls_uplift, state:)
+      end
+
+      let(:state) { 'granted' }
+
+      let(:record) do
+        {
+          application: {
+            letters_and_calls: [
+              {
+                type: {
+                  en: 'Letters',
+                    value: 'letters'
+                },
+                count: 3,
+                count_original: 2,
+                adjustment_comment: 'Increased letter count'
+              },
+              {
+                type: {
+                  en: 'Calls',
+                    value: 'calls'
+                },
+                uplift: 40,
+                uplift_original: 20,
+                adjustment_comment: 'Increased call uplift'
+              }
+            ],
+            work_items: [],
+            disbursements: []
+          }
+        }.deep_stringify_keys
+      end
+
+      it 'syncs letters adjustment fields' do
+        expect(claim.allowed_letters).to eq 3
+        expect(claim.letters).to eq 2
+        expect(claim.letters_adjustment_comment).to eq 'Increased letter count'
+      end
+
+      it 'syncs calls adjustment fields' do
+        expect(claim.allowed_calls_uplift).to eq 40
+        expect(claim.calls_uplift).to eq 20
+        expect(claim.calls_adjustment_comment).to eq 'Increased call uplift'
+      end
+    end
+
+    context 'when granted with work items adjusted' do
+      let(:state) { 'granted' }
+
+      let(:uplifted_work_item) { build(:work_item, :valid, :with_uplift) }
+      let(:work_item) { build(:work_item, :valid) }
+
+      let(:claim) do
+        create(:claim, state: state, work_items: [uplifted_work_item, work_item])
+      end
+
+      let(:record) do
+        {
+          application: {
+            letters_and_calls: letters_and_calls,
+            work_items: [
+              {
+                id: uplifted_work_item.id,
+                uplift: 20,
+                time_spent: 60,
+                uplift_original: 15,
+                adjustment_comment: 'Changed work item',
+                time_spent_original: 40,
+                work_type: { en: 'Bananas', value: 'bananas' },
+                work_type_original: { en: 'Pyjamas', value: 'pyjamas' },
+              },
+              {
+                id: work_item.id,
+                uplift: 0,
+                time_spent: 120
+              }
+            ],
+            disbursements: []
+          },
+        }.deep_stringify_keys
+      end
+
+      before do
+        uplifted_work_item.reload
+        work_item.reload
+      end
+
+      it 'syncs adjusted work item' do
+        expect(uplifted_work_item.allowed_uplift).to eq 20
+        expect(uplifted_work_item.adjustment_comment).to eq 'Changed work item'
+        expect(uplifted_work_item.allowed_time_spent).to eq 60
+        expect(uplifted_work_item.allowed_work_type).to eq 'bananas'
+      end
+
+      it 'does not sync non adjusted work item' do
+        expect(work_item.allowed_time_spent).to be_nil
+        expect(work_item.allowed_uplift).to be_nil
+        expect(work_item.adjustment_comment).to be_nil
+        expect(work_item.allowed_work_type).to be_nil
+      end
+    end
+
+    context 'when granted with disbursements adjusted' do
+      let(:state) { 'part_grant' }
+      let(:disbursement_with_vat) { build(:disbursement, :valid) }
+      let(:disbursement_no_vat) { build(:disbursement, :no_vat) }
+
+      let(:claim) do
+        create(:claim, state: state, disbursements: [disbursement_with_vat, disbursement_no_vat])
+      end
+
+      let(:record) do
+        {
+          application: {
+            letters_and_calls: letters_and_calls,
+            work_items: [],
+            disbursements: [
+              {
+                id: disbursement_with_vat.id,
+                adjustment_comment: 'Increased disbursement',
+                vat_amount: 20,
+                vat_amount_original: 10,
+                total_cost_without_vat: 150,
+                total_cost_without_vat_original: 100,
+                apply_vat: 'true',
+                apply_vat_original: 'true',
+                miles: 130,
+                miles_original: 110
+              },
+              {
+                id: disbursement_no_vat.id,
+                vat_amount: 0,
+                total_cost_without_vat: 10
+              }
+            ]
+          }
+        }.deep_stringify_keys
+      end
+
+      before do
+        disbursement_with_vat.reload
+        disbursement_no_vat.reload
+      end
+
+      it 'syncs adjusted disbursement' do
+        expect(disbursement_with_vat).to have_attributes(
+          allowed_vat_amount: 20,
+          adjustment_comment: 'Increased disbursement',
+          allowed_total_cost_without_vat: 150,
+          allowed_miles: 130,
+          allowed_apply_vat: 'true'
         )
       end
 

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -269,7 +269,12 @@ RSpec.describe 'View claim page', type: :system do
   end
 
   context 'when adjustments exist' do
-    let(:claim) { create(:claim, :firm_details, :adjusted_letters_calls, work_items:, disbursements:, assessment_comment:) }
+    let(:claim) do
+      create(:claim, :firm_details, :adjusted_letters_calls,
+             state:, work_items:, disbursements:, assessment_comment:)
+    end
+
+    let(:state) { :part_grant }
 
     let(:work_items) do
       [
@@ -291,6 +296,41 @@ RSpec.describe 'View claim page', type: :system do
         build(:disbursement, :valid_other, :with_adjustment, :dna_testing, age: 4,
               total_cost_without_vat: 150, allowed_total_cost_without_vat: 100),
       ]
+    end
+
+    it 'shows the Overview, Claimed and Adjusted tabs' do
+      visit nsm_steps_view_claim_path(claim.id)
+
+      expect(page)
+        .to have_link('Overview')
+        .and have_link('Claimed costs')
+        .and have_link('Adjusted costs')
+    end
+
+    context 'with granted claims' do
+      let(:state) { :granted }
+
+      it 'shows the Overview, Claimed and Adjusted tabs' do
+        visit nsm_steps_view_claim_path(claim.id)
+
+        expect(page)
+          .to have_link('Overview')
+          .and have_link('Claimed costs')
+          .and have_link('Adjusted costs')
+      end
+    end
+
+    context 'with rejected claims' do
+      let(:state) { :rejected }
+
+      it 'shows the Overview and Claimed tabs (only)' do
+        visit nsm_steps_view_claim_path(claim.id)
+
+        expect(page)
+          .to have_link('Overview')
+          .and have_link('Claimed costs')
+          .and have_no_link('Adjusted costs')
+      end
     end
 
     it 'shows an adjusted cost summary table with VAT' do

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -301,6 +301,12 @@ RSpec.describe 'View claim page', type: :system do
     it 'shows the Overview, Claimed and Adjusted tabs' do
       visit nsm_steps_view_claim_path(claim.id)
 
+      within('.govuk-summary-card', text: 'Claim status') do
+        expect(page)
+          .to have_content('£833.42 claimed')
+          .and have_content('£606.26 allowed')
+      end
+
       expect(page)
         .to have_link('Overview')
         .and have_link('Claimed costs')
@@ -309,6 +315,19 @@ RSpec.describe 'View claim page', type: :system do
 
     context 'with granted claims' do
       let(:state) { :granted }
+
+      it 'shows the adjusted/allowed amount' do
+        visit nsm_steps_view_claim_path(claim.id)
+
+        # NOTE: granted claims will only have increased allowed
+        # amounts going forward (see CRM457-1679) but this excercises
+        # the fact that granteds should show adjusted amounts for transpanrency.
+        within('.govuk-summary-card', text: 'Claim status') do
+          expect(page)
+            .to have_content('£833.42 claimed')
+            .and have_content('£606.26 allowed')
+        end
+      end
 
       it 'shows the Overview, Claimed and Adjusted tabs' do
         visit nsm_steps_view_claim_path(claim.id)
@@ -322,6 +341,16 @@ RSpec.describe 'View claim page', type: :system do
 
     context 'with rejected claims' do
       let(:state) { :rejected }
+
+      it 'shows the £0.00 for allowed amount' do
+        visit nsm_steps_view_claim_path(claim.id)
+
+        within('.govuk-summary-card', text: 'Claim status') do
+          expect(page)
+            .to have_content('£833.42 claimed')
+            .and have_content('£0.00 allowed')
+        end
+      end
 
       it 'shows the Overview and Claimed tabs (only)' do
         visit nsm_steps_view_claim_path(claim.id)


### PR DESCRIPTION
## Description of change
Show adjustments and allowed total for granted applications with adjustments

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1950)

Claims can be adjusted upward and still granted. In such instances the
provider needs to be made aware of the adjustments nonetheless.

## Notes for reviewer
It has been agreed with PM and designer that if granted applications are adjusted downwards (which is currently possible) we would show the adjustments regardless for transparency. Going forward CRM457-1679 is intended to prevent caseworkers granting claims with downward adjustments.

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
