### PR TITLE
[CRM457-2291][CRM457-2293] add YCF case disposal summary views to CYA and view_claim reports

### DIFF
--- a/app/presenters/nsm/check_answers/case_category_card.rb
+++ b/app/presenters/nsm/check_answers/case_category_card.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Nsm
+  module CheckAnswers
+    class CaseCategoryCard < Base
+      attr_reader :case_category_form,
+                  :case_outcome_form, :case_youth_court_fee
+
+      def initialize(claim)
+        @case_category_form = Nsm::Steps::CaseCategoryForm.build(claim)
+        @case_outcome_form = Nsm::Steps::CaseOutcomeForm.build(claim)
+        @case_youth_court_fee = Nsm::Steps::YouthCourtClaimAdditionalFeeForm.build(claim)
+
+        @group = 'about_case'
+        @section = 'case_category'
+      end
+
+      def row_data
+        row_data_array = [
+          {
+            head_key: find_key_by_value(case_category_form.plea_category),
+            text: format_plea_outcome
+          }
+        ]
+
+        add_additional_fee(row_data_array, :additional_fee, case_youth_court_fee.include_youth_court_fee)
+        add_date_object(row_data_array, :arrest_warrant_date, case_outcome_form.arrest_warrant_date)
+        add_date_object(row_data_array, :change_solicitor_date, case_outcome_form.change_solicitor_date)
+
+        row_data_array
+      end
+
+      private
+
+      def add_additional_fee(row_data_array, head_key, value)
+        return if value.nil?
+
+        row_data_array << {
+          head_key: head_key,
+          text: I18n.t("nsm.steps.check_answers.show.sections.case_category.additional_fee_options.#{value}")
+        }
+      end
+
+      def format_plea_outcome
+        if case_outcome_form.other?
+          other = I18n.t("laa_crime_forms_common.nsm.plea.#{case_outcome_form.plea}")
+          "#{other}: #{case_outcome_form.case_outcome_other_info}"
+        else
+          check_missing(case_outcome_form.plea) do
+            I18n.t("laa_crime_forms_common.nsm.plea.#{case_outcome_form.plea}")
+          end
+        end
+      end
+
+      def add_date_object(array, head_key, date_value)
+        return unless date_value
+
+        array << {
+          head_key: head_key,
+          text: date_value.to_fs(:stamp)
+        }
+      end
+
+      def find_key_by_value(value_to_find)
+        return :pending if value_to_find.blank?
+
+        PleaCategory.new(value_to_find).value
+      end
+    end
+  end
+end

--- a/app/presenters/nsm/check_answers/read_only_report.rb
+++ b/app/presenters/nsm/check_answers/read_only_report.rb
@@ -69,7 +69,7 @@ module Nsm
         [
           CaseDetailsCard.new(claim),
           HearingDetailsCard.new(claim),
-          CaseDisposalCard.new(claim)
+          case_disposal_form
         ]
       end
 
@@ -123,6 +123,14 @@ module Nsm
       end
 
       private
+
+      def case_disposal_form
+        ycf_flow = FeatureFlags.youth_court_fee.enabled? && claim.rep_order_date >= Constants::YOUTH_COURT_CUTOFF_DATE
+
+        return CaseCategoryCard.new(claim) if ycf_flow
+
+        CaseDisposalCard.new(claim)
+      end
 
       def group_heading(group_key, **)
         return nil if group_key.in?(%w[cost_summary adjusted_cost_summary costs claim_type])

--- a/app/presenters/nsm/check_answers/report.rb
+++ b/app/presenters/nsm/check_answers/report.rb
@@ -64,7 +64,7 @@ module Nsm
         [
           CaseDetailsCard.new(claim),
           HearingDetailsCard.new(claim),
-          CaseDisposalCard.new(claim)
+          case_disposal_form
         ]
       end
 
@@ -84,6 +84,14 @@ module Nsm
       end
 
       private
