### PR TITLE
CRM457-1964: Stop changing LAA reference on every form submission

### DIFF
--- a/app/forms/prior_authority/steps/ufn_form.rb
+++ b/app/forms/prior_authority/steps/ufn_form.rb
@@ -12,10 +12,12 @@ module PriorAuthority
 
       def extended_attributes
         attributes.merge(state: new_state,
-                         laa_reference: generate_laa_reference)
+                         laa_reference: laa_reference)
       end
 
-      def generate_laa_reference
+      def laa_reference
+        return application.laa_reference if application.laa_reference.present?
+
         loop do
           proposed_reference = "LAA-#{SecureRandom.alphanumeric(6)}"
           break proposed_reference unless PriorAuthorityApplication.exists?(laa_reference: proposed_reference)

--- a/spec/system/prior_authority/ufn_spec.rb
+++ b/spec/system/prior_authority/ufn_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe 'Prior authority applications - add Unique file number' do
       click_on 'Save and continue'
       expect(page).to have_title 'Your application progress'
     end
+
+    it 'generates an LAA reference' do
+      fill_in 'What is your unique file number (UFN)?', with: '111111/111'
+      click_on 'Save and continue'
+      expect(page).to have_content PriorAuthorityApplication.first.laa_reference
+    end
   end
 
   context 'when coming from the tasklist' do
@@ -33,6 +39,13 @@ RSpec.describe 'Prior authority applications - add Unique file number' do
       expect(page).to have_title 'Unique file number'
       click_on 'Back'
       expect(page).to have_title 'Your application progress'
+    end
+
+    it 'does not overwrite the LAA reference' do
+      application = PriorAuthorityApplication.first
+      old_reference = application.laa_reference
+      click_on 'Save and continue'
+      expect(application.reload.laa_reference).to eq old_reference
     end
   end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1964)
