### PR TITLE
CRM457-2352: Renumber defendants on deletion

### DIFF
--- a/app/forms/nsm/steps/defendant_delete_form.rb
+++ b/app/forms/nsm/steps/defendant_delete_form.rb
@@ -15,6 +15,9 @@ module Nsm
 
       def persist!
         record.destroy
+        application.defendants.order(:position).each_with_index do |defendant, index|
+          defendant.update!(position: index + 1)
+        end
       end
     end
   end

--- a/spec/forms/nsm/steps/defendants_delete_form_spec.rb
+++ b/spec/forms/nsm/steps/defendants_delete_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Nsm::Steps::DefendantDeleteForm do
     }
   end
 
-  let(:application) { instance_double(Claim,) }
+  let(:application) { instance_double(Claim, defendants: []) }
   let(:record) { instance_double(Defendant, id:, main:) }
   let(:id) { SecureRandom.uuid }
   let(:main) { false }
@@ -32,6 +32,23 @@ RSpec.describe Nsm::Steps::DefendantDeleteForm do
     it 'deletes the selected record' do
       expect(record).to receive(:destroy)
       subject.save!
+    end
+
+    context 'when there are multiple defendants' do
+      let(:application) { create(:claim, defendants:) }
+      let(:defendants) { [tom, dick, harry, sally] }
+      let(:record) { dick }
+      let(:tom) { build(:defendant, :valid, position: 1) }
+      let(:dick) { build(:defendant, :additional, position: 2) }
+      let(:harry) { build(:defendant, :additional, position: 3) }
+      let(:sally) { build(:defendant, :additional, position: 4) }
+
+      it 'renumbers remaining defendants' do
+        form.save!
+        expect(tom.reload.position).to eq 1
+        expect(harry.reload.position).to eq 2
+        expect(sally.reload.position).to eq 3
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2352)

## Notes for reviewer
I know we have a more complicated system for work items and disbursement line item numbers, but thinking about it, it really doesn't need to be complicated for defendants, given there will almost always be a very small number of them - this all takes place in a lock and it's quick and easy to renumber as needed.
