### PR TITLE
CRM457-1982: Handle situations where "old" incorrect information record has no 'sections changed'

### DIFF
--- a/app/presenters/prior_authority/check_answers/incorrect_information_card.rb
+++ b/app/presenters/prior_authority/check_answers/incorrect_information_card.rb
@@ -30,7 +30,7 @@ module PriorAuthority
       private
 
       def response
-        return nil if application.pending_incorrect_information == incorrect_information
+        return nil if incorrect_information.sections_changed.blank?
 
         {
           head_key: 'information_supplied',


### PR DESCRIPTION
## Description of change
Fix guard clause

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1982)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
