### PR TITLE
CRM457-2064: Get office codes from provider data API

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -3,10 +3,10 @@ module Providers
     skip_before_action :verify_authenticity_token
 
     def saml
-      active_office_codes = ActiveOfficeCodeService.call(auth_hash.info.office_codes)
+      active_office_codes = ActiveOfficeCodeService.call(office_codes)
 
       if active_office_codes.any?
-        provider = Provider.from_omniauth(auth_hash)
+        provider = Provider.from_omniauth(auth_data, office_codes)
 
         sign_in_and_redirect(
           provider, event: :authentication
@@ -30,8 +30,16 @@ module Providers
       new_provider_session_path
     end
 
-    def auth_hash
+    def auth_data
       request.env['omniauth.auth']
+    end
+
+    def office_codes
+      if FeatureFlags.omniauth_test_mode.enabled?
+        auth_data.info.office_codes
+      else
+        @office_codes ||= OfficeCodeService.call(auth_data.info.email)
+      end
     end
   end
 end

--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -38,7 +38,7 @@ module Providers
       if FeatureFlags.omniauth_test_mode.enabled?
         auth_data.info.office_codes
       else
-        @office_codes ||= OfficeCodeService.call(auth_data.info.email)
+        @office_codes ||= OfficeCodeService.call(auth_data.uid)
       end
     end
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,13 +18,13 @@ class Provider < ApplicationRecord
   has_many :prior_authority_applications, dependent: :destroy
 
   class << self
-    def from_omniauth(auth)
+    def from_omniauth(auth, office_codes)
       find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|
         record.update(
           email: auth.info.email,
           description: auth.info.description,
           roles: auth.info.roles,
-          office_codes: auth.info.office_codes,
+          office_codes: office_codes,
         )
       end
     end

--- a/app/services/active_office_code_service.rb
+++ b/app/services/active_office_code_service.rb
@@ -12,25 +12,7 @@ class ActiveOfficeCodeService
     end
 
     def contract_active?(office_code)
-      response = HTTParty.get("#{base_url}/provider-office/#{office_code}/office-contract-details",
-                              headers: { 'X-Authorization': api_key })
-
-      case response.code
-      when 200
-        true
-      when 204
-        false
-      else
-        raise "Unexpected status code #{response.code} when checking office code #{office_code}"
-      end
-    end
-
-    def base_url
-      ENV.fetch('PROVIDER_API_HOST')
-    end
-
-    def api_key
-      ENV.fetch('PROVIDER_API_KEY')
+      ProviderDataApiClient.contract_active?(office_code)
     end
 
     def always_inactive_office_codes

--- a/app/services/office_code_service.rb
+++ b/app/services/office_code_service.rb
@@ -1,0 +1,9 @@
+class OfficeCodeService
+  class << self
+    def call(email)
+      user_details = ProviderDataApiClient.user_details(email)
+      office_details = ProviderDataApiClient.user_office_details(user_details['userLogin'])
+      office_details.pluck('firmOfficeCode')
+    end
+  end
+end

--- a/app/services/office_code_service.rb
+++ b/app/services/office_code_service.rb
@@ -1,8 +1,7 @@
 class OfficeCodeService
   class << self
-    def call(email)
-      user_details = ProviderDataApiClient.user_details(email)
-      office_details = ProviderDataApiClient.user_office_details(user_details['userLogin'])
+    def call(username)
+      office_details = ProviderDataApiClient.user_office_details(username)
       office_details.pluck('firmOfficeCode')
     end
   end

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -1,0 +1,53 @@
+class ProviderDataApiClient
+  class << self
+    def contract_active?(office_code)
+      response = HTTParty.get("#{base_url}/provider-office/#{office_code}/office-contract-details",
+                              headers: { 'X-Authorization': api_key })
+
+      case response.code
+      when 200
+        true
+      when 204
+        false
+      else
+        raise "Unexpected status code #{response.code} when checking office code #{office_code}"
+      end
+    end
+
+    def user_details(email)
+      response = HTTParty.get("#{base_url}/provider-users/exists?userEmail=#{email}",
+                              headers: { 'X-Authorization': api_key })
+
+      case response.code
+      when 200
+        response.parsed_response['user']
+      else
+        raise "Unexpected status code #{response.code} when checking for user with email #{email}"
+      end
+    end
+
+    def user_office_details(user_login)
+      response = HTTParty.get("#{base_url}/provider-users/#{user_login}/provider-offices",
+                              headers: { 'X-Authorization': api_key })
+
+      case response.code
+      when 200
+        response.parsed_response['officeCodes']
+      when 204
+        []
+      else
+        raise "Unexpected status code #{response.code} when checking for office codes for user #{user_login}"
+      end
+    end
+
+    private
+
+    def base_url
+      ENV.fetch('PROVIDER_API_HOST')
+    end
+
+    def api_key
+      ENV.fetch('PROVIDER_API_KEY')
+    end
+  end
+end

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -17,7 +17,7 @@ class ProviderDataApiClient
 
     def user_office_details(user_login)
       query(
-        "provider-users/#{user_login}/provider-offices",
+        "provider-users/#{CGI.escape(user_login)}/provider-offices",
         200 => ->(data) { data['officeCodes'] },
         204 => [],
       )

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -8,16 +8,9 @@ class ProviderDataApiClient
       )
     end
 
