### PR TITLE
CRM457-2173: Fix "back" and "change" buttons in PA RFI

### DIFF
--- a/app/helpers/decision_step_header_helper.rb
+++ b/app/helpers/decision_step_header_helper.rb
@@ -7,6 +7,7 @@ module DecisionStepHeaderHelper
 
   def previous_decision_step_path(record:)
     form = Steps::BaseFormObject.new(application: current_application, record: record)
+    return { controller: :check_answers, action: :edit } if params[:return_to] == 'check_answers'
 
     Decisions::BackDecisionTree.new(
       form,

--- a/app/presenters/prior_authority/check_answers/base.rb
+++ b/app/presenters/prior_authority/check_answers/base.rb
@@ -58,6 +58,8 @@ module PriorAuthority
       end
 
       def title_actions
+        return [] if changes_forbidden?
+
         helper = Rails.application.routes.url_helpers
 
         [
@@ -66,9 +68,14 @@ module PriorAuthority
             helper.url_for(controller: "prior_authority/steps/#{section}",
                            action: request_method,
                            application_id: application.id,
-                           only_path: true)
+                           only_path: true,
+                           return_to: :check_answers)
           ),
         ]
+      end
+
+      def changes_forbidden?
+        application.sent_back? && !application.correction_needed?
       end
     end
   end

--- a/app/presenters/prior_authority/check_answers/further_information_card.rb
+++ b/app/presenters/prior_authority/check_answers/further_information_card.rb
@@ -44,6 +44,10 @@ module PriorAuthority
             sanitize(links.join(tag.br), tags: %w[a br])
           end
       end
+
+      def changes_forbidden?
+        false
+      end
     end
   end
 end

--- a/app/presenters/prior_authority/check_answers/ufn_card.rb
+++ b/app/presenters/prior_authority/check_answers/ufn_card.rb
@@ -35,6 +35,8 @@ module PriorAuthority
       end
 
       def ufn_change_link
+        return [] if changes_forbidden?
+
         helper = Rails.application.routes.url_helpers
 
         [

--- a/app/services/decisions/back_decision_tree.rb
+++ b/app/services/decisions/back_decision_tree.rb
@@ -101,9 +101,14 @@ module Decisions
       .goto(edit: DecisionTree::PRIOR_AUTHORITY_ALTERNATIVE_QUOTES)
 
     # check answers
-    from('prior_authority/steps/check_answers').goto(show: 'prior_authority/steps/start_page')
+    from('prior_authority/steps/check_answers')
+      .when(-> { application.sent_back? })
+      .goto(show: '/prior_authority/applications', id: -> { application.id })
+      .goto(show: 'prior_authority/steps/start_page')
 
     # further information
-    from('prior_authority/steps/further_information').goto(show: 'prior_authority/steps/start_page')
+    # We can't use overwrite_to_cya here because in a sent_back loop there will already be
+    # check answers in the navigation stack whether we've just come from there or not
+    from('prior_authority/steps/further_information').goto(show: '/prior_authority/applications', id: -> { application.id })
   end
 end

--- a/app/services/decisions/decision_tree.rb
+++ b/app/services/decisions/decision_tree.rb
@@ -195,7 +195,7 @@ module Decisions
       .goto { overwrite_to_cya }
 
     from(:further_information)
-      .goto { overwrite_to_cya }
+      .goto(edit: 'prior_authority/steps/check_answers')
 
     from(:check_answers)
       .goto(show: 'prior_authority/steps/submission_confirmation')

--- a/spec/system/prior_authority/further_information_request_spec.rb
+++ b/spec/system/prior_authority/further_information_request_spec.rb
@@ -2,7 +2,7 @@ require 'system_helper'
 
 RSpec.describe 'Prior authority applications - provider responds to further information request',
                :javascript, type: :system do
-  let(:application) { create(:prior_authority_application, :with_further_information_request) }
+  let(:application) { create(:prior_authority_application, :full, :with_further_information_request) }
 
   before do
     visit provider_saml_omniauth_callback_path
@@ -24,6 +24,8 @@ RSpec.describe 'Prior authority applications - provider responds to further info
       .to have_attributes(
         information_supplied: 'here is the information requested'
       )
+
+    expect(page).to have_current_path edit_prior_authority_steps_check_answers_path(application)
   end
 
   it 'allows user to submit further information with attachments' do
@@ -50,5 +52,23 @@ RSpec.describe 'Prior authority applications - provider responds to further info
 
     within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
     expect(page).to have_no_css('.govuk-table')
+  end
+
+  it 'takes me back to application details' do
+    click_on 'Back'
+    expect(page).to have_current_path prior_authority_application_path(application)
+  end
+
+  it 'can be navigated from check answers' do
+    visit edit_prior_authority_steps_check_answers_path(application)
+    click_on 'Change' # There should only be one of these on the page
+    expect(page).to have_current_path(
+      edit_prior_authority_steps_further_information_path(application, return_to: :check_answers)
+    )
+    click_on 'Back'
+    expect(page).to have_current_path edit_prior_authority_steps_check_answers_path(application)
+
+    click_on 'Back'
+    expect(page).to have_current_path prior_authority_application_path(application)
   end
 end


### PR DESCRIPTION
## Description of change
- Make sure back buttons don't lead to the task list in an RFI loop
- Hide 'change' links on check answers page in PA RFI if corrections are not allowed

This ticket simply fixes/hides links to prevent users accidentally going to places they shouldn't go. There is a separate ticket ([CRM457-2174](https://dsdmoj.atlassian.net/browse/CRM457-2174)) to make those places entirely inaccessible.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2173)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-2174]: https://dsdmoj.atlassian.net/browse/CRM457-2174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