### PR TITLE
CRM457-2162: Tweak task list behaviour

### DIFF
--- a/app/presenters/nsm/tasks/base.rb
+++ b/app/presenters/nsm/tasks/base.rb
@@ -2,6 +2,35 @@ module Nsm
   module Tasks
     class Base < ::Tasks::Generic
       DECISION_TREE = Decisions::DecisionTree
+
+      # If I complete sections A, B and C, then go back and change section A,
+      # `prune_navigation_stack` will remove B and C from the stack.
+      # The default behaviour in the gem is to mark B and C as not yet started,
+      # even though we have actually completed them. The desired behaviour is
+      # to mark B as in progress and C as 'Cannot start yet'.
+      # To achieve this, we need to loosen the definition of `in_progress?`
+      # to include "not in navigation stack but actually already complete",
+      # and adjust the rest of the logic around it accordingly
+      def current_status
+        return TaskStatus::NOT_APPLICABLE if not_applicable?
+        return TaskStatus::UNREACHABLE unless can_start? || previously_visited?
+        return TaskStatus::NOT_STARTED unless in_progress?
+        return TaskStatus::COMPLETED if fully_completed?
+
+        TaskStatus::IN_PROGRESS
+      end
+
+      def in_progress?
+        previously_visited? || completed?
+      end
+
+      def fully_completed?
+        completed? && previously_visited?
+      end
+
+      def previously_visited?
+        application.navigation_stack.include?(path)
+      end
     end
   end
 end

--- a/app/presenters/nsm/tasks/cost_summary.rb
+++ b/app/presenters/nsm/tasks/cost_summary.rb
@@ -3,17 +3,6 @@ module Nsm
     class CostSummary < Base
       PREVIOUS_TASKS = Disbursements
 
-      def can_start?
-        case application.has_disbursements
-        when YesNoAnswer::NO.to_s
-          true
-        when YesNoAnswer::YES.to_s
-          super
-        else
-          false
-        end
-      end
-
       def path
         nsm_steps_cost_summary_path(application)
       end

--- a/app/presenters/nsm/tasks/defendants.rb
+++ b/app/presenters/nsm/tasks/defendants.rb
@@ -5,7 +5,7 @@ module Nsm
       FORM = Nsm::Steps::DefendantDetailsForm
       PREVIOUS_STEP_NAME = :firm_details
 
-      def in_progress?
+      def previously_visited?
         [
           edit_nsm_steps_defendant_summary_path(application),
           edit_nsm_steps_defendant_details_path(id: application.id, defendant_id: '')

--- a/app/presenters/nsm/tasks/disbursements.rb
+++ b/app/presenters/nsm/tasks/disbursements.rb
@@ -9,7 +9,7 @@ module Nsm
       ].freeze
 
       # TODO: is this inefficient? do we care?