+
+      def case_disposal_form
+        ycf_flow = FeatureFlags.youth_court_fee.enabled? && claim.rep_order_date >= Constants::YOUTH_COURT_CUTOFF_DATE
+
+        return CaseCategoryCard.new(claim) if ycf_flow
+
+        CaseDisposalCard.new(claim)
+      end
 
       def actions(key, action)
         return [] if @readonly

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -109,6 +109,23 @@ en:
               not_guilty_pleas: Category 2
               arrest_warrant_date: Date of warrant issued
               cracked_trial_date: Date guilty plea indicated to solicitor
+            case_category:
+              arrest_warrant_date: Date of warrant issued
+              change_solicitor_date: Date of change of solicitor
+              guilty_pleas: Category 1
+              not_guilty_pleas: Category 2
+              pending: Category
+              category_2: Category 2
+              category_1a: Category 1a
+              category_1b: Category 1b
+              category_2a: Category 2a
+              category_2b: Category 2b
+              additional_fee: Additional fee
+              additional_fee_options:
+                'true': Youth court fee claimed
+                'false': Youth court fee not claimed
+              arrest_warrant_date: Date of warrant issued
+              cracked_trial_date: Date guilty plea indicated to solicitor
             supporting_evidence:
               send_by_post: Sending supporting evidence by post
               supporting_evidence: Evidence %{count}
@@ -153,6 +170,8 @@ en:
             hearing_details:
               title: Hearing details
             case_disposal:
+              title: Case disposal
+            case_category:
               title: Case disposal
           about_claim:
             heading: About the claim

