### PR TITLE
CRM457-2122: Improve autocomplete effectiveness

### DIFF
--- a/app/controllers/prior_authority/steps/primary_quote_controller.rb
+++ b/app/controllers/prior_authority/steps/primary_quote_controller.rb
@@ -2,15 +2,8 @@ module PriorAuthority
   module Steps
     class PrimaryQuoteController < BaseController
       def edit
-        counts = PriorAuthorityApplication
-                 .where.not(service_type: [nil, ''])
-                 .group(:service_type)
-                 .count
-        values = PriorAuthority::QuoteServices.values.map do |service|
-          [service.translated, counts.fetch(service.value.to_s, 0)]
-        end
+        @services = count_services
 
-        @values = values.sort_by { |_, count| -count }.to_h
         @form_object = PrimaryQuoteForm.build(
           record,
           application: current_application
@@ -33,6 +26,19 @@ module PriorAuthority
 
       def additional_permitted_params
         %i[service_type_autocomplete service_type_autocomplete_suggestion file_upload]
+      end
+
+      def count_services
+        counts = PriorAuthorityApplication
+                 .where.not(service_type: [nil, ''])
+                 .group(:service_type)
+                 .count
+
+        values = PriorAuthority::QuoteServices.values.map do |service|
+          [service.translated, counts.fetch(service.value.to_s, 0)]
+        end
+
+        values.sort_by { |_, count| -count }.to_h
       end
     end
   end

--- a/app/controllers/prior_authority/steps/primary_quote_controller.rb
+++ b/app/controllers/prior_authority/steps/primary_quote_controller.rb
@@ -2,6 +2,15 @@ module PriorAuthority
   module Steps
     class PrimaryQuoteController < BaseController
       def edit
+        counts = PriorAuthorityApplication
+                 .where.not(service_type: [nil, ''])
+                 .group(:service_type)
+                 .count
+        values = PriorAuthority::QuoteServices.values.map do |service|
+          [service.translated, counts.fetch(service.value.to_s, 0)]
+        end
+
+        @values = values.sort_by { |_, count| -count }.to_h
         @form_object = PrimaryQuoteForm.build(
           record,
           application: current_application

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,59 +1,37 @@
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
-import { initAll } from 'govuk-frontend'
-import accessibleAutocomplete from 'accessible-autocomplete'
-import './handle-forms'
-import './date-picker'
-import '@hotwired/turbo-rails'
-import $ from 'jquery'
-import { checkAndHandleResizeOnScrollablePane } from './scrollable_pane'
+import { initAll } from "govuk-frontend";
+import "./handle-forms";
+import "./date-picker";
+import "@hotwired/turbo-rails";
+import $ from "jquery";
+import { checkAndHandleResizeOnScrollablePane } from "./scrollable_pane";
+import { convertSelectToAutocomplete } from "./autocomplete.js";
 
-initAll()
+initAll();
 
-Turbo.setFormMode('optin')
-Turbo.session.drive = false
+// Most of this Turbo setup code is needed for the multi-form gem
+Turbo.setFormMode("optin");
+Turbo.session.drive = false;
 
-const $inputs = document.querySelectorAll('[data-module="govuk-input"]')
-if ($inputs) {
-  for (let i = 0; i < $inputs.length; i++) {
-    new Input($inputs[i]).init()
-  }
-}
+[...document.querySelectorAll('[data-module="govuk-input"]')].forEach((input) =>
+  new Input(input).init(),
+);
 
 // Avoid flickering header menu on small screens
 // Refer to `stylesheets/local/custom.scss`
-const $headerNavigation = document.querySelector('ul.app-header-menu-hidden-on-load')
-if ($headerNavigation) {
-  $headerNavigation.classList.remove("app-header-menu-hidden-on-load")
-}
+[...document.querySelectorAll("ul.app-header-menu-hidden-on-load")].forEach(
+  (header) => header.classList.remove("app-header-menu-hidden-on-load"),
+);
 
-convertSelectToAutocomplete()
+convertSelectToAutocomplete();
 
-// Most of this Turbo setup code is needed for the multi-form gem
-$(document).on('turbo:render', function () {
-  initAll()
-  convertSelectToAutocomplete()
-})
+document.addEventListener(
+  "DOMContentLoaded",
+  checkAndHandleResizeOnScrollablePane,
+);
+window.addEventListener("resize", checkAndHandleResizeOnScrollablePane);
 
-function convertSelectToAutocomplete(){
-  //enhance all tagged select elements to be accessible-autocomplete elements
-  const $acElements = document.querySelectorAll('[data-module="accessible-autocomplete"]')
-  if ($acElements) {
-    for (let i = 0; i < $acElements.length; i++) {
-      var convertedToAutocomplete = $acElements[i].getAttribute('data-converted')
-      if(!convertedToAutocomplete){
-        const name = $acElements[i].getAttribute('data-name')
-        accessibleAutocomplete.enhanceSelectElement({
-          selectElement: $acElements[i],
-          defaultValue: '',
-          showNoOptionsFound: name === null,
-          name: name,
-          autoselect: $acElements[i].getAttribute('data-autoselect') === "true"
-        })
-        $acElements[i].setAttribute('data-converted', true)
-      }
-    }
-  }
-}
-
-document.addEventListener('DOMContentLoaded', checkAndHandleResizeOnScrollablePane);
-window.addEventListener('resize', checkAndHandleResizeOnScrollablePane);
+$(document).on("turbo:render", function () {
+  initAll();
+  convertSelectToAutocomplete();
+});

--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -4,16 +4,18 @@ import accessibleAutocomplete from "accessible-autocomplete";
 // Convert select fields to use accessible-autocomplete instead.
 //
 // Also includes functions to support requirements to make the autocompletion more fuzzy
-const stopWords = ["a", "the", "of", "in", "and", "at", "&"];
+const stopWords = ["a", "an", "the", "of", "in", "and", "at", "&"];
 
 const removePunctuation = (str) => str.replace(/[^\w\s]/g, "");
 
-const sanitizeInput = (str) =>
-  removePunctuation(str)
-    .trim()
-    .toLowerCase()
-    .split(/\s+/)
-    .filter((token) => !stopWords.includes(token));
+function sanitizeInput(str) {
+  const words = removePunctuation(str).trim().toLowerCase().split(/\s+/);
+  if (words.length === 1) {
+    return words;
+  }
+
+  return words.filter((token) => !stopWords.includes(token));
+}
 
 const fuzzyMatch = (option, query) =>
   query.some((word) => option.some((w) => w.includes(word)));

--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -28,6 +28,7 @@ export function convertSelectToAutocomplete() {
   ].forEach((element) => {
     const name = element.dataset.name;
     const values = element.dataset.values;
+    const useCustom = element.dataset.custom === "true";
 
     let counts = null;
     if (values) {
@@ -39,7 +40,7 @@ export function convertSelectToAutocomplete() {
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: element,
       defaultValue: "",
-      showNoOptionsFound: name === null,
+      showNoOptionsFound: name === null && !useCustom,
       name: name,
       autoselect: element.dataset.autoselect === "true",
       source: (query, populateResults) => {
@@ -63,7 +64,13 @@ export function convertSelectToAutocomplete() {
           return distA - distB;
         });
 
-        populateResults(sorted.map((opt) => opt.text));
+        const results = sorted.map((opt) => opt.text);
+
+        if (useCustom) {
+          populateResults([...results, query]);
+        } else {
+          populateResults(results);
+        }
       },
     });
     element.dataset.converted = true;

--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -1,0 +1,68 @@
+import { distance } from "fastest-levenshtein";
+import accessibleAutocomplete from "accessible-autocomplete";
+
+// Convert select fields to use accessible-autocomplete instead.
+//
+// Also includes functions to support requirements to make the autocompletion more fuzzy
+const stopWords = ["a", "the", "of", "in", "and", "at", "&"];
+
+// Maximum amount of partial matches that should count as found
+const MAX_MATCHES = 1;
+
+const matchCompose =
+  (...matchers) =>
+  (option, queryWords) => {
+    return matchers.some((matcher) => matcher(option, queryWords));
+  };
+
+const removePunctuation = (str) => str.replace(/[^\w\s]/g, "");
+
+const sanitizeInput = (str) =>
+  removePunctuation(str)
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => !stopWords.includes(token));
+
+const exactMatch = (option, query) =>
+  query.every((word) => option.some((w) => w.includes(word)));
+
+const partialMatch = (option, query) =>
+  query.filter((word) => option.some((w) => w.includes(word))) >= MAX_MATCHES;
+
+const matcher = matchCompose(exactMatch, partialMatch);
+
+export function convertSelectToAutocomplete() {
+  const $acElements = document.querySelectorAll(
+    '[data-module="accessible-autocomplete"]:not([data-converted="true"])',
+  );
+  if ($acElements) {
+    for (let i = 0; i < $acElements.length; i++) {
+      const element = $acElements[i];
+      const name = element.getAttribute("data-name");
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: element,
+        defaultValue: "",
+        showNoOptionsFound: name === null,
+        name: name,
+        source: (query, populateResults) => {
+          const trimmed = sanitizeInput(query);
+          const filtered = [...element.options].filter((opt) =>
+            matcher(sanitizeInput(opt.text), trimmed),
+          );
+
+          const sorted = filtered.sort((a, b) => {
+            const distA = distance(query.toLowerCase(), a.text.toLowerCase());
+            const distB = distance(query.toLowerCase(), b.text.toLowerCase());
+
+            return distA - distB;
+          });
+
+          populateResults(sorted.map((opt) => opt.text));
+        },
+        autoselect: $acElements[i].getAttribute("data-autoselect") === "true",
+      });
+      $acElements[i].setAttribute("data-converted", true);
+    }
+  }
+}

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { autoselect: true, values: @values.to_json } %>
+                              data: { autoselect: true, values: @services.to_json } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { autoselect: true, values: @services.to_json } %>
+                              data: { custom: true, autoselect: true, values: @services.to_json } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { autoselect: true } %>
+                              data: { autoselect: true, values: @values.to_json } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { autoselect: false } %>
+                              data: { autoselect: true } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { custom: true, autoselect: true, values: @services.to_json } %>
+                              data: { custom: false, autoselect: false, values: @services.to_json } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "braces": "^3.0.3",
     "esbuild": "^0.24.0",
     "govuk-frontend": "5.7.1",
