### PR TITLE
CRM457-2338: Add functionality to clone claims & applications

### DIFF
--- a/app/controllers/concerns/claim_creatable.rb
+++ b/app/controllers/concerns/claim_creatable.rb
@@ -1,5 +1,6 @@
 module ClaimCreatable
   extend ActiveSupport::Concern
+  include GeneratesLaaReference
 
   def initialize_application(&block)
     attributes = {
@@ -8,12 +9,5 @@ module ClaimCreatable
       laa_reference: generate_laa_reference
     }
     Claim.create!(attributes).tap(&block)
-  end
-
-  def generate_laa_reference
-    loop do
-      random_reference = "LAA-#{SecureRandom.alphanumeric(6)}"
-      break random_reference unless Claim.exists?(laa_reference: random_reference)
-    end
   end
 end

--- a/app/controllers/concerns/cloneable.rb
+++ b/app/controllers/concerns/cloneable.rb
@@ -1,0 +1,9 @@
+module Cloneable
+  include GeneratesLaaReference
+
+  def clone_application
+    current_application.deep_dup.tap do |new_application|
+      new_application.laa_reference = generate_laa_reference
+    end
+  end
+end

--- a/app/controllers/concerns/generates_laa_reference.rb
+++ b/app/controllers/concerns/generates_laa_reference.rb
@@ -1,0 +1,11 @@
+module GeneratesLaaReference
+  def generate_laa_reference
+    ActiveRecord::Base.transaction do
+      self.class.model_class.lock
+      loop do
+        random_reference = "LAA-#{SecureRandom.alphanumeric(6)}"
+        break random_reference unless self.class.model_class.exists?(laa_reference: random_reference)
+      end
+    end
+  end
+end

--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -2,6 +2,7 @@ module Nsm
   class ClaimsController < ApplicationController
     include Searchable
     include ClaimCreatable
+    include Cloneable
     layout 'nsm'
 
     before_action :set_scope, only: %i[submitted draft]
@@ -41,6 +42,17 @@ module Nsm
       @model = Claim.for(current_provider).find(params[:id])
       @model.destroy
       redirect_to draft_nsm_applications_path, flash: { success: t('.deleted') }
+    end
+
+    def clone
+      clone = clone_application
+      clone.save
+
+      redirect_to nsm_steps_start_page_path(clone.id), flash: { success: t('.cloned') }
+    end
+
+    def self.model_class
+      Claim
     end
 
     private

--- a/app/controllers/nsm/imports_controller.rb
+++ b/app/controllers/nsm/imports_controller.rb
@@ -23,5 +23,9 @@ module Nsm
         render :new
       end
     end
+
+    def self.model_class
+      Claim
+    end
   end
 end

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -1,6 +1,8 @@
 module PriorAuthority
   class ApplicationsController < ApplicationController
     include Searchable
+    include Cloneable
+
     before_action :set_scope, only: %i[submitted drafts]
     before_action :set_default_table_sort_options
     layout 'prior_authority'
@@ -56,6 +58,17 @@ module PriorAuthority
       send_data pdf,
                 filename: "#{current_application.laa_reference}.pdf",
                 type: 'application/pdf'
+    end
+
+    def clone
+      clone = clone_application
+      clone.save
+
+      redirect_to prior_authority_steps_start_page_path(clone.id), flash: { success: t('.cloned') }
+    end
+
+    def self.model_class
+      PriorAuthorityApplication
     end
 
     private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -74,6 +74,15 @@ class Claim < ApplicationRecord
     defendants.where(main: false)
   end
 
+  def dup
+    super.tap do |new_record|
+      new_record.defendants = defendants.map(&:dup)
+      new_record.work_items = work_items.map(&:dup)
+      new_record.disbursements = disbursements.map(&:dup)
+      new_record.supporting_evidence = supporting_evidence.map(&:dup)
+    end
+  end
+
   private
 
   def sorted_work_item_ids

--- a/app/models/firm_office.rb
+++ b/app/models/firm_office.rb
@@ -1,2 +1,3 @@
 class FirmOffice < ApplicationRecord
