### PR TITLE
CRM457-2276: Do things synchronously

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -26,3 +26,5 @@ ENABLE_SYNC_TRIGGER_ENDPOINT=true
 
 PROVIDER_API_HOST=https://provider-api.example.com
 PROVIDER_API_KEY=123
+
+APP_STORE_URL=https://app-store.example.com

--- a/app/controllers/prior_authority/steps/submission_confirmation_controller.rb
+++ b/app/controllers/prior_authority/steps/submission_confirmation_controller.rb
@@ -8,7 +8,10 @@ module PriorAuthority
       private
 
       def step_valid?
-        current_application.submitted? || current_application.provider_updated?
+        # By the time a provider has submitted their application and been redirected here it may already
+        # have been autogranted, but we still want them to see this screen, which is why auto_grant is
+        # included here.
+        current_application.submitted? || current_application.provider_updated? || current_application.auto_grant?
       end
     end
   end

--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -20,7 +20,7 @@ module PriorAuthority
 
         application.update!(state: new_state)
         update_incorrect_information if application.correction_needed?
-        SubmitToAppStore.perform_later(submission: application)
+        SubmitToAppStore.new.perform(submission: application)
 
         true
       end

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -7,7 +7,7 @@ class AppStoreClient
 
     case response.code
     when 200..204
-      JSON.parse(response.body)
+      response.body.present? ? JSON.parse(response.body) : :success
     when 409
       raise "Application ID already exists in AppStore for '#{message[:application_id]}'"
     else

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -7,7 +7,7 @@ class AppStoreClient
 
     case response.code
     when 200..204
-      :success
+      JSON.parse(response.body)
     when 409
       raise "Application ID already exists in AppStore for '#{message[:application_id]}'"
     else
@@ -20,7 +20,7 @@ class AppStoreClient
 
     case response.code
     when 201
-      :success
+      JSON.parse(response.body)
     else
       raise "Unexpected response from AppStore - status #{response.code} for '#{message[:application_id]}'"
     end

--- a/app/services/app_store_update_processor.rb
+++ b/app/services/app_store_update_processor.rb
@@ -1,11 +1,11 @@
 class AppStoreUpdateProcessor
   class << self
-    def call(record)
+    def call(record, local_record = nil)
       case record['application_type']
       when 'crm7'
-        update_claim(record)
+        update_claim(record, local_record)
       when 'crm4'
-        update_prior_authority_application(record)
+        update_prior_authority_application(record, local_record)
       end
     end
 
@@ -16,8 +16,8 @@ class AppStoreUpdateProcessor
       }
     end
 
-    def update_claim(record)
-      claim = Claim.find_by(id: record['application_id'])
+    def update_claim(record, local_record)
+      claim = local_record || Claim.find_by(id: record['application_id'])
 
       return unless claim
 
@@ -25,8 +25,8 @@ class AppStoreUpdateProcessor
       Nsm::AssessmentSyncer.call(claim, record:)
     end
 
-    def update_prior_authority_application(record)
-      application = PriorAuthorityApplication.find_by(id: record['application_id'])
+    def update_prior_authority_application(record, local_record)
+      application = local_record || PriorAuthorityApplication.find_by(id: record['application_id'])
       return unless application
 
       application.update!(convert_params(record))

--- a/spec/forms/nsm/steps/solicitor_declaration_form_spec.rb
+++ b/spec/forms/nsm/steps/solicitor_declaration_form_spec.rb
@@ -13,8 +13,11 @@ RSpec.describe Nsm::Steps::SolicitorDeclarationForm do
   let(:application) { create(:claim, :complete, state: 'draft') }
 
   describe '#save the form' do
+    let(:job) { instance_double(SubmitToAppStore) }
+
     before do
-      allow(SubmitToAppStore).to receive(:perform_later)
+      allow(SubmitToAppStore).to receive(:new).and_return(job)
+      allow(job).to receive(:perform)
       allow(application).to receive(:update!).and_return(true)
     end
 
@@ -30,7 +33,7 @@ RSpec.describe Nsm::Steps::SolicitorDeclarationForm do
       it 'notifies the app store' do
         form.save
 
-        expect(SubmitToAppStore).to have_received(:perform_later).with(submission: application)
+        expect(job).to have_received(:perform).with(submission: application)
       end
 
       it 'updates submission to correct state' do
@@ -45,14 +48,13 @@ RSpec.describe Nsm::Steps::SolicitorDeclarationForm do
       let(:application) { create(:claim, :complete, :with_further_information_supplied, state: 'sent_back') }
 
       before do
-        allow(SubmitToAppStore).to receive(:perform_later)
         allow(application.pending_further_information).to receive(:update!).and_return(true)
       end
 
       it 'notifies the app store' do
         form.save
 
-        expect(SubmitToAppStore).to have_received(:perform_later).with(submission: application)
+        expect(job).to have_received(:perform).with(submission: application)
       end
 
       it 'updates submission to correct state' do
@@ -67,7 +69,6 @@ RSpec.describe Nsm::Steps::SolicitorDeclarationForm do
       let(:application) { create(:claim, :complete, state: 'submitted') }
 
       before do
-        allow(SubmitToAppStore).to receive(:perform_later)
         allow(application).to receive(:update!).and_return(true)
       end
 

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
     end
 
     context 'when response code is 201 - created' do