-    def user_details(email)
-      query(
-        "provider-users/exists?userEmail=#{email}",
-        200 => ->(data) { data['user'] }
-      )
-    end
-
     def user_office_details(user_login)
       query(
-        "provider-users/#{CGI.escape(user_login)}/provider-offices",
+        "provider-users/#{ERB::Util.url_encode(user_login)}/provider-offices",
         200 => ->(data) { data['officeCodes'] },
         204 => [],
       )

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -3,8 +3,8 @@ class ProviderDataApiClient
     def contract_active?(office_code)
       query(
         "provider-office/#{office_code}/office-contract-details",
-        200 => ->(_) { true },
-        204 => ->(_) { false },
+        200 => true,
+        204 => false,
       )
     end
 
@@ -19,7 +19,7 @@ class ProviderDataApiClient
       query(
         "provider-users/#{user_login}/provider-offices",
         200 => ->(data) { data['officeCodes'] },
-        204 => ->(_) { [] },
+        204 => [],
       )
     end
 
@@ -33,7 +33,11 @@ class ProviderDataApiClient
         raise "Unexpected status code #{response.code} when querying provider API endpoint #{endpoint}"
       end
 
-      return_values[response.code].call(response.parsed_response)
+      if return_values[response.code].respond_to?(:call)
+        return_values[response.code].call(response.parsed_response)
+      else
+        return_values[response.code]
+      end
     end
 
     def base_url

--- a/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Providers::OmniauthCallbacksController, type: :controller do
     context 'when not in test mode' do
       before do
         allow(FeatureFlags).to receive(:omniauth_test_mode).and_return(double(:omniauth_test_mode, enabled?: false))
-        allow(OfficeCodeService).to receive(:call).with('provider@example.com').and_return(%w[DDDDDD EEEEEE])
+        allow(OfficeCodeService).to receive(:call).with('test-user').and_return(%w[DDDDDD EEEEEE])
         allow(ActiveOfficeCodeService).to receive(:call).with(%w[DDDDDD EEEEEE]).and_return(['EEEEEE'])
         get :saml
       end

--- a/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe Providers::OmniauthCallbacksController, type: :controller do
     # Mimic the router behavior of setting the Devise scope through the env.
     request.env['devise.mapping'] = Devise.mappings[:provider]
 
-    request.env['omniauth.auth'] = OmniAuth::AuthHash.new({
-                                                            provider: 'saml',
+    request.env['omniauth.auth'] = OmniAuth::AuthHash.new(
+      provider: 'saml',
       uid: 'test-user',
       info: {
         email: 'provider@example.com',
         roles: 'EFORMS,EFORMS_eFormsAuthor,CRIMEAPPLY',
-        office_codes: office_codes
+        office_codes: office_codes,
       }
-                                                          })
+    )
   end
 
   describe '#saml' do
@@ -76,6 +76,23 @@ RSpec.describe Providers::OmniauthCallbacksController, type: :controller do
       it 'redirects to inactive offices error page' do
         get :saml
         expect(response).to redirect_to '/errors/inactive_offices'
