### PR TITLE
CRM457-1907: Enable maintenance mode on prod

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -13,5 +13,5 @@ feature_flags:
     local: <%= ENV.fetch("MAINTENANCE_MODE", false) %>
     development: false
     uat: false
-    production: false
+    production: true
 


### PR DESCRIPTION
## Description of change
Enable maintance mode for PROD appstore DB upgrade 4/09/2024

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1907)

## Notes for reviewer