-      def in_progress?
+      def previously_visited?
         application.disbursements.any? &&
           [
             edit_nsm_steps_disbursement_type_path(id: application.id, disbursement_id: ''),

--- a/app/presenters/nsm/tasks/work_items.rb
+++ b/app/presenters/nsm/tasks/work_items.rb
@@ -5,7 +5,7 @@ module Nsm
       PREVIOUS_STEP_NAME = :claim_details
       FORM = Nsm::Steps::WorkItemForm
 
-      def in_progress?
+      def previously_visited?
         [
           edit_nsm_steps_work_items_path(application),
           edit_nsm_steps_work_item_path(id: application.id, work_item_id: '')

--- a/app/views/nsm/claims/search.html.erb
+++ b/app/views/nsm/claims/search.html.erb
@@ -23,14 +23,20 @@
           <div class="govuk-date-input__item">
             <div class="moj-datepicker" data-module="moj-date-picker">
               <div class="govuk-form-group">
-                <%= f.govuk_text_field :submitted_from, label: { text: t('.submitted_from') }, class: 'moj-js-datepicker-input' %>
+                <%= f.govuk_text_field :submitted_from,
+                                       label: { text: t('.submitted_from') },
+                                       class: 'moj-js-datepicker-input',
+                                       value: @form.submitted_from&.to_fs(:date_picker) %>
               </div>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="moj-datepicker" data-module="moj-date-picker">
               <div class="govuk-form-group">
-                <%= f.govuk_text_field :submitted_to, label: { text: t('.submitted_to') }, class: 'moj-js-datepicker-input' %>
+                <%= f.govuk_text_field :submitted_to,
+                                       label: { text: t('.submitted_to') },
+                                       class: 'moj-js-datepicker-input',
+                                       value: @form.submitted_to&.to_fs(:date_picker) %>
               </div>
             </div>
           </div>
@@ -43,14 +49,20 @@
           <div class="govuk-date-input__item">
             <div class="moj-datepicker" data-module="moj-date-picker">
               <div class="govuk-form-group">
-                <%= f.govuk_text_field :updated_from, label: { text: t('.updated_from') }, class: 'moj-js-datepicker-input' %>
+                <%= f.govuk_text_field :updated_from,
+                                       label: { text: t('.updated_from') },
+                                       class: 'moj-js-datepicker-input',
+                                       value: @form.updated_from&.to_fs(:date_picker) %>
               </div>
             </div>
           </div>
           <div class="govuk-date-input__item">
             <div class="moj-datepicker" data-module="moj-date-picker">
               <div class="govuk-form-group">
-                <%= f.govuk_text_field :updated_to, label: { text: t('.updated_to') }, class: 'moj-js-datepicker-input' %>
+                <%= f.govuk_text_field :updated_to,
+                                       label: { text: t('.updated_to') },
+                                       class: 'moj-js-datepicker-input',
+                                       value: @form.updated_to&.to_fs(:date_picker)  %>
               </div>
             </div>
           </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -7,4 +7,5 @@ Date::DATE_FORMATS[:stamp] = '%-d %B %Y' # DD MONTH YYYY
 Time::DATE_FORMATS[:stamp] = '%-d %B %Y' # DD MONTH YYYY
 Date::DATE_FORMATS[:short_stamp] = '%-d %b %Y'
 Time::DATE_FORMATS[:short_stamp] = '%-d %b %Y'
+Date::DATE_FORMATS[:date_picker] = "%-d/%-m/%Y" # d/m/yyyy
 

--- a/spec/presenter/nsm/steps/cost_summary_presenter_spec.rb
+++ b/spec/presenter/nsm/steps/cost_summary_presenter_spec.rb
@@ -25,24 +25,6 @@ RSpec.describe Nsm::Tasks::CostSummary, type: :system do
     it { expect(subject).not_to be_not_applicable }
   end
 
-  describe '#can_start?' do
-    context 'when has_disbursements is no' do
-      let(:has_disbursements) { 'no' }
-
-      it { expect(subject).to be_can_start }
-    end
-
-    context 'when has_disbursements is nil' do
-      it { expect(subject).not_to be_can_start }
-    end
-
-    context 'when has_disbursements is yes' do
-      let(:has_disbursements) { 'yes' }
-
-      it_behaves_like 'a task with generic can_start?', Nsm::Tasks::Disbursements
-    end
-  end
-
   describe '#completed?' do
     context 'cost_summary is last page in the navigation stack' do
       let(:navigation_stack) { ["/non-standard-magistrates/applications/#{id}/steps/cost_summary"] }

--- a/spec/presenter/nsm/steps/solicitor_declaration_presenter_spec.rb
+++ b/spec/presenter/nsm/steps/solicitor_declaration_presenter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Nsm::Tasks::SolicitorDeclaration, type: :system do
     context 'when status is COMPLETED' do
       it 'is disabled' do
         allow(subject).to receive_messages(not_applicable?: false, can_start?: true, in_progress?: true,
-                                           completed?: true)
+                                           fully_completed?: true)
 
         expect(subject.status).not_to be_enabled
         expect(subject.status).to eq(TaskStatus::COMPLETED)

--- a/spec/system/nsm/task_list_spec.rb
+++ b/spec/system/nsm/task_list_spec.rb
@@ -1,0 +1,102 @@
+require 'system_helper'
+
+RSpec.describe 'Task list' do
+  it 'updates the task list appropriately' do
+    visit provider_saml_omniauth_callback_path
+    click_on "Claim non-standard magistrates' court payments, previously CRM7"
+    click_on 'Start a new claim'
+
+    # Claim type
+    fill_in 'What is your unique file number (UFN)?', with: '120223/001'
+    choose "Non-standard magistrates' court payment"
+    within('.govuk-radios__conditional', text: 'Representation order date') do
+      fill_in 'Day', with: '20'
+      fill_in 'Month', with: '4'
+      fill_in 'Year', with: '2023'
+    end
+    click_on 'Save and continue'
+
+    # Firm in undesignated area
+    choose 'No'
+    click_on 'Save and continue'
+
+    # Task list:
+    expect(page)
+      .to have_content('What are you claiming for Completed')
+      .and have_content('Firm details Not yet started')
+      .and have_content('Defendant details Cannot start yet')
+
+    click_on 'Firm details'
+
+    fill_in 'Firm name', with: 'Lawyers'
+    fill_in 'Address line 1', with: 'home'
+    fill_in 'Town or city', with: 'hometown'
+    fill_in 'Postcode', with: 'AA1 1AA'
+    choose 'nsm-steps-firm-details-form-firm-office-attributes-vat-registered-yes-field'
+    fill_in 'Solicitor first name', with: 'James'
+    fill_in 'Solicitor last name', with: 'Robert'
+    fill_in 'Solicitor reference number', with: '2222'
+
+    click_on 'Save and continue'
+
+    # Contact details
+    fill_in 'First name', with: 'Jim'
+    fill_in 'Last name', with: 'Bob'
+    fill_in 'Email address', with: 'jim@bob.com'
+    click_on 'Save and continue'
+
+    # Defendant details
+    fill_in 'First name', with: 'Jim'
+    fill_in 'Last name', with: 'Bob'
+    fill_in 'MAAT ID number', with: '1234567'
+    click_on 'Save and continue'
+
+    # Defendant summary
+    choose 'No'
+    click_on 'Save and continue'
+
+    # Case details
+    select 'Assault (common)', from: 'Main offence'
+    within('.govuk-form-group', text: 'Main offence date') do
+      fill_in 'Day', with: '20'
+      fill_in 'Month', with: '4'
+      fill_in 'Year', with: '2023'
+    end
+
+    find('.govuk-form-group', text: 'Was there an assigned counsel?').choose 'Yes'
+    find('.govuk-form-group', text: 'Was there an unassigned counsel?').choose 'No'
+    find('.govuk-form-group', text: 'Was there an instructed agent?').choose 'Yes'
+    find('.govuk-form-group',
+         text: 'Has the case been remitted from the Crown Court to the magistrates\' court?').choose 'Yes'
+
+    within('.govuk-form-group', text: 'Has the case been remitted from the Crown Court to the magistrates\' court?') do
+      fill_in 'Day', with: '02'
+      fill_in 'Month', with: '07'
+      fill_in 'Year', with: '2023'
+    end
+
+    click_on 'Save and continue'
+
+    click_on "Claim a non-standard magistrates' court payment"
+    click_on 'Drafts'
+    click_on '120223/001'
+
+    # Task list:
+    expect(page)
+      .to have_content('Firm details Completed')
+      .and have_content('Defendant details Completed')
+      .and have_content('Case details Completed')
+
+    # Amend firm details - this will prune the old navigation stack
+    click_on 'Firm details'
+    click_on 'Save and continue'
+    click_on "Claim a non-standard magistrates' court payment"
+    click_on 'Drafts'
+    click_on '120223/001'
+
+    expect(page)
+      .to have_content('Firm details Completed')
+      .and have_content('Defendant details In progress')
+      .and have_content('Case details Cannot start yet')
+  end
+end


### PR DESCRIPTION
## Description of change
Override NSM task list to change labelling behaviour. Previously, if you'd completed a sectionB  but then amended a previous section A, removing B from the navigation stack, B would be marked as 'Not started' even though we still had all of the previously entered data for B. This made it look like we had thrown data away. Now we mark 'B' as in progress (by detecting that, despite not being in the stack, it is complete).

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2162)

