### PR TITLE
CRM457-2217: Simplify event builder

### DIFF
--- a/app/forms/prior_authority/steps/check_answers_form.rb
+++ b/app/forms/prior_authority/steps/check_answers_form.rb
@@ -26,12 +26,8 @@ module PriorAuthority
       end
 
       def update_incorrect_information
-        builder = SubmitToAppStore::PriorAuthorityPayloadBuilder.new(application:)
-        events = SubmitToAppStore::PriorAuthority::EventBuilder.new(application, builder.data)
-        sections_changed = events.corrected_info
-
         latest_incorrect_info = application.incorrect_informations.order(requested_at: :desc).first
-        latest_incorrect_info.update(sections_changed:)
+        latest_incorrect_info.update(sections_changed: changes_made_since_request)
       end
 
       def application_corrected
@@ -39,8 +35,14 @@ module PriorAuthority
       end
 
       def application_changed_since_request?
-        content = SubmitToAppStore::PriorAuthorityPayloadBuilder.new(application:).data
-        ::PriorAuthority::ChangeLister.call(application, content).present?
+        changes_made_since_request.present?
+      end
+
+      def changes_made_since_request
+        @changes_made_since_request ||= ::PriorAuthority::ChangeLister.call(
+          application,
+          SubmitToAppStore::PriorAuthorityPayloadBuilder.new(application:).data
+        )
       end
 
       def needs_correcting?

--- a/app/jobs/submit_to_app_store.rb
+++ b/app/jobs/submit_to_app_store.rb
@@ -22,8 +22,8 @@ class SubmitToAppStore < ApplicationJob
     end
   end
 
-  def submit(submission, include_events: true)
-    payload = PayloadBuilder.call(submission, include_events:)
+  def submit(submission)
+    payload = PayloadBuilder.call(submission)
     client = AppStoreClient.new
     payload.with_indifferent_access['application_state'] == 'submitted' ? client.post(payload) : client.put(payload)
   end

--- a/app/services/fixes/multiple_primary_quote_fixer.rb
+++ b/app/services/fixes/multiple_primary_quote_fixer.rb
@@ -42,7 +42,7 @@ module Fixes
       # We assume that any affected submissions will be manually put into "sent_back"
       #  before this job runs, and then put into their intended state after it runs.
       application.provider_updated!
-      SubmitToAppStore.new.submit(application, include_events: false)
+      SubmitToAppStore.new.submit(application)
       application.update(state: old_state)
     end
 

--- a/app/services/submit_to_app_store/payload_builder.rb
+++ b/app/services/submit_to_app_store/payload_builder.rb
@@ -1,11 +1,11 @@
 class SubmitToAppStore
   class PayloadBuilder
-    def self.call(submission, include_events: true)
+    def self.call(submission)
       case submission
       when Claim, AppStore::V1::Nsm::Claim
         NsmPayloadBuilder.new(claim: submission).payload
       when PriorAuthorityApplication
-        PriorAuthorityPayloadBuilder.new(application: submission, include_events: include_events).payload
+        PriorAuthorityPayloadBuilder.new(application: submission).payload
       else
         raise 'Unknown submission type'
       end

--- a/app/services/submit_to_app_store/prior_authority_payload_builder.rb
+++ b/app/services/submit_to_app_store/prior_authority_payload_builder.rb
@@ -1,8 +1,7 @@
 class SubmitToAppStore
   class PriorAuthorityPayloadBuilder
-    def initialize(application:, include_events: true)
+    def initialize(application:)
       @application = application
-      @include_events = include_events
     end
 
     def payload
@@ -11,7 +10,7 @@ class SubmitToAppStore
         application_state: application.state,
         application: validated_data,
         application_type: 'crm4',
-        events: @include_events ? PriorAuthority::EventBuilder.call(application, data) : [] }
+        events: PriorAuthority::EventBuilder.call(application) }
     end
 
     def validated_data

--- a/spec/jobs/submit_to_app_store_spec.rb
+++ b/spec/jobs/submit_to_app_store_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SubmitToAppStore do
 
     it 'generates a payload' do
       expect(described_class::PayloadBuilder).to receive(:call)
-        .with(submission, include_events: true)
+        .with(submission)
 
       subject.perform(submission:)
     end

