### PR TITLE
Remove multi form gem: Remove dead references to /gem folder and adjust some comments (CRM457-2353)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,6 @@ AllCops:
     - 'lib/generators/**/*'
     - 'features/**/*'
     - 'vendor/**/*'
-    - 'gems/laa_multi_step_forms/spec/dummy/**/*'
     - 'tmp/**/*'
     - 'node_modules/**/*'
 

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,2 @@
-sonar.sources=app, lib, gems/laa_multi_step_forms/app, gems/laa_multi_step_forms/lib
-sonar.tests=spec, gems/laa_multi_step_forms/spec
+sonar.sources=app, lib
+sonar.tests=spec

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,7 @@ import { convertSelectToAutocomplete } from "./autocomplete.js";
 
 initAll();
 
-// Most of this Turbo setup code is needed for the multi-form gem
+// Most of this Turbo setup code is needed for the multi-form capabilities
 Turbo.setFormMode("optin");
 Turbo.session.drive = false;
 

--- a/app/presenters/nsm/tasks/base.rb
+++ b/app/presenters/nsm/tasks/base.rb
@@ -5,7 +5,7 @@ module Nsm
 
       # If I complete sections A, B and C, then go back and change section A,
       # `prune_viewed_steps` will remove B and C from the stack.
-      # The default behaviour in the gem is to mark B and C as not yet started,
+      # The default behaviour in the multi form system is to mark B and C as not yet started,
       # even though we have actually completed them. The desired behaviour is
       # to mark B as in progress and C as 'Cannot start yet'.
       # To achieve this, we need to loosen the definition of `in_progress?`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'webmock/rspec'
 
 SimpleCov.start 'rails' do
   add_filter 'spec/'
-  add_filter 'gems/'
   add_filter 'config/'
   add_filter 'lib/tasks/'
 


### PR DESCRIPTION
## Description of change
Results of investigation on code after gem was removed to ensure no other issues are still present

Addresses some of [Clean up Rubocop setup](https://dsdmoj.atlassian.net/browse/CRM457-2353)