### PR TITLE
CRM457-2013: Stop orphaning solicitor records

### DIFF
--- a/app/forms/prior_authority/steps/case_contact/solicitor_form.rb
+++ b/app/forms/prior_authority/steps/case_contact/solicitor_form.rb
@@ -14,15 +14,8 @@ module PriorAuthority
         private
 
         def persist!
-          existing = application.solicitor
-          existing&.assign_attributes(attributes)
-
-          if existing.nil? || existing.changed?
-            application.create_solicitor!(attributes)
-            application.save!
-          else
-            application.update!(solicitor: existing)
-          end
+          solicitor = application.solicitor || application.build_solicitor
+          solicitor.update!(attributes)
         end
       end
     end

--- a/app/forms/prior_authority/steps/case_contact_form.rb
+++ b/app/forms/prior_authority/steps/case_contact_form.rb
@@ -29,6 +29,9 @@ module PriorAuthority
       def persist!
         firm_office.save!
         solicitor.save!
+        # The save! below is to ensure that the in-memory application object has both its
+        # firm_office and solicitor relations populated
+        application.save!
       end
     end
   end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -3,8 +3,8 @@ class Claim < ApplicationRecord
   include StageReachedCalculatable
 
   belongs_to :submitter, class_name: 'Provider'
-  belongs_to :firm_office, optional: true
-  belongs_to :solicitor, optional: true
+  belongs_to :firm_office, optional: true, dependent: :destroy
+  belongs_to :solicitor, optional: true, dependent: :destroy
   has_many :defendants, -> { order(:position) }, dependent: :destroy, as: :defendable, inverse_of: :defendable
   has_one :main_defendant, lambda {
                              where(main: true)

--- a/app/models/firm_office.rb
+++ b/app/models/firm_office.rb
@@ -1,6 +1,2 @@
 class FirmOffice < ApplicationRecord
-  belongs_to :previous, optional: true, class_name: 'FirmOffice'
-  has_many :nexts, class_name: 'FirmOffice', foreign_key: :previous_id, inverse_of: :previous, dependent: nil
-
-  scope :latest, -> { left_joins(:nexts).where(nexts_firm_offices: { id: nil }) }
 end

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -1,7 +1,7 @@
 class PriorAuthorityApplication < ApplicationRecord
   belongs_to :provider
-  belongs_to :firm_office, optional: true
-  belongs_to :solicitor, optional: true
+  belongs_to :firm_office, optional: true, dependent: :destroy
+  belongs_to :solicitor, optional: true, dependent: :destroy
   has_one :defendant, dependent: :destroy, as: :defendable
   has_many :quotes, dependent: :destroy
   has_one :primary_quote,

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -1,9 +1,4 @@
 class Solicitor < ApplicationRecord
-  belongs_to :previous, optional: true, class_name: 'Solicitor'
-  has_many :nexts, class_name: 'Solicitor', foreign_key: :previous_id, inverse_of: :previous, dependent: nil
-
-  scope :latest, -> { left_joins(:nexts).where(nexts_solicitors: { id: nil }) }
-
   def contact_full_name
     "#{contact_first_name} #{contact_last_name}"
   end

--- a/db/migrate/20241015133053_delete_orphans.rb
+++ b/db/migrate/20241015133053_delete_orphans.rb
@@ -1,0 +1,12 @@
+class DeleteOrphans < ActiveRecord::Migration[7.2]
+  def change
+    Solicitor.joins("LEFT JOIN prior_authority_applications pa ON pa.solicitor_id = solicitors.id")
+             .joins("LEFT JOIN claims c ON c.solicitor_id = solicitors.id")
+             .where("pa.id IS NULL AND c.id IS NULL")
+             .destroy_all
+    FirmOffice.joins("LEFT JOIN prior_authority_applications pa ON pa.firm_office_id = firm_offices.id")
+              .joins("LEFT JOIN claims c ON c.firm_office_id = firm_offices.id")
+              .where("pa.id IS NULL AND c.id IS NULL")
+              .destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_15_084055) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_15_133053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## Description of change
- The original devs used to have a mechanism where for NSM firm offices and solicitors we'd try to share matching records across claims, and if the details changed we'd create a new version of the same record and link them. But it was never fully implemented and most of it was removed, except part of it got copy-pasted across to PA without really understanding it.
- The upshot is that there has been some code to "orphan" solicitor and firm office records every time they change, so that we have records no longer associated with a particular claim or application.
- This PR gets rid of the last vestiges of the orphaning mechanism, destroys all current orphans, and clears out some associated logic linking older and newer versions of records that never gets used

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2013)
