### PR TITLE
CRM457-2313: Add future date validation back in

### DIFF
--- a/app/forms/nsm/steps/claim_type_form.rb
+++ b/app/forms/nsm/steps/claim_type_form.rb
@@ -10,14 +10,12 @@ module Nsm
 
       validates :ufn, presence: true, ufn: true
       validates_inclusion_of :claim_type, in: :choices
-      # TODO: CRM457-2313: Disable this feature flag check
       validates :rep_order_date, presence: true,
-              multiparam_date: { allow_past: true, allow_future: FeatureFlags.youth_court_fee.enabled? },
+              multiparam_date: { allow_past: true, allow_future: false },
               if: :non_standard_claim?
       validates :cntp_order, presence: true, if: :breach_claim?
-      # TODO: CRM457-2313: Disable this feature flag check
       validates :cntp_date, presence: true,
-              multiparam_date: { allow_past: true, allow_future: FeatureFlags.youth_court_fee.enabled? },
+              multiparam_date: { allow_past: true, allow_future: false },
               if: :breach_claim?
 
       def choices

--- a/spec/forms/nsm/steps/claim_type_form_spec.rb
+++ b/spec/forms/nsm/steps/claim_type_form_spec.rb
@@ -175,18 +175,6 @@ RSpec.describe Nsm::Steps::ClaimTypeForm do
           expect(subject.errors.of_kind?(:cntp_date, :blank)).to be(true)
         end
       end
-
-      context 'without a CNTP date in the future being set' do
-        let(:cntp_date) { 3.days.from_now.to_date }
-        let(:cntp_order) { 'AAAA' }
-
-        # TODO: CRM457-2313: Remove the feature flag checks here
-        it 'is also valid' do
-          expect(subject.valid?).to eq(FeatureFlags.youth_court_fee.enabled?)
-          expect(subject.errors.of_kind?(:cntp_order, :blank)).to be(false)
-          expect(subject.errors.of_kind?(:cntp_date, :future_not_allowed)).to be(!FeatureFlags.youth_court_fee.enabled?)
-        end
-      end
     end
   end
 end

--- a/spec/forms/nsm/steps/claim_type_form_spec.rb
+++ b/spec/forms/nsm/steps/claim_type_form_spec.rb
@@ -175,6 +175,17 @@ RSpec.describe Nsm::Steps::ClaimTypeForm do
           expect(subject.errors.of_kind?(:cntp_date, :blank)).to be(true)
         end
       end
+
+      context 'without a CNTP date in the future being set' do
+        let(:cntp_date) { 3.days.from_now.to_date }
+        let(:cntp_order) { 'AAAA' }
+
+        it 'is also valid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:cntp_order, :blank)).to be(false)
+          expect(subject.errors.of_kind?(:cntp_date, :future_not_allowed)).to be(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2313)

## Notes for reviewer

- Add validation to not allow future dates for rep order date and CNTP date