--- a/spec/presenters/nsm/check_answers/case_category_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_category_card_spec.rb
@@ -1,0 +1,168 @@
+require 'rails_helper'
+
+RSpec.describe Nsm::CheckAnswers::CaseCategoryCard do
+  subject { described_class.new(claim) }
+
+  let(:claim) do
+    build(:claim,
+          plea:,
+          plea_category:,
+          include_youth_court_fee:,
+          arrest_warrant_date:,
+          case_outcome_other_info:,
+          change_solicitor_date:)
+  end
+
+  let(:arrest_warrant_date) { nil }
+  let(:change_solicitor_date) { nil }
+  let(:plea) { nil }
+  let(:plea_category) { nil }
+  let(:include_youth_court_fee) { nil }
+  let(:case_outcome_other_info) { nil }
+
+  describe '#initialize' do
+    it 'creates the data instance' do
+      expect(Nsm::Steps::CaseCategoryForm).to receive(:build).with(claim)
+      expect(Nsm::Steps::CaseOutcomeForm).to receive(:build).with(claim)
+      expect(Nsm::Steps::YouthCourtClaimAdditionalFeeForm).to receive(:build).with(claim)
+      subject
+    end
+  end
+
+  describe '#title' do
+    it 'shows correct title' do
+      expect(subject.title).to eq('Case disposal')
+    end
+  end
+
+  context 'when plea is guilty' do
+    let(:plea_category) { :category_1a }
+    let(:plea) { :guilty }
+    let(:include_youth_court_fee) { true }
+
+    it 'returns the correct row_data' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :category_1a,
+            text: 'Guilty plea'
+          },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee claimed'
+          }
+        ]
+      )
+    end
+  end
+
+  context 'case outcome is other' do
+    let(:plea_category) { :category_2a }
+    let(:plea) { :other }
+    let(:include_youth_court_fee) { false }
+    let(:case_outcome_other_info) { 'test' }
+
+    it 'returns case category and other details' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :category_2a,
+            text: 'Other: test'
+          },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee not claimed'
+          }
+        ]
+      )
+    end
+  end
+
+  context 'when plea is guilty - ARREST_WARRANT' do
+    let(:arrest_warrant_date) { Date.new(2023, 3, 1) }
+    let(:plea_category) { :category_1a }
+    let(:plea) { :arrest_warrant }
+    let(:include_youth_court_fee) { false }
+
+    it 'returns the correct row_data' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :category_1a,
+            text: 'Warrant of arrest'
+          },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee not claimed'
+          },
+          {
+            head_key: :arrest_warrant_date,
+            text: '1 March 2023'
+          },
+        ]
+      )
+    end
+  end
+
+  context 'when plea is guilty - CHANGE OF SOLICITOR' do
+    let(:change_solicitor_date) { Date.new(2023, 3, 1) }
+    let(:plea_category) { :category_1a }
+    let(:plea) { :change_solicitor }
+    let(:include_youth_court_fee) { false }
+
+    it 'returns the correct row_data' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :category_1a,
+            text: 'Change of solicitor'
+          },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee not claimed'
+          },
+          {
+            head_key: :change_solicitor_date,
+            text: '1 March 2023'
+          },
+        ]
+      )
+    end
+  end
+
+  context 'when plea is not guilty' do
+    let(:plea_category) { :category_1a }
+    let(:plea) { :not_guilty }
+    let(:include_youth_court_fee) { true }
+
+    it 'returns the correct row_data' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :category_1a,
+            text: 'Not guilty plea'
+          },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee claimed'
+          }
+        ]
+      )
+    end
+  end
+
+  context 'when plea is not set' do
+    let(:plea_category) { nil }
+
+    it 'returns the correct row_data' do
+      expect(subject.row_data).to eq(
+        [
+          {
+            head_key: :pending,
+            text: '<strong class="govuk-tag govuk-tag--red">Incomplete</strong>'
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/presenters/nsm/check_answers/read_only_report_spec.rb
+++ b/spec/presenters/nsm/check_answers/read_only_report_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Nsm::CheckAnswers::ReadOnlyReport do
     context 'not in a complete state' do
       subject { described_class.new(claim, cost_summary_in_overview:) }
 
-      let(:claim) { build(:claim, :complete) }
+      let(:claim) { build(:claim, :complete, rep_order_date:) }
+      let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE - 1.day }
       let(:cost_summary_in_overview) { true }
 
       context 'section groups' do
@@ -100,7 +101,8 @@ RSpec.describe Nsm::CheckAnswers::ReadOnlyReport do
     context 'in a complete state' do
       subject { described_class.new(claim) }
 
-      let(:claim) { build(:claim, :complete, :completed_state) }
+      let(:claim) { build(:claim, :complete, :completed_state, rep_order_date:) }
+      let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE - 1.day }
 
       context 'section groups' do
         it 'returns multiple groups' do

--- a/spec/presenters/nsm/check_answers/report_spec.rb
+++ b/spec/presenters/nsm/check_answers/report_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Nsm::CheckAnswers::Report do
     context 'not in a complete state' do
       subject { described_class.new(claim) }
 
-      let(:claim) { build_stubbed(:claim, :complete) }
+      let(:claim) { build_stubbed(:claim, :complete, rep_order_date:) }
+      let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE - 1.day }
 
       context 'section groups' do
         it 'returns multiple groups' do
@@ -79,7 +80,8 @@ RSpec.describe Nsm::CheckAnswers::Report do
     context 'in a complete state' do
       subject { described_class.new(claim, read_only: true) }
 
-      let(:claim) { build(:claim, :complete, :completed_state) }
+      let(:claim) { build(:claim, :complete, :completed_state, rep_order_date:) }
+      let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE - 1.day }
 
       context 'section groups' do
         it 'returns multiple groups' do

--- a/spec/system/nsm/check_answers_spec.rb
+++ b/spec/system/nsm/check_answers_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Check answers page', type: :system do
-  let(:claim) { create(:claim, :case_type_breach, :firm_details, :letters_calls, work_items:, disbursements:) }
+  let(:claim) { create(:claim, :case_type_breach, :firm_details, :letters_calls, work_items:, disbursements:, rep_order_date:) }
+  let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE - 1.day }
   let(:work_items) do
     [
       build(:work_item, :valid, :attendance_without_counsel, time_spent: 90),
@@ -39,5 +40,94 @@ RSpec.describe 'Check answers page', type: :system do
         'Sum of net cost and VAT on claimed: £638.70'
       ]
     )
