### PR TITLE
Change input type of period field to number

### DIFF
--- a/gems/laa_multi_step_forms/app/lib/govuk_design_system_formbuilder/elements/period.rb
+++ b/gems/laa_multi_step_forms/app/lib/govuk_design_system_formbuilder/elements/period.rb
@@ -105,7 +105,7 @@ module GOVUKDesignSystemFormBuilder
           id: id(segment, link_errors),
           class: classes(width),
           name: name(segment),
-          type: 'text',
+          type: 'number',
           inputmode: 'numeric',
           value: value,
           maxlength: (width if maxlength_enabled?),


### PR DESCRIPTION
## Description of change

Change the input type of the period field to be number instead of text since it's intended that numbers be entered.
