### PR TITLE
CRM457-2187: Fix file deletion via check answers screen

### DIFF
--- a/app/javascript/file-upload.js
+++ b/app/javascript/file-upload.js
@@ -105,9 +105,9 @@ MOJFrontend.MultiFileUpload.prototype.onFileDeleteClick = function (e) {
                     .text()
 
     $.ajax({
-        url: `${this.params.deleteUrl}?evidence_id=${button.attr('value')}`,
+        url: this.params.deleteUrl,
         type: 'delete',
-
+        data: { evidence_id: button.attr('value') },
         success: function (response) {
             feedback.html(this.getSuccessHtml(`${fileName} has been deleted`));
             button.parents('.moj-multi-file-upload__row').remove();


### PR DESCRIPTION
Put delete params in payload, rather than badly trying to put them in the query string. (When there already is a query string in the URL, appending `?` just breaks stuff)

## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2187)