### PR TITLE
log auth_hash info when checking provider is enrolled

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -37,6 +37,7 @@ module Providers
     end
 
     def check_provider_is_enrolled
+      Rails.logger.info auth_hash if ENV.fetch('ENV', false) == 'uat'
       return if gatekeeper.provider_enrolled?
 
       Rails.logger.warn "Not enrolled provider access attempt, UID: #{auth_hash.uid}, " \

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -37,7 +37,9 @@ module Providers
     end
 
     def check_provider_is_enrolled
+      # :nocov:
       Rails.logger.info auth_hash if ENV.fetch('ENV', false) == 'uat'
+      # :nocov:
       return if gatekeeper.provider_enrolled?
 
       Rails.logger.warn "Not enrolled provider access attempt, UID: #{auth_hash.uid}, " \


### PR DESCRIPTION
## Description of change

This will be reverted after we do the check 
Only will apply to UAT so we don't put PII in logs