### PR TITLE
CRM457-2101: Move clam to separate deployment/pods

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -23,7 +23,7 @@ deploy_branch() {
                 --set ingress.tls[0].host="$RELEASE_HOST" \
                 --set nameOverride="$BRANCH_RELEASE_NAME"\
                 --set fullnameOverride="$BRANCH_RELEASE_NAME"\
-                --set customErrorService.enabled=false
+                --set branch=true
 
 }
 

--- a/config/clamd/clamd.cloud-platform.conf
+++ b/config/clamd/clamd.cloud-platform.conf
@@ -1,0 +1,2 @@
+TCPAddr clamav-service
+TCPSocket 3310

--- a/config/clamd/clamd.dev.conf
+++ b/config/clamd/clamd.dev.conf
@@ -1,2 +1,0 @@
-TCPAddr clamav
-TCPSocket 3310

--- a/config/clamd/clamd.prod.conf
+++ b/config/clamd/clamd.prod.conf
@@ -1,2 +1,0 @@
-TCPAddr clamav
-TCPSocket 3310

--- a/config/clamd/clamd.uat.conf
+++ b/config/clamd/clamd.uat.conf
@@ -1,2 +1,0 @@
-TCPAddr clamav
-TCPSocket 3310

--- a/helm_deploy/templates/custom-error-pages.yaml
+++ b/helm_deploy/templates/custom-error-pages.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.customErrorService.enabled }}
+{{ if not .Values.branch }}
 # Custom error page configMap
 ---
 apiVersion: v1

--- a/helm_deploy/templates/deployment-clamav.yaml
+++ b/helm_deploy/templates/deployment-clamav.yaml
@@ -1,0 +1,67 @@
+{{ if not .Values.branch }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clamav
+spec:
+  replicas: {{ .Values.replicaCount.clamav }}
+  revisionHistoryLimit: 2
+  minReadySeconds: 15
+  serviceName: clamav
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+  selector:
+    matchLabels:
+      app: submit-crime-forms-clamav
+  template:
+    metadata:
+      labels:
+        app: submit-crime-forms-clamav
+        tier: backend
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: clamav
+        image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed:latest
+        imagePullPolicy: Always
+        command: ['/bin/sh', '-c', 'freshclam && clamd && touch startup.txt && clamdscan startup.txt']
+        securityContext:
+          {{- include "laa-submit-crime-forms.defaultSecurityContext" . | nindent 12 }}
+        ports:
+          - containerPort: 3310
+            protocol: TCP
+        volumeMounts:
+          - mountPath: /var/lib/clamav
+            name: clamav-signatures
+        resources:
+          requests:
+            cpu: 25m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 3Gi
+        readinessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 60
+          periodSeconds: 60
+        livenessProbe:
+          tcpSocket:
+            port: 3310
+          initialDelaySeconds: 60
+          periodSeconds: 60
+  volumeClaimTemplates:
+  - metadata:
+      name: clamav-signatures
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+{{ end }}

--- a/helm_deploy/templates/deployment-custom-errors.yaml
+++ b/helm_deploy/templates/deployment-custom-errors.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.customErrorService.enabled }}
+{{ if not .Values.branch }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -185,6 +185,8 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: provider_api_key
+            - name: CLAMD_CONF_FILENAME
+              value: clamd.cloud-platform.conf
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -32,18 +32,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-          # https://github.com/ministryofjustice/hmpps-utility-container-images
-        - name: clamav
-          image: ghcr.io/ministryofjustice/hmpps-clamav:sha-5cd6693
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: clamav
-              containerPort: 3310
-              protocol: TCP
-          resources:
-            {{- toYaml .Values.clamav_resources | nindent 12 }}
-          securityContext:
-            {{- include "laa-submit-crime-forms.defaultSecurityContext" . | nindent 12 }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- include "laa-submit-crime-forms.defaultSecurityContext" . | nindent 12 }}
@@ -221,6 +209,8 @@ spec:
                 secretKeyRef:
                   name: app-secrets
                   key: provider_api_key
+            - name: CLAMD_CONF_FILENAME
+              value: clamd.cloud-platform.conf
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/service.yaml
+++ b/helm_deploy/templates/service.yaml
@@ -31,7 +31,7 @@ spec:
       name: metrics
   selector:
     metrics-target: {{ include "laa-submit-crime-forms.fullname" . }}-metrics-target
-{{ if .Values.customErrorService.enabled }}
+{{ if not .Values.branch }}
 ---
 apiVersion: v1
 kind: Service
@@ -48,4 +48,18 @@ spec:
   - port: 80
     targetPort: 8080
     name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clamav-service
+  labels:
+    app: submit-crime-forms-clamav
+spec:
+  ports:
+  - port: 3310
+    name: clamav
+    targetPort: 3310
+  selector:
+    app: submit-crime-forms-clamav
 {{ end }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,11 +5,11 @@
 replicaCount:
   app: 1
   worker: 1
+  clamav: 1
 
 namespace: laa-submit-crime-forms-dev
 
-customErrorService:
-  enabled: true
+branch: false
 
 image:
   repository: nginx

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,11 +5,11 @@
 replicaCount:
   app: 4
   worker: 2
+  clamav: 2
 
 namespace: laa-submit-crime-forms-prod
 
-customErrorService:
-  enabled: true
+branch: false
 
 image:
   repository: nginx

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -5,11 +5,11 @@
 replicaCount:
   app: 4
   worker: 2
+  clamav: 2
 
 namespace: laa-submit-crime-forms-uat
 
-customErrorService:
-  enabled: true
+branch: false
 
 image:
   repository: nginx


### PR DESCRIPTION
## Description of change
- Instead of having clamav in a container on every app pod, have it running as its own pod in its own deployment accessed via its own service
- This allows clamav to have its own liveness probe, and not have to be restarted every time new app pods are rolled out
- Switch to using the latest image
- Only have one clam service on dev, not one per branch, reusing the same mechanism employed for the custom error service
[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2101)

## Note to reviewer
When this is merged, dev main will be responsible for the dev clam service, and branches will simply use the service. However, for the purposes of this getting clamby working for this PR we need the branch to run the service. Hence in the second commit I've hacked the config to have the branch deploy the service, and added 3 'TODO' statements to revert it on merge to giving responsibility to main.
