### PR TITLE
CRM457-2248: Escape the query to prevent syntax errors

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -10,15 +10,20 @@ class SearchService
 
     private
 
+    def escape_string(string)
+      %('''#{string.gsub("'", "''")}''')
+    end
+
     def filter_on_search_string(base_query, params)
       return base_query if params[:search_string].blank?
 
       params[:search_string].split.reduce(base_query) do |built_query, token|
         word = token.strip
+
         if laa_reference_or_ufn?(word)
-          built_query.where("core_search_fields @@ to_tsquery('simple', ?)", word)
+          built_query.where("core_search_fields @@ to_tsquery('simple', ?)", escape_string(word))
         else
-          built_query.where("searchable_defendants.search_fields @@ to_tsquery('simple', ?)", word)
+          built_query.where("searchable_defendants.search_fields @@ to_tsquery('simple', ?)", escape_string(word))
         end
       end
     end

--- a/app/views/nsm/claims/search.html.erb
+++ b/app/views/nsm/claims/search.html.erb
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="search-panel govuk-!-margin-bottom-6">
-      <%= form_with(url: search_nsm_applications_path(anchor: :'results-count'), method: :get, model: @form) do |f| %>
+      <%= form_with(url: search_nsm_applications_path(anchor: :'results'), method: :get, model: @form) do |f| %>
         <div class="govuk-form-group govuk-!-width-two-thirds" role="search">
           <%= f.govuk_text_field :search_string, label: { size: 's', text: t("nsm.claims.search.label") } %>
         </div>

--- a/app/views/prior_authority/applications/search.html.erb
+++ b/app/views/prior_authority/applications/search.html.erb
@@ -11,7 +11,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="search-panel govuk-!-margin-bottom-6">
-      <%= form_with(url: search_prior_authority_applications_path(anchor: :'results-count'), method: :get, model: @form) do |f| %>
+      <%= form_with(url: search_prior_authority_applications_path(anchor: :'results'), method: :get, model: @form) do |f| %>
         <div class="govuk-form-group govuk-!-width-two-thirds" role="search">
           <%= f.govuk_text_field :search_string, label: { size: 's', text: t("prior_authority.applications.search.label") } %>
         </div>

--- a/spec/system/search_spec.rb
+++ b/spec/system/search_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe 'Search' do
              laa_reference: 'LAA-AB1234',
              office_code: 'XYZXYZ',
              ufn: '070620/123',
-             main_defendant: build(:defendant, :valid, first_name: 'Joe', last_name: 'Bloggs'),
+             main_defendant: build(:defendant, :valid, first_name: 'Joe', last_name: "Bloggs-O'Reilly"),
              state: :submitted,
              updated_at: DateTime.new(2024, 9, 1, 10, 17, 26),
              originally_submitted_at: DateTime.new(2024, 9, 1, 10, 17, 26)
@@ -277,8 +277,20 @@ RSpec.describe 'Search' do
         end
       end
 
+      context 'when I search by partial last name' do
+        let(:query) { 'Bloggs' }
+
+        it 'shows only the matching record that I am associated with' do
+          within('#results') do
+            expect(page).to have_content 'Submitted'
+            expect(page).to have_no_content 'Draft'
+            expect(page).to have_no_content 'Rejected'
+          end
+        end
+      end
+
       context 'when I search by last name' do
-        let(:query) { 'bloggs' }
+        let(:query) { "Bloggs-O'Reilly" }
 
         it 'shows only the matching record that I am associated with' do
           within('#results') do
@@ -290,11 +302,39 @@ RSpec.describe 'Search' do
       end
 
       context 'when I search by combo' do
-        let(:query) { 'BLOGGS JOE 070620/123' }
+        let(:query) { "BLOGGS-O'REILLY JOE 070620/123" }
 
         it 'shows only the matching record that I am associated with' do
           within('#results') do
             expect(page).to have_content 'Submitted'
+            expect(page).to have_no_content 'Draft'
+            expect(page).to have_no_content 'Rejected'
+          end
+        end
+      end
+
+      context 'when I search for unmatched parentheses' do
+        let(:query) { 'Joe)' }
+
+        it 'shows only the matching record that I am associated with' do
+          expect(page).to have_no_content 'Something went wrong trying to perform this search'
+
+          within('#results') do
+            expect(page).to have_content 'Submitted'
+            expect(page).to have_no_content 'Draft'
+            expect(page).to have_no_content 'Rejected'
+          end
+        end
+      end
+
+      context 'when I search for a query with ampersands' do
+        let(:query) { '&' }
+
+        it 'shows only the matching record that I am associated with' do
+          expect(page).to have_no_content 'Something went wrong trying to perform this search'
+
+          within('#results') do
+            expect(page).to have_no_content 'Submitted'
             expect(page).to have_no_content 'Draft'
             expect(page).to have_no_content 'Rejected'
           end


### PR DESCRIPTION
## Description of change
Include the same change from https://github.com/ministryofjustice/laa-crime-application-store/pull/312 to ensure that we protect against incorrect syntax error exceptions.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2248)

