### PR TITLE
[CRM457-2271] Youth court additional fee changes to display of information

### DIFF
--- a/app/presenters/nsm/check_answers/case_category_card.rb
+++ b/app/presenters/nsm/check_answers/case_category_card.rb
@@ -23,9 +23,9 @@ module Nsm
           }
         ]
 
-        add_additional_fee(row_data_array, :additional_fee, case_youth_court_fee.include_youth_court_fee)
         add_date_object(row_data_array, :arrest_warrant_date, case_outcome_form.arrest_warrant_date)
         add_date_object(row_data_array, :change_solicitor_date, case_outcome_form.change_solicitor_date)
+        add_additional_fee(row_data_array, :additional_fee, case_youth_court_fee.include_youth_court_fee)
 
         row_data_array
       end

--- a/app/presenters/nsm/cost_summary/additional_fees.rb
+++ b/app/presenters/nsm/cost_summary/additional_fees.rb
@@ -42,7 +42,7 @@ module Nsm
       end
 
       def change_key
-        'case_category'
+        'youth_court_claim_additional_fee'
       end
     end
   end

--- a/config/locales/en/nsm/check_answers.yml
+++ b/config/locales/en/nsm/check_answers.yml
@@ -116,10 +116,10 @@ en:
               not_guilty_pleas: Category 2
               pending: Category
               category_2: Category 2
-              category_1a: Category 1a
-              category_1b: Category 1b
-              category_2a: Category 2a
-              category_2b: Category 2b
+              category_1a: Category 1A
+              category_1b: Category 1B
+              category_2a: Category 2A
+              category_2b: Category 2B
               additional_fee: Additional fee
               additional_fee_options:
                 'true': Youth court fee claimed

--- a/spec/presenters/nsm/check_answers/case_category_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/case_category_card_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe Nsm::CheckAnswers::CaseCategoryCard do
             text: 'Warrant of arrest'
           },
           {
-            head_key: :additional_fee,
-            text: 'Youth court fee not claimed'
-          },
-          {
             head_key: :arrest_warrant_date,
             text: '1 March 2023'
           },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee not claimed'
+          }
         ]
       )
     end
@@ -118,13 +118,13 @@ RSpec.describe Nsm::CheckAnswers::CaseCategoryCard do
             text: 'Change of solicitor'
           },
           {
-            head_key: :additional_fee,
-            text: 'Youth court fee not claimed'
-          },
-          {
             head_key: :change_solicitor_date,
             text: '1 March 2023'
           },
+          {
+            head_key: :additional_fee,
+            text: 'Youth court fee not claimed'
+          }
         ]
       )
     end

--- a/spec/system/nsm/check_answers_spec.rb
+++ b/spec/system/nsm/check_answers_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe 'Check answers page', type: :system do
           visit nsm_steps_check_answers_path(claim.id)
 
           within('.govuk-summary-card', text: 'Case disposal') do
-            expect(page).to have_content('Category 1a')
+            expect(page).to have_content('Category 1A')
             expect(page).to have_content('Guilty')
             expect(page).to have_content('Additional fee')
             expect(page).to have_content('Youth court fee claimed')
@@ -85,7 +85,7 @@ RSpec.describe 'Check answers page', type: :system do
           visit nsm_steps_check_answers_path(claim.id)
 
           within('.govuk-summary-card', text: 'Case disposal') do
-            expect(page).to have_content('Category 1a')
+            expect(page).to have_content('Category 1A')
             expect(page).to have_content('Guilty')
           end
         end

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -340,7 +340,7 @@ time_spent: 90),
             visit nsm_steps_view_claim_path(claim.id)
 
             within('.govuk-summary-card', text: 'Case disposal') do
-              expect(page).to have_content('Category 1a')
+              expect(page).to have_content('Category 1A')
               expect(page).to have_content('Guilty')
               expect(page).to have_content('Additional fee')
               expect(page).to have_content('Youth court fee claimed')
@@ -355,7 +355,7 @@ time_spent: 90),
             visit nsm_steps_view_claim_path(claim.id)
 
             within('.govuk-summary-card', text: 'Case disposal') do
-              expect(page).to have_content('Category 1a')
+              expect(page).to have_content('Category 1A')
               expect(page).to have_content('Guilty')
               expect(page).to have_content('Additional fee')
               expect(page).to have_content('Youth court fee not claimed')
@@ -368,7 +368,7 @@ time_spent: 90),
             visit nsm_steps_view_claim_path(claim.id)
 
             within('.govuk-summary-card', text: 'Case disposal') do
-              expect(page).to have_content('Category 1a')
+              expect(page).to have_content('Category 1A')
               expect(page).to have_content('Guilty')
               expect(page).not_to have_content('Additional fee')
             end


### PR DESCRIPTION
## Description of change
fixes 

- capitalised sub-category display
- `change` on cost summary links to youth court fee confirmation page
- youth court fee confirmation listed as last element

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2271)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
