### PR TITLE
CRM457-2273: If validation fails, calculation should not explode

### DIFF
--- a/app/models/concerns/letters_and_calls_costs.rb
+++ b/app/models/concerns/letters_and_calls_costs.rb
@@ -83,9 +83,9 @@ module LettersAndCallsCosts
     {
       type: :calls,
       claimed_items: calls.to_i || 0,
-      claimed_uplift_percentage: apply_calls_uplift ? calls_uplift : 0,
+      claimed_uplift_percentage: apply_calls_uplift ? calls_uplift.to_i : 0,
       assessed_items: application.allowed_calls || calls || 0,
-      assessed_uplift_percentage: application.allowed_calls_uplift || calls_uplift,
+      assessed_uplift_percentage: application.allowed_calls_uplift || calls_uplift.to_i,
     }
   end
 
@@ -93,9 +93,9 @@ module LettersAndCallsCosts
     {
       type: :letters,
       claimed_items: letters.to_i || 0,
-      claimed_uplift_percentage: apply_letters_uplift ? letters_uplift : 0,
+      claimed_uplift_percentage: apply_letters_uplift ? letters_uplift.to_i : 0,
       assessed_items: application.allowed_letters || letters || 0,
-      assessed_uplift_percentage: application.allowed_letters_uplift || letters_uplift,
+      assessed_uplift_percentage: application.allowed_letters_uplift || letters_uplift.to_i,
     }
   end
 

--- a/spec/forms/nsm/steps/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/steps/letters_calls_form_spec.rb
@@ -395,6 +395,23 @@ RSpec.describe Nsm::Steps::LettersCallsForm do
         end
       end
 
+      context 'when uplift is required but values are invalid' do
+        let(:letters_uplift) { 'zero' }
+        let(:calls_uplift) { 'lots' }
+
+        it 'returns the values without error' do
+          expect(subject.calculation_rows).to eq(
+            [['Items', 'Before uplift', 'After uplift'],
+             ['Letters',
+              { html_attributes: { id: 'letters-without-uplift' }, text: '£8.18' },
+              { html_attributes: { id: 'letters-with-uplift' }, text: '£8.18' }],
+             ['Phone calls',
+              { html_attributes: { id: 'calls-without-uplift' }, text: '£4.09' },
+              { html_attributes: { id: 'calls-with-uplift' }, text: '£4.09' }]]
+          )
+        end
+      end
+
       context 'when uplift is required and values are set' do
         it 'returns the values' do
           expect(subject.calculation_rows).to eq(


### PR DESCRIPTION
## Description of change
If the form fails validation, invalid number attributes may be held as strings (so we can accurately pre-populate the relevant field with the exact wrong input the user provided). But we will still be calling the calculator with the form values we have. To avoid it exploding, we `to_i` the values, so that if they are strings they will be treated as zeroes for the purposes of the calculation.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2273)