+  has_many :prior_authority_applications, dependent: :destroy
 end

--- a/app/models/firm_office.rb
+++ b/app/models/firm_office.rb
@@ -1,3 +1,4 @@
 class FirmOffice < ApplicationRecord
-  has_many :prior_authority_applications, dependent: :destroy
+  has_one :prior_authority_applications, dependent: :destroy
+  has_one :claims, dependent: :destroy
 end

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -51,4 +51,17 @@ class PriorAuthorityApplication < ApplicationRecord
   def pending_incorrect_information
     incorrect_informations.where(created_at: app_store_updated_at..).order(:created_at).last
   end
+
+  def dup
+    super.tap do |new_record|
+      new_record.defendant = defendant.dup if defendant.present?
+      new_record.quotes = quotes.map(&:dup)
+
+      new_record.supporting_documents = supporting_documents.map(&:dup)
+
+      new_record.additional_costs = additional_costs.map(&:dup)
+      new_record.further_informations = further_informations.map(&:dup)
+      new_record.incorrect_informations = incorrect_informations.map(&:dup)
+    end
+  end
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -32,4 +32,10 @@ class Quote < ApplicationRecord
   def contact_full_name
     "#{contact_first_name} #{contact_last_name}"
   end
+
+  def dup
+    super.tap do |quote|
+      quote.build_document(document.dup.attributes) if document.present?
+    end
+  end
 end

--- a/app/models/solicitor.rb
+++ b/app/models/solicitor.rb
@@ -1,4 +1,7 @@
 class Solicitor < ApplicationRecord
+  has_one :prior_authority_applications, dependent: :destroy
+  has_one :claims, dependent: :destroy
+
   def contact_full_name
     "#{contact_first_name} #{contact_last_name}"
   end

--- a/app/views/nsm/claims/index.html.erb
+++ b/app/views/nsm/claims/index.html.erb
@@ -139,6 +139,16 @@
               <td class="govuk-table__cell"><%= claim.laa_reference %></td>
               <% if @scope == :draft %>
                 <td class="govuk-table__cell">
+                  <% if !HostEnv.production? %>
+                    <%= link_to clone_nsm_application_path(claim.id), class: "govuk-link--no-visited-state" do %>
+                      <%= t(".clone") %>
+                      <span class="govuk-visually-hidden">
+                        <%= t(".claim") %>
+                        <%= claim.laa_reference %>
+                      </span>
+                    <% end %>
+                    &nbsp;
+                  <% end %>
                   <%= link_to confirm_delete_nsm_application_path(claim), class: "govuk-link--no-visited-state" do %>
                     <%= t(".delete") %>
                     <span class="govuk-visually-hidden">

--- a/app/views/prior_authority/applications/_drafts.html.erb
+++ b/app/views/prior_authority/applications/_drafts.html.erb
@@ -41,6 +41,16 @@
               <%= application.laa_reference %>
             </td>
             <td class="govuk-table__cell">
+              <% if !HostEnv.production? %>
+                <%= link_to clone_prior_authority_application_path(application.id), class: "govuk-link--no-visited-state" do %>
+                  <%= t("prior_authority.applications.tabs.clone") %>
+                  <span class="govuk-visually-hidden">
+                  <%= t(".application") %>
+                    <%= application.laa_reference %>
+                  </span>
+                <% end %>
+                &nbsp;
+              <% end %>
               <%= link_to confirm_delete_prior_authority_application_path(application), class: "govuk-link--no-visited-state" do %>
                 <%= t("prior_authority.applications.tabs.delete") %>
                 <span class="govuk-visually-hidden">

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -10,6 +10,7 @@ en:
         import_claim: Import a claim
         table_info_item: claims
         delete: Delete
+        clone: Clone
         claim: claim
         header:
           ufn: UFN
@@ -55,3 +56,5 @@ en:
         no_undo: You cannot undo this action
       destroy:
         deleted: You deleted the claim