+      end
+    end
+
+    context 'when not in test mode' do
+      before do
+        allow(FeatureFlags).to receive(:omniauth_test_mode).and_return(double(:omniauth_test_mode, enabled?: false))
+        allow(OfficeCodeService).to receive(:call).with('provider@example.com').and_return(%w[DDDDDD EEEEEE])
+        allow(ActiveOfficeCodeService).to receive(:call).with(%w[DDDDDD EEEEEE]).and_return(['EEEEEE'])
+        get :saml
+      end
+
+      it 'redirects to root path' do
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'sets the office codes' do
+        expect(Provider.find_by(email: 'provider@example.com').office_codes).to eq %w[DDDDDD EEEEEE]
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Provider, type: :model do
   end
 
   describe '#from_omniauth' do
-    let(:info) { double('info', email: 'test@test.com', description: 'desc', roles: 'a,b', office_codes: office_codes) }
+    let(:info) { double('info', email: 'test@test.com', description: 'desc', roles: 'a,b') }
     let(:auth) { double('auth', provider: 'govuk', uid: SecureRandom.uuid, info: info) }
 
     context 'new user' do
@@ -38,7 +38,7 @@ RSpec.describe Provider, type: :model do
         let(:office_codes) { %w[A1 A2] }
 
         it 'creates a new user record' do
-          expect { described_class.from_omniauth(auth) }.to change(described_class, :count).by(1)
+          expect { described_class.from_omniauth(auth, office_codes) }.to change(described_class, :count).by(1)
         end
       end
     end

--- a/spec/services/active_office_code_service_spec.rb
+++ b/spec/services/active_office_code_service_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe ActiveOfficeCodeService do
         let(:status) { 500 }
 
         it 'raises an error' do
-          expect { subject }.to raise_error 'Unexpected status code 500 when checking office code AAAAA'
+          expect { subject }.to raise_error(
+            'Unexpected status code 500 when querying provider API endpoint provider-office/AAAAA/office-contract-details'
+          )
         end
       end
     end

--- a/spec/services/office_code_service_spec.rb
+++ b/spec/services/office_code_service_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe OfficeCodeService do
     end
 
     it 'raises an error' do
-      expect { subject }.to raise_error 'Unexpected status code 500 when checking for office codes for user LOGIN'
+      expect { subject }.to raise_error(
+        'Unexpected status code 500 when querying provider API endpoint provider-users/LOGIN/provider-offices'
+      )
     end
   end
 
@@ -64,7 +66,9 @@ RSpec.describe OfficeCodeService do
     end
 
     it 'raises an error' do
-      expect { subject }.to raise_error 'Unexpected status code 204 when checking for user with email EMAIL'
+      expect { subject }.to raise_error(
+        'Unexpected status code 204 when querying provider API endpoint provider-users/exists?userEmail=EMAIL'
+      )
     end
   end
 end

--- a/spec/services/office_code_service_spec.rb
+++ b/spec/services/office_code_service_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe OfficeCodeService do
-  subject { described_class.call(email) }
+  subject { described_class.call(user_login) }
 
-  let(:email) { 'EMAIL' }
   let(:user_login) { 'LOGIN' }
   let(:known_user_payload) do
     {
@@ -21,13 +20,11 @@ RSpec.describe OfficeCodeService do
     }.to_json
   end
   let(:headers) { { 'Content-type' => 'application/json' } }
-  let(:user_details_endpoint) { 'https://provider-api.example.com/provider-users/exists?userEmail=EMAIL' }
   let(:user_offices_endpoint) { 'https://provider-api.example.com/provider-users/LOGIN/provider-offices' }
   let(:populated_codes) { %w[AAAAAA BBBBBB] }
 
   context 'when all is working correctly' do
     before do
-      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
       stub_request(:get, user_offices_endpoint).to_return(status: 200, body: populated_code_payload, headers: headers)
     end
 
@@ -38,7 +35,6 @@ RSpec.describe OfficeCodeService do
 
   context 'when user has no office codes' do
     before do
-      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
       stub_request(:get, user_offices_endpoint).to_return(status: 204, headers: headers)
     end
 
@@ -47,27 +43,14 @@ RSpec.describe OfficeCodeService do
     end
   end
 
-  context 'when second endpoint call errors' do
+  context 'when endpoint call errors' do
     before do
