### PR TITLE
CRM457-2095: Add flags indicating sync job status

### DIFF
--- a/app/jobs/send_notification_email.rb
+++ b/app/jobs/send_notification_email.rb
@@ -1,6 +1,12 @@
 class SendNotificationEmail < ApplicationJob
+  def self.perform_later(submission)
+    submission.update!(send_notification_email_completed: false)
+    super
+  end
+
   def perform(submission)
     Nsm::SubmissionMailer.notify(submission).deliver_now! if submission.is_a?(Claim)
     PriorAuthority::SubmissionMailer.notify(submission).deliver_now! if submission.is_a?(PriorAuthorityApplication)
+    submission.update!(send_notification_email_completed: true)
   end
 end

--- a/app/jobs/submit_to_app_store.rb
+++ b/app/jobs/submit_to_app_store.rb
@@ -1,6 +1,11 @@
 class SubmitToAppStore < ApplicationJob
   queue_as :default
 
+  def self.perform_later(submission:)
+    submission.update!(submit_to_app_store_completed: false)
+    super
+  end
+
   def perform(submission:)
     # This job may have been enqueued while the submission was locked, before a DB
     # transaction had been committed. So if we read from the DB straight away we
@@ -10,6 +15,7 @@ class SubmitToAppStore < ApplicationJob
     submission.with_lock do
       submit(submission)
       notify(submission)
+      submission.update!(submit_to_app_store_completed: true)
     end
   end
 

--- a/app/services/submit_to_app_store/nsm_payload_builder.rb
+++ b/app/services/submit_to_app_store/nsm_payload_builder.rb
@@ -64,7 +64,8 @@ class SubmitToAppStore
     def direct_attributes
       claim.as_json(except: %w[navigation_stack firm_office_id solicitor_id submitter_id allowed_calls
                                allowed_calls_uplift allowed_letters allowed_letters_uplift
-                               calls_adjustment_comment letters_adjustment_comment state core_search_fields])
+                               calls_adjustment_comment letters_adjustment_comment state core_search_fields
+                               submit_to_app_store_completed send_notification_email_completed])
     end
 
     def firm_office

--- a/db/migrate/20241015084055_add_synced_to_app_store_to_submissions.rb
+++ b/db/migrate/20241015084055_add_synced_to_app_store_to_submissions.rb
@@ -1,0 +1,8 @@
+class AddSyncedToAppStoreToSubmissions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :claims, :submit_to_app_store_completed, :boolean
+    add_column :claims, :send_notification_email_completed, :boolean
+    add_column :prior_authority_applications, :submit_to_app_store_completed, :boolean
+    add_column :prior_authority_applications, :send_notification_email_completed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_07_161008) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_15_084055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -108,6 +108,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_161008) do
     t.boolean "court_in_undesignated_area"
     t.boolean "transferred_to_undesignated_area"
     t.virtual "core_search_fields", type: :tsvector, as: "(to_tsvector('simple'::regconfig, COALESCE((laa_reference)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((ufn)::text, ''::text)))", stored: true
+    t.boolean "submit_to_app_store_completed"
+    t.boolean "send_notification_email_completed"
     t.index ["core_search_fields"], name: "index_claims_on_core_search_fields", using: :gin
     t.index ["firm_office_id"], name: "index_claims_on_firm_office_id"
     t.index ["solicitor_id"], name: "index_claims_on_solicitor_id"
@@ -228,6 +230,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_07_161008) do
     t.datetime "resubmission_requested"
     t.datetime "resubmission_deadline"
     t.virtual "core_search_fields", type: :tsvector, as: "(to_tsvector('simple'::regconfig, COALESCE((laa_reference)::text, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((ufn)::text, ''::text)))", stored: true
+    t.boolean "submit_to_app_store_completed"
+    t.boolean "send_notification_email_completed"
     t.index ["core_search_fields"], name: "index_prior_authority_applications_on_core_search_fields", using: :gin
     t.index ["firm_office_id"], name: "index_prior_authority_applications_on_firm_office_id"
     t.index ["provider_id"], name: "index_prior_authority_applications_on_provider_id"

--- a/spec/jobs/send_notification_email_spec.rb
+++ b/spec/jobs/send_notification_email_spec.rb
@@ -3,16 +3,31 @@ require 'rails_helper'
 RSpec.describe SendNotificationEmail do
   subject { described_class.new }
 
+  describe '.perform_later' do
+    let(:submission) { create :claim, send_notification_email_completed: nil }
+
+    it 'sets a flag' do
+      described_class.perform_later(submission)
+      expect(submission.reload.send_notification_email_completed).to be false
+    end
+  end
+
   describe '#notify' do
     context 'when submission is a claim' do
       let(:submission) { create(:claim) }
-      let(:mailer) { instance_double(ActionMailer::MessageDelivery) }
+      let(:mailer) { instance_double(ActionMailer::MessageDelivery, deliver_now!: true) }
 
       it 'triggers an email for nsm' do
         expect(Nsm::SubmissionMailer).to receive(:notify).with(submission).and_return(mailer)
         expect(mailer).to receive(:deliver_now!)
 
         subject.perform(submission)
+      end
+
+      it 'updates the db record' do
+        allow(Nsm::SubmissionMailer).to receive(:notify).and_return(mailer)
+        subject.perform(submission)
+        expect(submission.reload).to be_send_notification_email_completed
       end
     end
 

--- a/spec/jobs/send_notification_email_spec.rb
+++ b/spec/jobs/send_notification_email_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe SendNotificationEmail do
     let(:submission) { create :claim, send_notification_email_completed: nil }
 
     it 'sets a flag' do
-      described_class.perform_later(submission)
+      begin
+        described_class.perform_later(submission)
+      rescue RedisClient::CannotConnectError
+        nil # In the test environment, enqueuing to Redis will fail
+      end
       expect(submission.reload.send_notification_email_completed).to be false
     end
   end

--- a/spec/jobs/submit_to_app_store_spec.rb
+++ b/spec/jobs/submit_to_app_store_spec.rb
@@ -18,7 +18,11 @@ RSpec.describe SubmitToAppStore do
     let(:submission) { create :claim, submit_to_app_store_completed: nil }
 
     it 'sets a flag' do
-      described_class.perform_later(submission:)
+      begin
+        described_class.perform_later(submission:)
+      rescue RedisClient::CannotConnectError
+        nil # In the test environment, enqueuing to Redis will fail
+      end
       expect(submission.reload.submit_to_app_store_completed).to be false
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,9 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'sidekiq/testing'
 require 'axe-rspec'
-Sidekiq::Testing.inline!
 
 Rails.root.glob('spec/support/**/*.rb').each { |f| require f }
 


### PR DESCRIPTION
## Description of change
Set a flag before running an async job, change the flag after running it, that way if we lose access to Redis (both the job queue and the logs of dead jobs), we know what needs to be re-synced.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2095)