+  end
+
+  context 'case disposal' do
+    let(:claim) do
+      create(:claim, :case_type_magistrates, :firm_details,
+             :letters_calls, work_items:, disbursements:, plea:, plea_category:,
+            include_youth_court_fee:, rep_order_date:)
+    end
+    let(:youth_court_fee_enabled) { nil }
+    let(:plea) { :guilty }
+    let(:plea_category) { :category_1a }
+    let(:include_youth_court_fee) { true }
+    let(:rep_order_date) { Constants::YOUTH_COURT_CUTOFF_DATE }
+
+    before do
+      visit provider_saml_omniauth_callback_path
+    end
+
+    context 'enabled' do
+      let(:youth_court_fee_enabled) { true }
+
+      before do
+        allow(FeatureFlags).to receive(:youth_court_fee).and_return(double(:youth_court_fee, enabled?: youth_court_fee_enabled))
+      end
+
+      describe 'youth court eligible' do
+        it 'shows category type with category outcome and Additional Fee' do
+          visit nsm_steps_check_answers_path(claim.id)
+
+          within('.govuk-summary-card', text: 'Case disposal') do
+            expect(page).to have_content('Category 1a')
+            expect(page).to have_content('Guilty')
+            expect(page).to have_content('Additional fee')
+            expect(page).to have_content('Youth court fee claimed')
+          end
+        end
+      end
+
+      describe 'youth court inelligible' do
+        let(:include_youth_court_fee) { nil }
+
+        it 'shows category type with category outcome without Additional Fee' do
+          visit nsm_steps_check_answers_path(claim.id)
+
+          within('.govuk-summary-card', text: 'Case disposal') do
+            expect(page).to have_content('Category 1a')
+            expect(page).to have_content('Guilty')
+          end
+        end
+      end
+
+      context 'backwards compatible with pre-YCF change claims' do
+        let(:include_youth_court_fee) { nil }
+        let(:plea_category) { :guilty_pleas }
+        let(:plea) { :guilty }
+
+        before do
+          claim.update!(rep_order_date:)
+        end
+
+        it 'shows pre-6th Dec plea outcome flow' do
+          visit nsm_steps_check_answers_path(claim.id)
+
+          within('.govuk-summary-card', text: 'Case disposal') do
+            expect(page).to have_content('Category 1')
+            expect(page).to have_content('Guilty plea')
+            expect(page).not_to have_content('Additional fee')
+          end
+        end
+
+        describe 'flag disabled' do
+          let(:youth_court_fee_enabled) { false }
+
+          before do
+            allow(FeatureFlags).to receive(:youth_court_fee)
+              .and_return(double(:youth_court_fee, enabled?: youth_court_fee_enabled))
+          end
+
+          it 'shows the correct data within the case disposal section' do
+            visit nsm_steps_check_answers_path(claim.id)
+
+            within('.govuk-summary-card', text: 'Case disposal') do
+              expect(page).to have_content('Category')
+              expect(page).to have_content('Guilty plea')
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

[CRM457-2291](https://dsdmoj.atlassian.net/browse/CRM457-2291)
[CRM457-2293](https://dsdmoj.atlassian.net/browse/CRM457-2293)

## Notes for reviewer

In place of `youth court fee feature flags` we are swapping `old` for `new` views of `case disposal` summaries in the CYA and view claims page via a check on `claim.include_youth_court_fee`. 

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature


[CRM457-2291]: https://dsdmoj.atlassian.net/browse/CRM457-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CRM457-2293]: https://dsdmoj.atlassian.net/browse/CRM457-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