--- a/spec/services/prior_authority/change_lister_spec.rb
+++ b/spec/services/prior_authority/change_lister_spec.rb
@@ -1,0 +1,380 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::ChangeLister do
+  describe '.call' do
+    let(:application) { create(:prior_authority_application, state: :provider_updated, prison_law: prison_law) }
+    let(:new_data) do
+      {
+        prison_law: prison_law,
+        ufn: '120423/123',
+        laa_reference: 'LAA-n4AohV',
+        status: 'pre_draft',
+        reason_why: 'something',
+        main_offence_id: 'something',
+        custom_main_offence_name: nil,
+        client_detained: true,
+        prison_id: 'something',
+        custom_prison_name: nil,
+        subject_to_poca: true,
+        next_hearing_date: '2024-01-16',
+        rep_order_date: nil,
+        plea: 'something',
+        court_type: 'central_criminal_court',
+        youth_court: true,
+        psychiatric_liaison: false,
+        psychiatric_liaison_reason_not: 'whatever you like',
+        next_hearing: true,
+        office_code: '1A123B',
+        service_type: 'pathologist_report',
+        custom_service_name: nil,
+        prior_authority_granted: false,
+        no_alternative_quote_reason: 'a reason',
+        defendant: {
+          first_name: 'bob',
+          last_name: 'jim',
+          maat: '1234567',
+          date_of_birth: '1981-11-12'
+        },
+        firm_office: {
+          account_number: '1A123B',
+          address_line_1: '2 Laywer Suite',
+          address_line_2: nil,
+          name: 'Firm A',
+          postcode: 'CR0 1RE',
+          town: 'Lawyer Town',
+          vat_registered: 'yes'
+        },
+        provider: {
+          description: nil,
+          email: 'provider@example.com'
+        },
+        solicitor: {
+          contact_email: 'james@email.com',
+          contact_first_name: 'James',
+          contact_last_name: 'James',
+          reference_number: '111222'
+        },
+        supporting_documents: [
+          {
+            document_type: 'supporting_document',
+            file_name: 'test.png',
+            file_path: 'test_path',
+            file_size: 1234,
+            file_type: 'image/png'
+          },
+          {
+            document_type: 'supporting_document',
+            file_name: 'test.png',
+            file_path: 'test_path',
+            file_size: 1234,
+            file_type: 'image/png'
+          }
+        ],
+        quotes: [primary_quote, alternative_quote, alternative_quote.merge(id: 'new-quote-id')],
+        additional_costs: [
+          {
+            id: '555555',
+            name: 'Some cost',
+            description: 'Some description',
+            unit_type: 'per_hour',
+            cost_per_hour: 150.0,
+            cost_per_item: nil,
+            items: nil,
+            period: 180,
+          }
+        ]
+      }
+    end
+    let(:prison_law) { true }
+
+    let(:primary_quote) do
+      {
+        contact_first_name: 'Joe',
+        contact_last_name: 'Bloggs',
+        organisation: 'LAA',
+        postcode: 'CR0 1RE',
+        primary: true,
+        cost_type: 'per_hour',
+        cost_per_hour: '10.0',
+        period: 180,
+        cost_per_item: nil,
+        items: nil,
+        item_type: 'item',
+        ordered_by_court: nil,
+        related_to_post_mortem: true,
+        id: '123123123',
+        document: {
+          document_type: 'quote_document',
+          file_name: 'test.png',
+          file_path: 'test_path',
+          file_size: 1234,
+          file_type: 'image/png'
+        },
+        travel_cost_per_hour: '50.0',
+        travel_cost_reason: nil,
+        travel_time: 150,
+        additional_cost_list: nil,
+        additional_cost_total: nil,
+      }
+    end
+
+    let(:alternative_quote) do
+      {
+        contact_first_name: 'Joe',
+        contact_last_name: 'Bloggs',
+        organisation: 'LAA',
+        postcode: 'CR0 1RE',
+        primary: false,
+        cost_type: 'per_hour',
+        cost_per_hour: '10.0',
+        period: 180,
+        cost_per_item: nil,
+        items: nil,
+        item_type: 'item',
+        ordered_by_court: nil,
+        related_to_post_mortem: true,
+        id: '456456456',
+        document: nil,
+        travel_cost_per_hour: '50.0',
+        travel_cost_reason: nil,
+        travel_time: 150,
+        additional_cost_list: nil,
+        additional_cost_total: nil,
+      }
+    end
+
+    let(:dummy_client) { instance_double(AppStoreClient) }
+    let(:old_data) { new_data.merge(changes).deep_stringify_keys }
+    let(:listed_corrections) { described_class.call(application, new_data) }
+
+    before do
+      allow(AppStoreClient).to receive(:new).and_return(dummy_client)
+      allow(dummy_client).to receive(:get).and_return({ 'application' => old_data })
+    end
+
+    context 'when application has not changed' do
+      let(:changes) { {} }
+
+      it 'returns an empty array' do
+        expect(listed_corrections).to eq([])
+      end
+    end
+
+    context 'when ufn has changed' do
+      let(:changes) { { ufn: '120423/999' } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:ufn]
+      end
+    end
+
+    context 'when firm office detail has changed' do
+      let(:changes) do
+        {
+          firm_office: {
+            account_number: '1A123B',
+            address_line_1: '3 Laywer Suite',
+            address_line_2: nil,
+            name: 'Firm A',
+            postcode: 'CR0 1RE',
+            town: 'Lawyer Town',
+            vat_registered: 'yes'
+          }
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:case_contact]
+      end
+    end
+
+    context 'when solicitor detail has changed' do
+      let(:changes) do
+        {
+          solicitor: {
+            contact_email: 'james@email.com',
+            contact_first_name: 'James',
+            contact_last_name: 'Rake',
+            reference_number: '111222'
+          },
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:case_contact]
+      end
+    end
+
+    context 'when client non-maat detail has changed' do
+      let(:changes) do
+        {
+          defendant: {
+            first_name: 'rob',
+            last_name: 'jim',
+            maat: '1234567',
+            date_of_birth: '1981-11-12'
+          },
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:client_detail]
+      end
+    end
+
+    context 'when client maat has changed' do
+      let(:changes) do
+        {
+          defendant: {
+            first_name: 'bob',
+            last_name: 'jim',
+            maat: 'AA2',
+            date_of_birth: '1981-11-12'
+          },
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:case_detail]
+      end
+    end
+
+    context 'when case detail has changed' do
+      let(:changes) { { main_offence_id: 'something_else' } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:case_detail]
+      end
+    end
+
+    context 'when hearing detail has changed for non-prison-law' do
+      let(:prison_law) { false }
+      let(:changes) { { plea: 'something_else' } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:hearing_detail]
+      end
+    end
+
+    context 'when next hearing detail has changed' do
+      let(:changes) { { next_hearing: false } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:next_hearing]
+      end
+    end
+
+    context 'when the application is prison law' do
+      let(:prison_law) { true }
+
+      context 'when hearing detail has changed' do
+        let(:changes) { { next_hearing: false, next_hearing_date: 1.month.from_now } }
+
+        it 'lists the change as next hearing' do
+          expect(listed_corrections).to eq [:next_hearing]
+        end
+      end
+    end
+
+    context 'when the application is NOT prison law' do
+      let(:prison_law) { false }
+
+      context 'when hearing detail has changed' do
+        let(:changes) { { next_hearing: false, next_hearing_date: 1.month.from_now } }
+
+        it 'lists the change as hearing detail' do
+          expect(listed_corrections).to eq [:hearing_detail]
+        end
+      end
+    end
+
+    context 'when primary quote has changed' do
+      let(:changes) do
+        {
+          quotes: [
+            primary_quote.merge(organisation: 'other'),
+            alternative_quote,
+            alternative_quote.merge(id: 'new-quote-id')
+          ]
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:primary_quote]
+      end
+    end
+
+    context 'when primary quote-related attribute has changed' do
+      let(:changes) { { service_type: 'other_service_type' } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:primary_quote]
+      end
+    end
+
+    context 'when additional costs have changed' do
+      let(:changes) { { additional_costs: [] } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:primary_quote]
+      end
+    end
+
+    context 'when reason why fields changed' do
+      let(:changes) do
+        {
+          supporting_documents: [
+            {
+              document_type: 'supporting_document',
+              file_name: 'test5.png',
+              file_path: 'test_path',
+              file_size: 1234,
+              file_type: 'image/png'
+            },
+          ],
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq [:reason_why]
+      end
+    end
+
+    context 'when alternative quote has changed' do
+      let(:changes) do
+        {
+          quotes: [
+            primary_quote,
+            alternative_quote.merge(period: 500),
+            alternative_quote.merge(id: 'new-quote-id')
+          ],
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq ['alternative_quote_1']
+      end
+    end
+
+    context 'when no alternative quote reason has changed' do
+      let(:changes) { { no_alternative_quote_reason: 'Some other reason' } }
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq ['alternative_quote_1']
+      end
+    end
+
+    context 'when alternative quote has been added' do
+      let(:changes) do
+        {
+          quotes: [primary_quote,
+                   alternative_quote],
+        }
+      end
+
+      it 'lists the change' do
+        expect(listed_corrections).to eq ['alternative_quote_2']
+      end
+    end
+  end
+end

--- a/spec/services/submit_to_app_store/payload_builder_spec.rb
+++ b/spec/services/submit_to_app_store/payload_builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SubmitToAppStore::PayloadBuilder do
 
     it 'delegates to NsmPayloadBuilder' do
       expect(SubmitToAppStore::PriorAuthorityPayloadBuilder).to(
-        receive(:new).with(application: submission, include_events: true).and_return(builder)
+        receive(:new).with(application: submission).and_return(builder)
       )
       subject
     end

--- a/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
+++ b/spec/services/submit_to_app_store/prior_authority/event_builder_spec.rb
@@ -3,178 +3,33 @@ require 'rails_helper'
 RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
   describe '.call' do
     let(:application) { create(:prior_authority_application, state:, prison_law:) }
-    let(:new_data) do
-      {
-        prison_law: prison_law,
-        ufn: '120423/123',
-        laa_reference: 'LAA-n4AohV',
-        status: 'pre_draft',
-        reason_why: 'something',
-        main_offence_id: 'something',
-        custom_main_offence_name: nil,
-        client_detained: true,
-        prison_id: 'something',
-        custom_prison_name: nil,
-        subject_to_poca: true,
-        next_hearing_date: '2024-01-16',
-        rep_order_date: nil,
-        plea: 'something',
-        court_type: 'central_criminal_court',
-        youth_court: true,
-        psychiatric_liaison: false,
-        psychiatric_liaison_reason_not: 'whatever you like',
-        next_hearing: true,
-        office_code: '1A123B',
-        service_type: 'pathologist_report',
-        custom_service_name: nil,
-        prior_authority_granted: false,
-        no_alternative_quote_reason: 'a reason',
-        defendant: {
-          first_name: 'bob',
-          last_name: 'jim',
-          maat: '1234567',
-          date_of_birth: '1981-11-12'
-        },
-        firm_office: {
-          account_number: '1A123B',
-          address_line_1: '2 Laywer Suite',
-          address_line_2: nil,
-          name: 'Firm A',
-          postcode: 'CR0 1RE',
-          town: 'Lawyer Town',
-          vat_registered: 'yes'
-        },
-        provider: {
-          description: nil,
-          email: 'provider@example.com'
-        },
-        solicitor: {
-          contact_email: 'james@email.com',
-          contact_first_name: 'James',
-          contact_last_name: 'James',
-          reference_number: '111222'
-        },
-        supporting_documents: [
-          {
-            document_type: 'supporting_document',
-            file_name: 'test.png',
-            file_path: 'test_path',
-            file_size: 1234,
-            file_type: 'image/png'
-          },
-          {
-            document_type: 'supporting_document',
-            file_name: 'test.png',
-            file_path: 'test_path',
-            file_size: 1234,
-            file_type: 'image/png'
-          }
-        ],
-        quotes: [primary_quote, alternative_quote, alternative_quote.merge(id: 'new-quote-id')],
-        additional_costs: [
-          {
-            id: '555555',
-            name: 'Some cost',
-            description: 'Some description',
-            unit_type: 'per_hour',
-            cost_per_hour: 150.0,
-            cost_per_item: nil,
-            items: nil,
-            period: 180,
-          }
-        ]
-      }
-    end
     let(:prison_law) { true }
+    let(:random_id) { 'random-id' }
 
-    let(:primary_quote) do
-      {
-        contact_first_name: 'Joe',
-        contact_last_name: 'Bloggs',
-        organisation: 'LAA',
-        postcode: 'CR0 1RE',
-        primary: true,
-        cost_type: 'per_hour',
-        cost_per_hour: '10.0',
-        period: 180,
-        cost_per_item: nil,
-        items: nil,
-        item_type: 'item',
-        ordered_by_court: nil,
-        related_to_post_mortem: true,
-        id: '123123123',
-        document: {
-          document_type: 'quote_document',
-          file_name: 'test.png',
-          file_path: 'test_path',
-          file_size: 1234,
-          file_type: 'image/png'
-        },
-        travel_cost_per_hour: '50.0',
-        travel_cost_reason: nil,
-        travel_time: 150,
-        additional_cost_list: nil,
-        additional_cost_total: nil,
-      }
-    end
-
-    let(:alternative_quote) do
-      {
-        contact_first_name: 'Joe',
-        contact_last_name: 'Bloggs',
-        organisation: 'LAA',
-        postcode: 'CR0 1RE',
-        primary: false,
-        cost_type: 'per_hour',
-        cost_per_hour: '10.0',
-        period: 180,
-        cost_per_item: nil,
-        items: nil,
-        item_type: 'item',
-        ordered_by_court: nil,
-        related_to_post_mortem: true,
-        id: '456456456',
-        document: nil,
-        travel_cost_per_hour: '50.0',
-        travel_cost_reason: nil,
-        travel_time: 150,
-        additional_cost_list: nil,
-        additional_cost_total: nil,
-      }
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(random_id)
     end
 
     context 'when application is in submitted state' do
       let(:state) { :submitted }
 
       it 'returns an empty array' do
-        expect(described_class.call(application, new_data)).to eq []
+        expect(described_class.call(application)).to eq []
       end
     end
 
     context 'when application is provider_updated' do
       let(:state) { :provider_updated }
-      let(:dummy_client) { instance_double(AppStoreClient) }
-      let(:old_data) { new_data.merge(changes).deep_stringify_keys }
-      let(:listed_corrections) { described_class.call(application, new_data).first.dig(:details, :corrected_info) }
-      let(:random_id) { 'random-id' }
-
-      before do
-        allow(AppStoreClient).to receive(:new).and_return(dummy_client)
-        allow(SecureRandom).to receive(:uuid).and_return(random_id)
-        allow(dummy_client).to receive(:get).and_return({ 'application' => old_data })
-      end
 
       context 'when application has not changed' do
-        let(:changes) { {} }
-
         it 'returns an event with no corrected info' do
-          expect(described_class.call(application, new_data)).to eq(
+          expect(described_class.call(application)).to eq(
             [
               {
                 id: random_id,
                 details: {
                   comment: nil,
-                  corrected_info: [],
+                  corrected_info: false,
                   documents: []
                 },
                 event_type: 'provider_updated'
@@ -185,7 +40,6 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
       end
 
       context 'when application has further information added' do
-        let(:changes) { {} }
         let(:application) do
           create(:prior_authority_application, :with_further_information_supplied,
                  app_store_updated_at: DateTime.now - 1.day,
@@ -194,13 +48,13 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
         let(:further_info_documents) { application.further_informations.order(:created_at).last.supporting_documents }
 
         it 'returns an event with further info comment' do
-          expect(described_class.call(application, new_data)).to eq(
+          expect(described_class.call(application)).to eq(
             [
               {
                 id: random_id,
                 details: {
                   comment: 'here is the extra information you requested',
-                  corrected_info: [],
+                  corrected_info: false,
                   documents: further_info_documents
                 },
                 event_type: 'provider_updated'
@@ -210,220 +64,15 @@ RSpec.describe SubmitToAppStore::PriorAuthority::EventBuilder do
         end
       end
 
-      context 'when ufn has changed' do
-        let(:changes) { { ufn: '120423/999' } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:ufn]
-        end
-      end
-
-      context 'when firm office detail has changed' do
-        let(:changes) do
-          {
-            firm_office: {
-              account_number: '1A123B',
-              address_line_1: '3 Laywer Suite',
-              address_line_2: nil,
-              name: 'Firm A',
-              postcode: 'CR0 1RE',
-              town: 'Lawyer Town',
-              vat_registered: 'yes'
-            }
-          }
+      context 'when a section has changed' do
+        let(:application) do
+          create(:prior_authority_application, :with_corrections,
+                 app_store_updated_at: DateTime.now - 1.day,
+                 state: state)
         end
 
         it 'lists the change' do
-          expect(listed_corrections).to eq [:case_contact]
-        end
-      end
-
-      context 'when solicitor detail has changed' do
-        let(:changes) do
-          {
-            solicitor: {
-              contact_email: 'james@email.com',
-              contact_first_name: 'James',
-              contact_last_name: 'Rake',
-              reference_number: '111222'
-            },
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:case_contact]
-        end
-      end
-
-      context 'when client non-maat detail has changed' do
-        let(:changes) do
-          {
-            defendant: {
-              first_name: 'rob',
-              last_name: 'jim',
-              maat: '1234567',
-              date_of_birth: '1981-11-12'
-            },
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:client_detail]
-        end
-      end
-
-      context 'when client maat has changed' do
-        let(:changes) do
-          {
-            defendant: {
-              first_name: 'bob',
-              last_name: 'jim',
-              maat: 'AA2',
-              date_of_birth: '1981-11-12'
-            },
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:case_detail]
-        end
-      end
-
-      context 'when case detail has changed' do
-        let(:changes) { { main_offence_id: 'something_else' } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:case_detail]
-        end
-      end
-
-      context 'when hearing detail has changed for non-prison-law' do
-        let(:prison_law) { false }
-        let(:changes) { { plea: 'something_else' } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:hearing_detail]
-        end
-      end
-
-      context 'when next hearing detail has changed' do
-        let(:changes) { { next_hearing: false } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:next_hearing]
-        end
-      end
-
-      context 'when the application is prison law' do
-        let(:prison_law) { true }
-
-        context 'when hearing detail has changed' do
-          let(:changes) { { next_hearing: false, next_hearing_date: 1.month.from_now } }
-
-          it 'lists the change as next hearing' do
-            expect(listed_corrections).to eq [:next_hearing]
-          end
-        end
-      end
-
-      context 'when the application is NOT prison law' do
-        let(:prison_law) { false }
-
-        context 'when hearing detail has changed' do
-          let(:changes) { { next_hearing: false, next_hearing_date: 1.month.from_now } }
-
-          it 'lists the change as hearing detail' do
-            expect(listed_corrections).to eq [:hearing_detail]
-          end
-        end
-      end
-
-      context 'when primary quote has changed' do
-        let(:changes) do
-          {
-            quotes: [
-              primary_quote.merge(organisation: 'other'),
-              alternative_quote,
-              alternative_quote.merge(id: 'new-quote-id')
-            ]
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:primary_quote]
-        end
-      end
-
-      context 'when primary quote-related attribute has changed' do
-        let(:changes) { { service_type: 'other_service_type' } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:primary_quote]
-        end
-      end
-
-      context 'when additional costs have changed' do
-        let(:changes) { { additional_costs: [] } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:primary_quote]
-        end
-      end
-
-      context 'when reason why fields changed' do
-        let(:changes) do
-          {
-            supporting_documents: [
-              {
-                document_type: 'supporting_document',
-                file_name: 'test5.png',
-                file_path: 'test_path',
-                file_size: 1234,
-                file_type: 'image/png'
-              },
-            ],
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq [:reason_why]
-        end
-      end
-
-      context 'when alternative quote has changed' do
-        let(:changes) do
-          {
-            quotes: [
-              primary_quote,
-              alternative_quote.merge(period: 500),
-              alternative_quote.merge(id: 'new-quote-id')
-            ],
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq ['alternative_quote_1']
-        end
-      end
-
-      context 'when no alternative quote reason has changed' do
-        let(:changes) { { no_alternative_quote_reason: 'Some other reason' } }
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq ['alternative_quote_1']
-        end
-      end
-
-      context 'when alternative quote has been added' do
-        let(:changes) do
-          {
-            quotes: [primary_quote,
-                     alternative_quote],
-          }
-        end
-
-        it 'lists the change' do
-          expect(listed_corrections).to eq ['alternative_quote_2']
+          expect(described_class.call(application).first.dig(:details, :corrected_info)).to be(true)
         end
       end
     end

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe 'View applications', :stub_oauth_token do
   let(:arbitrary_fixed_date) { DateTime.new(2024, 3, 22, 15, 23, 11) }
   let(:data) do
     data = SubmitToAppStore::PriorAuthorityPayloadBuilder.new(
-      application: application,
-      include_events: false
+      application:
     ).payload.merge(last_updated_at: application.app_store_updated_at)
     data[:application][:assessment_comment] = application.assessment_comment
     data


### PR DESCRIPTION
## Description of change
"Events" are getting simpler. We don't need them to list what sections have changed. All we need is for `corrected_info` to be truthy if the provider responded to a request for corrections, and falsey if it was just a request for further info. This allows us to simplify the code somewhat. 

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2217)