-      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
       stub_request(:get, user_offices_endpoint).to_return(status: 500)
     end
 
     it 'raises an error' do
       expect { subject }.to raise_error(
         'Unexpected status code 500 when querying provider API endpoint provider-users/LOGIN/provider-offices'
-      )
-    end
-  end
-
-  context 'when user not recognised' do
-    before do
-      stub_request(:get, user_details_endpoint).to_return(status: 204, headers: headers)
-    end
-
-    it 'raises an error' do
-      expect { subject }.to raise_error(
-        'Unexpected status code 204 when querying provider API endpoint provider-users/exists?userEmail=EMAIL'
       )
     end
   end

--- a/spec/services/office_code_service_spec.rb
+++ b/spec/services/office_code_service_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe OfficeCodeService do
+  subject { described_class.call(email) }
+
+  let(:email) { 'EMAIL' }
+  let(:user_login) { 'LOGIN' }
+  let(:known_user_payload) do
+    {
+      'user' => {
+        'userLogin' => user_login
+      }
+    }.to_json
+  end
+  let(:populated_code_payload) do
+    {
+      'officeCodes' => [
+        { 'firmOfficeCode' => 'AAAAAA' },
+        { 'firmOfficeCode' => 'BBBBBB' }
+      ]
+    }.to_json
+  end
+  let(:headers) { { 'Content-type' => 'application/json' } }
+  let(:user_details_endpoint) { 'https://provider-api.example.com/provider-users/exists?userEmail=EMAIL' }
+  let(:user_offices_endpoint) { 'https://provider-api.example.com/provider-users/LOGIN/provider-offices' }
+  let(:populated_codes) { %w[AAAAAA BBBBBB] }
+
+  context 'when all is working correctly' do
+    before do
+      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
+      stub_request(:get, user_offices_endpoint).to_return(status: 200, body: populated_code_payload, headers: headers)
+    end
+
+    it 'retrieves office codes from the provider data API in 2 steps' do
+      expect(subject).to eq populated_codes
+    end
+  end
+
+  context 'when user has no office codes' do
+    before do
+      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
+      stub_request(:get, user_offices_endpoint).to_return(status: 204, headers: headers)
+    end
+
+    it 'returns an empty array' do
+      expect(subject).to eq []
+    end
+  end
+
+  context 'when second endpoint call errors' do
+    before do
+      stub_request(:get, user_details_endpoint).to_return(status: 200, body: known_user_payload, headers: headers)
+      stub_request(:get, user_offices_endpoint).to_return(status: 500)
+    end
+
+    it 'raises an error' do
+      expect { subject }.to raise_error 'Unexpected status code 500 when checking for office codes for user LOGIN'
+    end
+  end
+
+  context 'when user not recognised' do
+    before do
+      stub_request(:get, user_details_endpoint).to_return(status: 204, headers: headers)
+    end
+
+    it 'raises an error' do
+      expect { subject }.to raise_error 'Unexpected status code 204 when checking for user with email EMAIL'
+    end
+  end
+end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -16,6 +16,6 @@ module AuthenticationHelpers
     allow(warden).to receive_messages(authenticate!: auth_provider, authenticate: auth_provider)
     codes = auth_provider.office_codes
     allow(ActiveOfficeCodeService).to receive(:call).with(codes).and_return(codes)
-    allow(OfficeCodeService).to receive(:call).with(auth_provider.email).and_return(codes) if auth_provider.respond_to?(:email)
+    allow(OfficeCodeService).to receive(:call).with(auth_provider.uid).and_return(codes) if auth_provider.respond_to?(:email)
   end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -14,6 +14,8 @@ module AuthenticationHelpers
 
   def sign_in
     allow(warden).to receive_messages(authenticate!: auth_provider, authenticate: auth_provider)
-    allow(ActiveOfficeCodeService).to receive(:call).with(auth_provider.office_codes).and_return(auth_provider.office_codes)
+    codes = auth_provider.office_codes
+    allow(ActiveOfficeCodeService).to receive(:call).with(codes).and_return(codes)
+    allow(OfficeCodeService).to receive(:call).with(auth_provider.email).and_return(codes) if auth_provider.respond_to?(:email)
   end
 end


### PR DESCRIPTION
## Description of change
- Stop trusting portal to tell us correct office codes on each login
- Instead use the provider data API (which we also query about which office codes are active, so that it becomes the single point of truth about office codes)

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2064)
