### PR TITLE
Nicely format Snyk output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,10 @@ jobs:
           command: snyk monitor --all-projects
       - run:
           name: Scan container image for vulnerabilities
-          command: snyk container test app --file=./Dockerfile --policy-path=.snyk --severity-threshold=high
+          command: snyk container test app --file=./Dockerfile --policy-path=.snyk --severity-threshold=high --json | bin/snyk-formatted /tmp/snyk.json
+      - store_artifacts:
+          path: /tmp/snyk.json
+          destination: snyk.json
       - run:
           name: Monitor container image for vulnerabilities
           command: snyk container monitor app

--- a/bin/snyk-formatted
+++ b/bin/snyk-formatted
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+require 'json'
+
+# Save stdin to file and parse
+input = $stdin.read
+File.write(ARGV[0], input) unless ARGV.length != 1
+json = JSON.parse(input)
+
+# Process vulnerabilities from applications or root
+vulns = (json['applications'] || [json]).flat_map do |app|
+  next [] unless (app['uniqueCount']).positive?
+
+  app['vulnerabilities'].map do |v|
+    fix = v['upgradePath'][0] ? "Upgrade via #{v['upgradePath'][0]}" : 'Upgrade direct dependency'
+
+    <<~VULN
+
+      #{v['packageName']} [#{v['severity']}] #{v['title']} (CVSS: #{v['cvssScore']})
+
+      https://security.snyk.io/vuln/#{v['id']}
+      [ #{fix} to #{v['upgradePath'][1]} ]
+
+    VULN
+  end
+end
+
+puts vulns
+exit vulns.length


### PR DESCRIPTION
## Description of change

Use Ruby to generate a nicely formatted output.

![image](https://github.com/user-attachments/assets/64c3c135-3a51-4c10-b82e-cc2213e1a340)

[Sample step](https://app.circleci.com/pipelines/github/ministryofjustice/laa-submit-crime-forms/6318/workflows/fb3968a1-a7a4-4565-8239-541edc44c41e/jobs/44093)

It'll likely break randomly over time, which is why I've also made the script save the full output as a JSON artifact. Even if the script fails, we can still check and see what broke.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2252)
