### PR TITLE
CRM457-1583: Replace incorrect_information_explanation

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -19,7 +19,7 @@ module PriorAuthority
         end
 
         application.update!(state: new_state)
-        update_incorrect_information if application.incorrect_information_explanation.present?
+        update_incorrect_information if application.correction_needed?
         SubmitToAppStore.perform_later(submission: application)
 
         true
@@ -44,8 +44,7 @@ module PriorAuthority
       end
 
       def needs_correcting?
-        application.sent_back? &&
-          application.incorrect_information_explanation.present?
+        application.sent_back? && application.correction_needed?
       end
 
       def new_state

--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -67,8 +67,6 @@ module PriorAuthority
 
     def sync_sent_back_request
       application.update(
-        # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
-        incorrect_information_explanation: incorrect_information_explanation,
         resubmission_deadline: resubmission_deadline,
         resubmission_requested: DateTime.current
       )
@@ -79,11 +77,6 @@ module PriorAuthority
 
     def further_info_required?
       data['updates_needed'].include?('further_information')
-    end
-
-    # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
-    def incorrect_information_explanation
-      data['incorrect_information_explanation'] if info_correction_required?
     end
 
     def info_correction_required?

--- a/app/services/prior_authority/assessment_syncer.rb
+++ b/app/services/prior_authority/assessment_syncer.rb
@@ -67,6 +67,7 @@ module PriorAuthority
 
     def sync_sent_back_request
       application.update(
+        # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
         incorrect_information_explanation: incorrect_information_explanation,
         resubmission_deadline: resubmission_deadline,
         resubmission_requested: DateTime.current
@@ -80,6 +81,7 @@ module PriorAuthority
       data['updates_needed'].include?('further_information')
     end
 
+    # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
     def incorrect_information_explanation
       data['incorrect_information_explanation'] if info_correction_required?
     end

--- a/app/views/prior_authority/steps/check_answers/edit.html.erb
+++ b/app/views/prior_authority/steps/check_answers/edit.html.erb
@@ -6,17 +6,17 @@
     <%= govuk_error_summary(@form_object) %>
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
 
-    <% if @form_object.application.incorrect_information_explanation %>
+    <% if @form_object.application.correction_needed? %>
       <% if @form_object.errors.of_kind?(:base, :application_not_corrected) %>
         <div class="govuk-form-group--error">
           <p class="govuk-error-message" id="prior-authority-steps-check-answers-form-base-field-error"><%= t('.incorrect_information_heading') %></p>
-          <p class="govuk-body"><%= simple_format @form_object.application.incorrect_information_explanation %></p>
+          <p class="govuk-body"><%= simple_format @form_object.application.pending_incorrect_information.information_requested %></p>
         </div>
       <% else %>
         <div class="govuk-inset-text">
           <strong><%= t('.incorrect_information_heading') %></strong><br>
           <br>
-          <%= simple_format @form_object.application.incorrect_information_explanation %>
+          <%= simple_format @form_object.application.pending_incorrect_information.information_requested %>
         </div>
       <% end %>
     <% end %>

--- a/db/migrate/20240603125345_create_incorrect_informations.rb
+++ b/db/migrate/20240603125345_create_incorrect_informations.rb
@@ -11,6 +11,7 @@ class CreateIncorrectInformations < ActiveRecord::Migration[7.1]
     end
 
     # avoid creation of invalid data due to migration
+    # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation reference
     caseworker_ids = FurtherInformation.pluck(:caseworker_id)
     PriorAuthorityApplication.where.not(incorrect_information_explanation: nil).each do |paa|
       paa.incorrect_informations.create(

--- a/db/migrate/20240603125345_create_incorrect_informations.rb
+++ b/db/migrate/20240603125345_create_incorrect_informations.rb
@@ -9,16 +9,5 @@ class CreateIncorrectInformations < ActiveRecord::Migration[7.1]
 
       t.timestamps
     end
-
-    # avoid creation of invalid data due to migration
-    # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation reference
-    caseworker_ids = FurtherInformation.pluck(:caseworker_id)
-    PriorAuthorityApplication.where.not(incorrect_information_explanation: nil).each do |paa|
-      paa.incorrect_informations.create(
-        caseworker_id: caseworker_ids.sample,
-        information_requested: paa.incorrect_information_explanation,
-        requested_at: paa.app_store_updated_at - 60 # to ensure time is before any further info requests
-      )
-    end
   end
 end

--- a/db/migrate/20240918093306_remove_incorrect_information_explanation_from_application.rb
+++ b/db/migrate/20240918093306_remove_incorrect_information_explanation_from_application.rb
@@ -1,0 +1,5 @@
+class RemoveIncorrectInformationExplanationFromApplication < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :prior_authority_applications, :incorrect_information_explanation, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,6 +182,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_142103) do
     t.index ["prior_authority_application_id"], name: "index_incorrect_informations_on_prior_authority_application_id"
   end
 
+  # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
   create_table "prior_authority_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "provider_id"
     t.uuid "firm_office_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_22_142103) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_18_093306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -182,7 +182,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_142103) do
     t.index ["prior_authority_application_id"], name: "index_incorrect_informations_on_prior_authority_application_id"
   end
 
-  # TODO: CRM457-1583 Subsequent PR to drop column should also remove this incorrect_information_explanation
   create_table "prior_authority_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "provider_id"
     t.uuid "firm_office_id"
@@ -219,7 +218,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_22_142103) do
     t.string "custom_prison_name"
     t.datetime "app_store_updated_at"
     t.string "assessment_comment"
