### PR TITLE
CRM457-2263: Resolve QA issues

### DIFF
--- a/app/services/decisions/back_decision_tree.rb
+++ b/app/services/decisions/back_decision_tree.rb
@@ -29,7 +29,7 @@ module Decisions
     from('nsm/steps/reason_for_claim')
       .when(-> { application.can_claim_youth_court? })
       .goto(edit: DecisionTree::NSM_YCF_FEE)
-      .when(-> { application.can_access_youth_court_flow? })
+      .when(-> { application.after_youth_court_cutoff? })
       .goto(edit: DecisionTree::NSM_CASE_OUTCOME)
       .goto(edit: 'nsm/steps/case_disposal')
 

--- a/app/views/nsm/steps/case_outcome/edit.html.erb
+++ b/app/views/nsm/steps/case_outcome/edit.html.erb
@@ -6,10 +6,10 @@
     <%= govuk_error_summary(@form_object) %>
 
     <%= step_form @form_object do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :case_outcome, legend: { size: 'l', class: 'govuk-!-margin-bottom-6', tag: 'h1' } do %>
+      <%= f.govuk_radio_buttons_fieldset :plea, legend: { text: t('.legend'), size: 'l', tag: 'h1' } do %>
         <% @case_outcomes.each_with_index do |outcome, index| %>
           <span id="<%= outcome %>"></span>
-          <%= f.govuk_radio_button :plea, outcome, link_errors: index.zero?,
+          <%= f.govuk_radio_button :plea, outcome.to_s, link_errors: index.zero?,
                                    label: { text: t("laa_crime_forms_common.nsm.plea.#{outcome}")} do %>
             <% if outcome.requires_date_field? %>
               <%= f.govuk_fully_validatable_date_field :"#{outcome}_date",
@@ -34,7 +34,7 @@
         <% end %>
 
       <% end %>
-      <%= f.continue_button(secondary: false) %>
+      <%= f.continue_button %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en/nsm/steps.yml
+++ b/config/locales/en/nsm/steps.yml
@@ -61,6 +61,7 @@ en:
           court_if_transferred_to_undesignated_area: Which court was the last case hearing heard at?
       case_outcome:
         edit:
+          legend: Case outcome
           page_title: Case outcome
           change_solicitor_date_hint: For example, 27 3 2024
           change_solicitor_date: Date of change

--- a/spec/system/nsm/case_outcome_spec.rb
+++ b/spec/system/nsm/case_outcome_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'When filling in the case outcome', type: :system do
     let(:feature_enabled) { true }
 
     it 'the user is able to submit an outcome' do
-      expect(page).to have_content(I18n.t('helpers.legend.nsm_steps_case_outcome_form.case_outcome'))
+      expect(page).to have_content(I18n.t('nsm.steps.case_outcome.edit.legend'))
 
       choose 'Guilty'
       click_on 'Save and continue'
@@ -26,7 +26,7 @@ RSpec.describe 'When filling in the case outcome', type: :system do
     let(:feature_enabled) { false }
 
     it 'the user is not able to visit the page' do
-      expect(page).to have_no_content(I18n.t('helpers.legend.nsm_steps_case_outcome_form.case_outcome'))
+      expect(page).to have_no_content(I18n.t('nsm.steps.case_outcome.edit.legend'))
       expect(page).to have_content('No route matches')
       expect(page).to have_http_status(:not_found)
     end


### PR DESCRIPTION
## Description of change
- Case outcome errors weren't including the radio buttons
- Adjusted how we set the outcomes list to match Case Category
- Remove extra margin from legend
- Add back "Save and come back later"
- Resolve incorrect back button logic with Post 6th NON-YC claims

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2263)