### PR TITLE
CRM457-1965: Fix email address

### DIFF
--- a/app/presenters/nsm/check_answers/application_status_card.rb
+++ b/app/presenters/nsm/check_answers/application_status_card.rb
@@ -3,7 +3,6 @@
 module Nsm
   module CheckAnswers
     class ApplicationStatusCard < Base
-      EMAIL = 'CRM7fi@justice.gov.uk'
       include GovukLinkHelper
       include GovukVisuallyHiddenHelper
       include ActionView::Helpers::UrlHelper
@@ -104,11 +103,11 @@ module Nsm
       def update_claim
         return [] unless claim.sent_back?
 
-        key = 'update_further_info'
-        email = tag.a(EMAIL, href: "mailto:#{EMAIL}")
+        rfi_email = Rails.configuration.x.contact.nsm_rfi_email
+        email = tag.a(rfi_email, href: "mailto:#{rfi_email}")
         [
           tag.span(translate('update_claim'), class: 'govuk-!-font-weight-bold'),
-          translate(key).sub('%email%', email).html_safe
+          translate('update_further_info').sub('%email%', email).html_safe
         ].compact
       end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,7 @@ module Crm7restbackend
     config.x.contact.case_enquiries_tel = '0300 200 2020'
     config.x.contact.support_email = 'magsbilling@justice.gov.uk'
     config.x.contact.technical_support_email = 'CRM457@digital.justice.gov.uk'
+    config.x.contact.nsm_rfi_email = 'CRM7fi.request@justice.gov.uk'
     config.x.analytics.cookies_consent_name = 'cookies_preferences_set'
     config.x.analytics.cookies_consent_expiration = 1.year
     config.x.analytics.analytics_consent_name = 'analytics_preferences_set'

--- a/spec/presenters/nsm/check_answers/application_status_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/application_status_card_spec.rb
@@ -190,8 +190,8 @@ RSpec.describe Nsm::CheckAnswers::ApplicationStatusCard do
             {
               head_key: 'laa_response',
               text: '<p>this is a comment</p><p>2nd line</p><p><span class="govuk-!-font-weight-bold">Update your ' \
-                    'claim</span></p><p>To update your claim, email <a href="mailto:CRM7fi@justice.gov.uk">' \
-                    'CRM7fi@justice.gov.uk</a> with the LAA case reference in the subject of the email and include ' \
+                    'claim</span></p><p>To update your claim, email <a href="mailto:CRM7fi.request@justice.gov.uk">' \
+                    'CRM7fi.request@justice.gov.uk</a> with the LAA case reference in the subject of the email and include ' \
                     "any supporting information requested.\n</p>"
             }
           ]


### PR DESCRIPTION
## Description of change
NSM RFI email is [CRM7fi.request@justice.gov.uk](mailto:CRM7fi.request@justice.gov.uk) but we have it listed as [crm7fi@justice.gov.uk](mailto:crm7fi@justice.gov.uk). Also we arguably defined it in the wrong place.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1965)
