### PR TITLE
Experiment: With minimal config is modsec phase 4 still broken?

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -21,23 +21,11 @@ metadata:
     {{- include "laa-submit-crime-forms.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/custom-http-errors: "423"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecRequestBodyNoFilesLimit 524288
-      SecRequestBodyLimit 104857600
-      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team,status:423"
-      SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team,status:423"
-      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      SecRuleRemoveById 920120
-      SecRuleRemoveById 921110
-      SecRuleRemoveById 933210
-      SecRuleRemoveById 942230
-      SecRuleRemoveById 951120
-      SecRuleRemoveById 951220
-      SecRuleRemoveById 952100
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
+      SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -24,7 +24,6 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
-      SecResponseBodyAccess Off
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
       SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
     external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -24,6 +24,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
+      SecResponseBodyAccess Off
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
       SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
     external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
Yes: https://crm457-1721-b-expl-nscc-provider-dev.cloud-platform.service.justice.gov.uk/assets/file-upload-b450e66e.js.map is triggering a modsec false positive in phase 4 against rule 952100. Modsec is trying to block it but the file is still being sent to the requester, just with a weird header.