### PR TITLE
Pin clamav version

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
           # https://github.com/ministryofjustice/hmpps-utility-container-images
         - name: clamav
-          image: ghcr.io/ministryofjustice/hmpps-clamav:latest
+          image: ghcr.io/ministryofjustice/hmpps-clamav:sha-5cd6693
           imagePullPolicy: IfNotPresent
           ports:
             - name: clamav


### PR DESCRIPTION


## Description of change
Pin clamav to older version

Latest version `sha-dfa1db2` erroring on our app

## Notes for reviewer
see https://github.com/ministryofjustice/hmpps-utility-container-images/pkgs/container/hmpps-clamav