### PR TITLE
Crm457 1966 find incorrect refs

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -15,6 +15,18 @@ namespace :fixes do
     end
   end
 
+  desc "Find mismatched LAA references for sent back CRM4 applications"
+  task find_mismatched_references: :environment do
+    sent_back_submissions = PriorAuthorityApplication.where(state: "sent_back")
+    sent_back_submissions.each do |submission|
+      app_store_data = AppStoreClient.new.get(submission.id)
+      app_store_reference = app_store_data['application']['laa_reference']
+      if submission.laa_reference != app_store_reference
+        puts "Submission ID: #{submission.id} App Store Reference: #{app_store_reference} Provider Reference: #{submission.laa_reference}"
+      end
+    end
+  end
+
   desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"
   task :update_contact_email, [:id, :new_contact_email] => :environment do |_, args|
     submission = PriorAuthorityApplication.find_by(id: args[:id]) || Claim.find_by(id: args[:id])

--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -25,6 +25,9 @@ namespace :fixes do
         puts "Submission ID: #{submission.id} App Store Reference: #{app_store_reference} Provider Reference: #{submission.laa_reference}"
       end
     end
+  rescue StandardError => e
+    puts "Error fetching details"
+    puts e
   end
 
   desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -35,7 +35,9 @@ describe 'fixes:find_mismatched_references', type: :task do
   end
 
   it 'prints out the correct information' do
+    # rubocop:disable Layout/LineLength
     expected_output = "Submission ID: #{unmatched_application.id} App Store Reference: LAA-654321 Provider Reference: LAA-ABCDEF\n"
+    # rubocop:enable Layout/LineLength
     expect { Rake::Task['fixes:find_mismatched_references'].execute }.to output(expected_output).to_stdout
   end
 end

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'fixes:find_mismatched_references', type: :task do
+  let(:matching_application) { create(:prior_authority_application, state: 'sent_back', laa_reference: 'LAA-123456') }
+  let(:unmatched_application) { create(:prior_authority_application, state: 'sent_back', laa_reference: 'LAA-ABCDEF') }
+  let(:matching_version) do
+    {
+      'application' => {
+        'id' => matching_application.id,
+        'state' => 'sent_back',
+        'laa_reference' => matching_application.laa_reference
+      }
+    }
+  end
+  let(:unmatched_version) do
+    {
+      'application' => {
+        'id' => unmatched_application.id,
+        'state' =>  'sent_back',
+        'laa_reference' => 'LAA-654321'
+      }
+    }
+  end
+  let(:client) { instance_double(AppStoreClient) }
+
+  before do
+    allow(AppStoreClient).to receive(:new).and_return(client)
+    allow(client).to receive(:get).with(matching_application.id).and_return(matching_version)
+    allow(client).to receive(:get).with(unmatched_application.id).and_return(unmatched_version)
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  after do
+    Rake::Task['fixes:find_mismatched_references'].reenable
+  end
+
+  it 'prints out the correct information' do
+    expected_output = "Submission ID: #{unmatched_application.id} App Store Reference: LAA-654321 Provider Reference: LAA-ABCDEF\n"
+    expect { Rake::Task['fixes:find_mismatched_references'].execute }.to output(expected_output).to_stdout
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1966)

Finds sent_back CRM4 applications that have mismatched laa references with their current version in the App Store
