### PR TITLE
CRM457-1981: handle nil `allowed_total_cost_without_vat`

### DIFF
--- a/app/views/nsm/steps/view_claim/_allowed_disbursements.html.erb
+++ b/app/views/nsm/steps/view_claim/_allowed_disbursements.html.erb
@@ -32,7 +32,7 @@
         { header: true, text: disbursement.position, numeric: true},
         { header: true, text: link, numeric: false},
         { text: simple_format(disbursement.adjustment_comment), numeric: false},
-        { text: NumberTo.pounds(disbursement.allowed_total_cost_without_vat), numeric: true },
+        { text: NumberTo.pounds(disbursement.allowed_total_cost_pre_vat), numeric: true },
         { text: NumberTo.pounds(disbursement.allowed_vat), numeric: true },
         { text: NumberTo.pounds(disbursement.allowed_total_cost), numeric: true },
       ]


### PR DESCRIPTION
## Description of change
Handle nil  `allowed_total_cost_without_vat`

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1981)

If only VAT is changed by the caseworker this value
`allowed_total_cost_without_vat` was being sync'd
as `nil`, resulting in an empty net cost allowed
field.

## Notes for reviewer
