### PR TITLE
Use ConfigMap for Maintenance Mode Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,12 @@ We have a default [k8s security context ](https://kubernetes.io/docs/reference/g
 - allowPrivilegeEscalation - AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. Currently defaults to false, this limits the level of access for bad actors/destructive processes
 - seccompProfile.type - The Secure Computing Mode (Linux kernel feature that limits syscalls that processes can run) options to use by this container. Currenly defaults to RuntimeDefault which is the [widely accepted default profile](https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile)
 - capabilities - The POSIX capabilities to add/drop when running containers. Currently defaults to drop["ALL"] which means all of these capabilities will be dropped - since this doesn't cause any issues, it's best to keep as is for security reasons until there's a need for change
+
+## Maintenance Mode
+This service has a maintenance mode which can be used to prevent users taking actions on the system.
+
+You can use the enable_maintenance_mode/disable_maintenance_mode scripts via `sh bin/enable_maintenance_mode <namespace>` or `sh bin/disable_maintenance_mode <namespace>`.
+
+If you want to change maintenance mode on a branch deployment, add the branch release name as a 2nd arg like this `sh bin/enable_maintenance_mode <namespace> <branch release name>`
+
+The helm_deploy/templates/configuration.yaml file initialises the configmap that is used to store the setting. It has a helm.sh/resource-policy of keep so that new deployments won't reset the setting. If the configmap is deleted for whatever reason, simply restart the deployment and the configmap will get regenerated with default values.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < LaaMultiStepForms::ApplicationController
   end
 
   def check_maintenance_mode
-    return unless FeatureFlags.maintenance_mode.enabled?
+    return unless ENV.fetch('MAINTENANCE_MODE', 'false') == 'true' || FeatureFlags.maintenance_mode.enabled?
 
     render file: 'public/maintenance.html', layout: false
   end

--- a/bin/disable_maintenance_mode
+++ b/bin/disable_maintenance_mode
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+NAMESPACE=$1
+
+# Default to main deployment if 2nd arg not provided
+BRANCH_RELEASE_NAME=${2:-laa-submit-crime-forms-app}
+
+echo "Creating configmap with maintenance mode disabled"
+kubectl create configmap $BRANCH_RELEASE_NAME -n $NAMESPACE --from-literal=MAINTENANCE_MODE=false --dry-run=client -o yaml | kubectl -n $NAMESPACE apply -f -
+kubectl rollout restart deployment -n $NAMESPACE $BRANCH_RELEASE_NAME

--- a/bin/enable_maintenance_mode
+++ b/bin/enable_maintenance_mode
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+NAMESPACE=$1
+
+# Default to main deployment if 2nd arg not provided
+BRANCH_RELEASE_NAME=${2:-laa-submit-crime-forms-app}
+
+echo "Creating configmap with maintenance mode enabled"
+kubectl create configmap $BRANCH_RELEASE_NAME -n $NAMESPACE --from-literal=MAINTENANCE_MODE=true --dry-run=client -o yaml | kubectl -n $NAMESPACE apply -f -
+kubectl rollout restart deployment -n $NAMESPACE $BRANCH_RELEASE_NAME

--- a/helm_deploy/templates/configuration.yaml
+++ b/helm_deploy/templates/configuration.yaml
@@ -1,0 +1,10 @@
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace (include "laa-submit-crime-forms.fullname" .)) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "laa-submit-crime-forms.fullname" . }}
+  annotations:
+    helm.sh/resource-policy: keep
+data:
+  MAINTENANCE_MODE: 'false'
+{{ end }}

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -171,6 +171,11 @@ spec:
               value: 'true'
             - name: ENABLE_PROMETHEUS_EXPORTER
               value: 'true'
+            - name: MAINTENANCE_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "laa-submit-crime-forms.fullname" . }}
+                  key: MAINTENANCE_MODE
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -207,6 +207,11 @@ spec:
               value: 'true'
             - name: ENABLE_PROMETHEUS_EXPORTER
               value: 'true'
+            - name: MAINTENANCE_MODE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "laa-submit-crime-forms.fullname" . }}
+                  key: MAINTENANCE_MODE
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1800)

- configuration.yaml adds a configmap for general settings we can change on the fly including MAINTENANCE_MODE
- MAINTENANCE_MODE configmap value use for environment variable 
- Maintenance mode feature uses environment variable OR feature flag if environment variable isn't present (note: want opinions on whether to remove feature flag completely or not)
- enable_maintenance_mode/disable_maintenance_mode scripts can be ran locally if you have kubernetes auth, 1st arg is the namespace you want to run this in, 2nd arg is an optional BRANCH_RELEASE_NAME value which defaults to laa-submit-crime-forms-app