-      it 'returns the response bodyu' do
+      it 'returns the response body' do
         expect(subject.put(message)).to eq('foo' => 'bar')
       end
     end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         it 'returns the response body' do
           expect(subject.post(message)).to eq('foo' => 'bar')
         end
+
+        context 'when there is no response body' do
+          let(:body) { nil }
+
+          it 'returns a success indicator' do
+            expect(subject.post(message)).to eq(:success)
+          end
+        end
       end
 
       context 'when response code is 409 - conflict' do

--- a/spec/system/prior_authority/check_your_answers/sent_back_for_correct_info_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/sent_back_for_correct_info_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe 'Prior authority applications, sent back for info correction - ch
 
   context 'Application has been updated' do
     before do
-      allow(PriorAuthority::ChangeLister).to receive(:call).and_return([true])
+      allow(PriorAuthority::ChangeLister).to receive(:call).and_return(['client_details'])
+      stub_request(:put, "https://app-store.example.com/v1/application/#{application.id}").to_return(
+        status: 201, body: { application_state: 'provider_updated' }.to_json
+      )
     end
 
     it 'shows the "incorrect information" details from the caseworker' do

--- a/spec/system/prior_authority/check_your_answers/submission_spec.rb
+++ b/spec/system/prior_authority/check_your_answers/submission_spec.rb
@@ -2,7 +2,6 @@ require 'system_helper'
 
 RSpec.describe 'Prior authority applications, check your answers, submission' do
   before do
-    allow(SubmitToAppStore).to receive(:perform_later)
     fill_in_until_step(:submit_application)
     click_on 'Submit application'
   end
@@ -31,14 +30,71 @@ RSpec.describe 'Prior authority applications, check your answers, submission' do
   end
 
   context 'when I have confirmed conditions I must abide by', :stub_oauth_token do
-    it 'allows me to submit my application' do
+    before do
       check 'I confirm that all costs are exclusive of VAT'
       check 'I confirm that any travel expenditure (such as mileage, ' \
             'parking and travel fares) is included as additional items ' \
             'in the primary quote, and is not included as part of any hourly rate'
+    end
 
-      click_on 'Accept and send'
-      expect(page).to have_title('Application complete')
+    context 'when app store succeeds' do
+      let(:job) { instance_double(SubmitToAppStore, perform: true) }
+
+      before do
+        allow(SubmitToAppStore).to receive(:new).and_return(job)
+        click_on 'Accept and send'
+      end
+
+      it 'allows me to submit my application' do
+        expect(page).to have_title('Application complete')
+        expect(job).to have_received(:perform)
+        expect(PriorAuthorityApplication.last).to be_submitted
+      end
+
+      it 'can be seen on the list of submitted applications' do
+        visit submitted_prior_authority_applications_path
+
+        expect(page).to have_title('Your applications')
+        expect(page).to have_css('.govuk-table__row', text: '111111/123')
+      end
+
+      it 'stops me getting back to the check your answers page' do
+        application = PriorAuthorityApplication.find_by(ufn: '111111/123')
+        visit prior_authority_steps_check_answers_path(application)
+
+        expect(page).to have_title('Application details')
+      end
+    end
+
+    context 'when the app store fails' do
+      before do
+        stub_request(:post, 'https://app-store.example.com/v1/application/').to_return(status: 500)
+      end
+
+      it 'shows an error message' do
+        application = PriorAuthorityApplication.last
+        expect do
+          click_on 'Accept and send'
+        end.to raise_error "Unexpected response from AppStore - status 500 for '#{application.id}'"
+        expect(application.reload).to be_draft
+      end
+    end
+
+    context 'when the app store autogrants' do
+      before do
+        stub_request(:post, 'https://app-store.example.com/v1/application/').to_return(status: 201, body: {
+          application_state: 'auto_grant',
+          application_type: 'crm4',
+          last_updated_at: DateTime.current,
+          application: {},
+        }.to_json)
+      end
+
+      it 'records the autogrant' do
+        click_on 'Accept and send'
+        expect(page).to have_title('Application complete')
+        expect(PriorAuthorityApplication.last).to be_auto_grant
+      end
     end
   end
 
@@ -48,31 +104,6 @@ RSpec.describe 'Prior authority applications, check your answers, submission' do
       expect(page).to have_title('Check your answers')
         .and have_css('.govuk-error-summary', text: 'There is a problem on this page')
         .and have_css('.govuk-error-message', text: 'Select if you confirm that', count: 2)
-    end
-  end
-
-  context 'when check answers form already submitted' do
-    before do
-      check 'I confirm that all costs are exclusive of VAT'
-      check 'I confirm that any travel expenditure (such as mileage, ' \
-            'parking and travel fares) is included as additional items ' \
-            'in the primary quote, and is not included as part of any hourly rate'
-
-      click_on 'Accept and send'
-    end
-
-    it 'can be seen on the list of submitted applications' do
-      visit submitted_prior_authority_applications_path
-
-      expect(page).to have_title('Your applications')
-      expect(page).to have_css('.govuk-table__row', text: '111111/123')
-    end
-
-    it 'stops me getting back to the check your answers page' do
-      application = PriorAuthorityApplication.find_by(ufn: '111111/123')
-      visit prior_authority_steps_check_answers_path(application)
-
-      expect(page).to have_title('Application details')
     end
   end
 end


### PR DESCRIPTION
## Description of change
- Submit to app store synchronously
- Check the app store response to see if there's been an immediate state change (i.e. autogrant)
- Now the only thing that uses Sidekiq is the submission confirmation email

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2276)
