### PR TITLE
CRM457-1988 (BUG): Fix expired claim logic

### DIFF
--- a/app/presenters/nsm/check_answers/application_status_card.rb
+++ b/app/presenters/nsm/check_answers/application_status_card.rb
@@ -138,9 +138,8 @@ module Nsm
 
       def expiry_response
         I18n.t('nsm.steps.view_claim.expiry_explanations',
-               requested: claim.pending_further_information.requested_at.to_fs(:stamp),
-               deadline:
-                 tag.strong(resubmission_deadline_text)).map(&:html_safe)
+               requested: claim.further_informations.maximum(:requested_at).to_fs(:stamp),
+               deadline: tag.strong(resubmission_deadline_text)).map(&:html_safe)
       end
 
       def further_information_response


### PR DESCRIPTION
## Description of change
When a claim has expired, the most recent `further_information` stops being "pending", so we can't access it with `.pending_further_information`.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1988)