+      clone:
+        cloned: Claim cloned successfully

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -19,6 +19,8 @@ en:
       expired: Expired
       provider_updated: Resubmitted
     applications:
+      clone:
+        cloned: Application cloned successfully
       reviewed:
         page_title: Reviewed
       submitted:
@@ -35,6 +37,7 @@ en:
           submitted: Submitted
           reviewed: Reviewed
       tabs:
+        clone: Clone
         drafts: Drafts
         submitted: Submitted
         reviewed: Reviewed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,9 @@ Rails.application.routes.draw do
         get 'offboard'
         get :confirm_delete, path: 'confirm-delete'
         get :download
+        constraints ->(_req) { !HostEnv.production? } do
+          get :clone
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,9 @@ Rails.application.routes.draw do
       member do
         get :delete
         get :confirm_delete, path: 'confirm-delete'
+        constraints ->(_req) { !HostEnv.production? } do
+          get :clone
+        end
       end
     end
 

--- a/spec/controllers/nsm/claims_controller_spec.rb
+++ b/spec/controllers/nsm/claims_controller_spec.rb
@@ -57,6 +57,45 @@ RSpec.describe Nsm::ClaimsController do
     end
   end
 
+  context 'clone' do
+    let(:claim) { create(:claim, :complete, :as_draft) }
+    # Ignore fields that `dup` doesn't handle, as well as fields that won't get duplicated
+    # We also have to ignore `viewed_steps` as we redirect to the start page after cloning
+    let(:ignored_attrs) { %w[id created_at updated_at core_search_fields laa_reference viewed_steps] }
+
+    before do
+      claim.save
+    end
+
+    it 'can clone an application' do
+      expect(Claim.count).to eq(1)
+
+      get :clone, params: { id: claim.id }
+
+      expect(Claim.count).to eq(2)
+
+      expected = Claim.first.attributes.except(*ignored_attrs)
+      actual = Claim.second.attributes.except(*ignored_attrs)
+
+      expect(expected).to eq(actual)
+    end
+
+    context 'when the app is in production' do
+      before do
+        allow(HostEnv).to receive(:env_name).and_return('production')
+        Rails.application.reload_routes!
+      end
+
+      routes do
+        ActionDispatch::Routing::RouteSet.new_with_config(Rails.application.config)
+      end
+
+      it 'returns a 404' do
+        expect(get: "/non-standard-magistrates/claims/#{claim.id}/clone").not_to be_routable
+      end
+    end
+  end
+
   context 'generate LAA reference' do
     it 'generates reference starting with: LAA- and ending in 6 alphanumeric' do
       expect(subject.send(:generate_laa_reference)).to match(/LAA-[A-Za-z0-9]+/)

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -39,6 +39,12 @@ FactoryBot.define do
       has_disbursements { 'no' }
     end
 
+    Claim.states.each_key do |state|
+      trait :"as_#{state}" do
+        state { state }
+      end
+    end
+
     trait :complete do
       claim_details
       full_firm_details

--- a/spec/factories/prior_authority_application.rb
+++ b/spec/factories/prior_authority_application.rb
@@ -19,6 +19,12 @@ FactoryBot.define do
       primary_quotes { build_list(:quote, 1, :primary, service_type_cost_type) }
     end
 
+    PriorAuthorityApplication.states.each_key do |state|
+      trait :"as_#{state}" do
+        state { state }
+      end
+    end
+
     trait :with_firm_and_solicitor do
       firm_office factory: %i[firm_office valid_pa]
       solicitor factory: %i[solicitor full_pa]

--- a/spec/models/quote_spec.rb
+++ b/spec/models/quote_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe Quote do
       end
     end
   end
+
+  describe '#clone' do
+    let(:attributes) { { document: nil } }
+
+    it 'does not duplicate the nil document' do
+      expect(subject.dup.document).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Allows draft claims and draft applications to be cloned when not in
production (since it's mostly for testing) and also resolve some
incorrect `dependent` calls for `belongs_to` models that shouldn't
have it.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2338)