+    "fastest-levenshtein": "^1.0.16",
     "jquery": "^3.7.1",
     "puppeteer": "^22.15.0",
     "sass": "^1.80.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2358,6 +2358,11 @@ fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fastest-levenshtein@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
+
 fb-watchman@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz"


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2122)

This PR aims to improve the autocomplete in a number of ways:

### Ignore spaces
Sometimes users put a space at the start or the end by mistake, as such leading and trailing spaces should be trimmed.

### Ignore case
Case here is only useful to display grammatically correct strings to the user. A&E and a&e are identical so should be treated as such

### Ignoring stop words
The way this is handled should probably change, the hardcoded list is somewhat inflexible _but_ I also don't imagine the list will be changed much once it's committed.

### Fuzzy matching
Candidates should also be matched regardless of word order and regardless of if all the words are present. The following cases are now considered

- User types "Child Psychologist" and both that and "Psychiatrist (including child)" are returned
- User types "Forensic Firearm" and both "Forensic scientist" and "firearm expert" are returned
- User types "Consultant Forensic psychiatrist" and "Forensic psychiatrist" is returned

### `autoselect: true`
This will prevent users from saving custom entries when they instead mean to just select the first entry when pressing `Return`.

### Sorting by frequency
Matches will first attempt to sort by how often they occur if the autocomplete component has the data passed as `data-values`.

### String distance
Matches will be sorted by how "distant" they are from the query using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) after attempting to sort by frequency. This won't always be correct, but close matches should be right near the top.

### Ignore punctuation
Candidates that have ampersands and quotes should match even without the user putting them in