-    t.string "incorrect_information_explanation"
     t.datetime "resubmission_requested"
     t.datetime "resubmission_deadline"
     t.index ["firm_office_id"], name: "index_prior_authority_applications_on_firm_office_id"

--- a/lib/test_data/pa_resubmitter.rb
+++ b/lib/test_data/pa_resubmitter.rb
@@ -5,7 +5,7 @@ module TestData
 
       PriorAuthorityApplication.sent_back.order('RANDOM()').limit(percentage * total / 100).find_each do |application|
         add_further_information(application) if application.further_information_needed?
-        make_changes(application) if application.incorrect_information_explanation.present?
+        make_changes(application) if application.correction_needed?
         update(application)
       end
     end

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -117,8 +117,6 @@ FactoryBot.define do
       no_alternative_quote_reason { 'a reason' }
       service_type { 'pathologist_report' }
       custom_service_name { nil }
-      further_informations { [build(:further_information, :with_response, :with_supporting_documents)] }
-      incorrect_informations { [build(:incorrect_information, :with_edits)] }
       after(:build) do |paa|
         build(:quote, :primary, prior_authority_application_id: paa.id)
         build(:quote, :alternative, document: nil, prior_authority_application_id: paa.id)
@@ -158,6 +156,12 @@ FactoryBot.define do
     trait :with_further_information_supplied do
       after(:create) do |paa|
         create(:further_information, :with_response, :with_supporting_documents, prior_authority_application_id: paa.id)
+      end
+    end
+
+    trait :with_corrections do
+      after(:create) do |paa|
+        create(:incorrect_information, :with_edits, prior_authority_application_id: paa.id)
       end
     end
 

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -132,10 +132,19 @@ FactoryBot.define do
 
     trait :sent_back_for_incorrect_info do
       state { 'sent_back' }
-      incorrect_information_explanation { 'Please correct the following information...' }
       resubmission_deadline { 14.days.from_now }
       resubmission_requested { DateTime.current }
       app_store_updated_at { DateTime.current }
+
+      transient do
+        information_requested { 'Please update the case details' }
+      end
+
+      after(:create) do |paa, evaluator|
+        create(:incorrect_information,
+               prior_authority_application_id: paa.id,
+               information_requested: evaluator.information_requested)
+      end
     end
 
     trait :with_further_information_request do

--- a/spec/services/prior_authority/assessment_syncer_spec.rb
+++ b/spec/services/prior_authority/assessment_syncer_spec.rb
@@ -135,8 +135,7 @@ RSpec.describe PriorAuthority::AssessmentSyncer, :stub_oauth_token do
 
       context 'with further info and incorrect info' do
         it 'syncs the incorrect info' do
-          expect(application.incorrect_information_explanation).to eq 'This is incorrect'
-          expect(application.incorrect_informations.exists?).to be true
+          expect(application.incorrect_informations.first.information_requested).to eq 'This is incorrect'
         end
 
         it 'syncs dates' do
@@ -162,7 +161,6 @@ RSpec.describe PriorAuthority::AssessmentSyncer, :stub_oauth_token do
         end
 
         it 'nullifies the incorrect info' do
-          expect(application.incorrect_information_explanation).to be_nil
           expect(application.incorrect_informations.exists?).to be false
         end
 
@@ -176,13 +174,20 @@ RSpec.describe PriorAuthority::AssessmentSyncer, :stub_oauth_token do
           {
             application: {
               incorrect_information_explanation: 'This is incorrect',
+              incorrect_information: [
+                {
+                  caseworker_id: 'case-worker-uuid',
+                  information_requested: 'This is incorrect',
+                  requested_at: DateTime.current
+                }
+              ],
               updates_needed: ['incorrect_information']
             }
           }.deep_stringify_keys
         end
 
         it 'syncs the incorrect info' do
-          expect(application.incorrect_information_explanation).to eq 'This is incorrect'
+          expect(application.incorrect_informations.first.information_requested).to eq 'This is incorrect'
         end
       end
     end

--- a/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority_payload_builder_spec.rb
@@ -176,7 +176,9 @@ RSpec.describe SubmitToAppStore::PriorAuthorityPayloadBuilder do
     }
   end
   let(:provider) { create(:provider) }
-  let(:application) { create(:prior_authority_application, :full, state: :submitted) }
+  let(:application) do
+    create(:prior_authority_application, :full, :with_further_information_supplied, :with_corrections, state: :submitted)
+  end
   let(:fixed_arbitrary_date) { DateTime.new(2024, 1, 15, 0, 0, 0) }
 
   before do

--- a/spec/system/prior_authority/check_your_answers/sent_back_for_correct_info_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/sent_back_for_correct_info_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe 'Prior authority applications, sent back for info correction - ch
     allow(SubmitToAppStore).to receive(:perform_later)
   end
 
-  let(:application) { create(:prior_authority_application, :full, :sent_back_for_incorrect_info) }
+  let(:application) do
+    create(:prior_authority_application, :full,
+           :sent_back_for_incorrect_info,
+           information_requested: 'Please correct the following information...')
+  end
 
   context 'Application has not been updated' do
     before do

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'View applications' do
       let(:application) do
         create(:prior_authority_application,
                :full,
+               :with_further_information_supplied,
                :with_alternative_quotes,
                state: 'rejected',
                app_store_updated_at: 1.day.ago,


### PR DESCRIPTION
## Description of change
Replace use of incorrect_information_explanation with incorrect_informations.information_requested

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1583)

Should be using the latest has_many relation incorrect_informations record value instead.

## TODO

- [X] replace use of incorrect_information_explanation with incorrect_informations.information_requested
- [X] drop the column `incorrect_information_explanation`