### PR TITLE
SPIKE: CRM457-1920: PII enforcement

### DIFF
--- a/config/pii.yml
+++ b/config/pii.yml
@@ -1,0 +1,13 @@
+# For each database table, and each column in that table, flag whether
+# there is PII in the column:
+firm_offices:
+  name: true
+  address_line_1: true
+  address_line_2: true
+  town: false
+  postcode: true
+  previous_id: false
+  vat_registered: false
+providers:
+  email: true
+  auth_provider: false

--- a/config/schemas/crm4.json
+++ b/config/schemas/crm4.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://submit-crime-forms.service.justice.gov.uk/crm4.json",
+  "title": "Prior Authority Application",
+  "description": "An application for prior authority to incur disbursements, previously CRM4",
+  "type": "object",
+  "properties": {
+    "application_id": {
+      "description": "The ID of the application",
+      "type": "string",
+      "x-pii": false
+    },
+    "application_state": {
+      "description": "The state of the application. Must initially be 'submitted'",
+      "type": "string",
+      "x-pii": false
+    },
+    "application": {
+      "type": "object",
+      "properties": {
+        "laa_reference": {
+          "type": "string",
+          "x-pii": false
+        },
+        "firm_office": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "x-pii": true
+            },
+            "account_number": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [ "laa_reference", "firm_office" ]
+    }
+  },
+  "required": [ "application_id", "application_state", "application" ]
+}

--- a/spec/pii_spec.rb
+++ b/spec/pii_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'PII' do
+  let(:ignored_tables) { %w[schema_migrations ar_internal_metadata] }
+  let(:ignored_columns) { %w[created_at id updated_at] }
+  let(:pii_definitions) { YAML.load_file(Rails.root.join('config/pii.yml')) }
+
+  it 'explicitly marks *every* database column as either PII or not' do
+    ActiveRecord::Base.connection.tables.each do |table_name|
+      next if ignored_tables.include?(table_name)
+
+      (ActiveRecord::Base.connection.columns(table_name).map(&:name) - ignored_columns).each do |column_name|
+        expect(pii_definitions.dig(table_name, column_name)).not_to(
+          be_nil,
+          "Table column #{table_name}.#{column_name} has not been listed in config/pii.yml"
+        )
+      end
+    end
+  end
+end

--- a/spec/pii_spec.rb
+++ b/spec/pii_spec.rb
@@ -1,20 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe 'PII' do
-  let(:ignored_tables) { %w[schema_migrations ar_internal_metadata] }
-  let(:ignored_columns) { %w[created_at id updated_at] }
-  let(:pii_definitions) { YAML.load_file(Rails.root.join('config/pii.yml')) }
+  describe 'pii.yml' do
+    let(:ignored_tables) { %w[schema_migrations ar_internal_metadata] }
+    let(:ignored_columns) { %w[created_at id updated_at] }
+    let(:pii_definitions) { YAML.load_file(Rails.root.join('config/pii.yml')) }
 
-  it 'explicitly marks *every* database column as either PII or not' do
-    ActiveRecord::Base.connection.tables.each do |table_name|
-      next if ignored_tables.include?(table_name)
+    it 'explicitly marks every database column as either PII or not' do
+      ActiveRecord::Base.connection.tables.each do |table_name|
+        next if ignored_tables.include?(table_name)
 
-      (ActiveRecord::Base.connection.columns(table_name).map(&:name) - ignored_columns).each do |column_name|
-        expect(pii_definitions.dig(table_name, column_name)).not_to(
-          be_nil,
-          "Table column #{table_name}.#{column_name} has not been listed in config/pii.yml"
-        )
+        (ActiveRecord::Base.connection.columns(table_name).map(&:name) - ignored_columns).each do |column_name|
+          expect(pii_definitions.dig(table_name, column_name)).not_to(
+            be_nil,
+            "Table column #{table_name}.#{column_name} has not been listed in config/pii.yml"
+          )
+        end
       end
+    end
+  end
+
+  describe 'PAA schema' do
+    let(:schema_file) { JSON.load_file(Rails.root.join('config/schemas/crm4.json')) }
+
+    it 'explicitly marks every property as PII or not' do
+      checker = lambda do |properties, parent_attributes|
+        properties.each do |name, attributes|
+          if attributes['type'] == 'object'
+            checker.call(attributes['properties'], parent_attributes + [name])
+          else
+            expect(attributes['x-pii']).not_to(
+              be_nil,
+              "#{parent_attributes.join('->')}->#{name} does not have a PII definition"
+            )
+          end
+        end
+      end
+
+      checker.call(schema_file['properties'], [])
     end
   end
 end


### PR DESCRIPTION
## Description of change
2 proof-of-concept specs to enforce keeping PII definitions up-to-date. 

One assumes a PII yaml file has been created which explicitly marks certain DB columns as containing PII. To ensure this yaml file is maintained when new columns are added, this spec will fail unless every DB column has been marked as either PII or not.

The other spec assumes the repo contains a JSON Schema file which will be used to validate every payload that is generated or stored. It parses the file and checks to make sure that for every property (including nested object properties), a custom PII boolean annotation has been set.

These will ensure that adding new stuff to the database or payload will break the test suite unless those changes also include updating the PII definitions to match.
