### PR TITLE
CRM457-1966: Find Mismatched LAA References 

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -15,19 +15,21 @@ namespace :fixes do
     end
   end
 
-  desc "Find mismatched LAA references for sent back CRM4 applications"
-  task find_mismatched_references: :environment do
-    sent_back_submissions = PriorAuthorityApplication.where(state: "sent_back")
-    sent_back_submissions.each do |submission|
-      app_store_data = AppStoreClient.new.get(submission.id)
-      app_store_reference = app_store_data['application']['laa_reference']
-      if submission.laa_reference != app_store_reference
-        puts "Submission ID: #{submission.id} App Store Reference: #{app_store_reference} Provider Reference: #{submission.laa_reference}"
+  namespace :mismatched_references do
+    desc "Find mismatched LAA references for sent back CRM4 applications"
+    task find: :environment do
+      sent_back_submissions = PriorAuthorityApplication.where(state: "sent_back")
+      sent_back_submissions.each do |submission|
+        app_store_data = AppStoreClient.new.get(submission.id)
+        app_store_reference = app_store_data['application']['laa_reference']
+        if submission.laa_reference != app_store_reference
+          puts "Submission ID: #{submission.id} App Store Reference: #{app_store_reference} Provider Reference: #{submission.laa_reference}"
+        end
       end
+    rescue StandardError => e
+      puts "Error fetching details"
+      puts e
     end
-  rescue StandardError => e
-    puts "Error fetching details"
-    puts e
   end
 
   desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"

--- a/spec/lib/tasks/find_mismatched_references_spec.rb
+++ b/spec/lib/tasks/find_mismatched_references_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'fixes:find_mismatched_references', type: :task do
+describe 'fixes:mismatched_references:find', type: :task do
   let(:matching_application) { create(:prior_authority_application, state: 'sent_back', laa_reference: 'LAA-123456') }
   let(:unmatched_application) { create(:prior_authority_application, state: 'sent_back', laa_reference: 'LAA-ABCDEF') }
   let(:matching_version) do
@@ -31,13 +31,13 @@ describe 'fixes:find_mismatched_references', type: :task do
   end
 
   after do
-    Rake::Task['fixes:find_mismatched_references'].reenable
+    Rake::Task['fixes:mismatched_references:find'].reenable
   end
 
   it 'prints out the correct information' do
     # rubocop:disable Layout/LineLength
     expected_output = "Submission ID: #{unmatched_application.id} App Store Reference: LAA-654321 Provider Reference: LAA-ABCDEF\n"
     # rubocop:enable Layout/LineLength
-    expect { Rake::Task['fixes:find_mismatched_references'].execute }.to output(expected_output).to_stdout
+    expect { Rake::Task['fixes:mismatched_references:find'].execute }.to output(expected_output).to_stdout
   end
 end


### PR DESCRIPTION
## Description of change

[Part 1: Find Mismatched Records in Provider App](https://dsdmoj.atlassian.net/browse/CRM457-1966)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
