### PR TITLE
CRM457-2263: Only NSMs can claim the youth court fee

### DIFF
--- a/app/presenters/nsm/tasks/case_disposal.rb
+++ b/app/presenters/nsm/tasks/case_disposal.rb
@@ -20,7 +20,7 @@ module Nsm
       end
 
       def completed?
-        if application.can_access_youth_court_flow?
+        if application.nsm? && application.can_access_youth_court_flow?
           plea_details_populated? && !application.include_youth_court_fee.nil?
         else
           plea_details_populated?


### PR DESCRIPTION
## Description of change
We shouldn't consider whether or not the provider has selected to
claim the fee or not since they shouldn't be able to.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2263)