### PR TITLE
CRM457-2262: Use v1 endpoint for provider user office codes

### DIFF
--- a/app/services/office_code_service.rb
+++ b/app/services/office_code_service.rb
@@ -1,8 +1,8 @@
 class OfficeCodeService
   class << self
-    def call(username, api_version = nil)
-      office_details = ProviderDataApiClient.user_office_details(username, api_version)
-      if api_version == 1
+    def call(username)
+      office_details = ProviderDataApiClient.user_office_details(username)
+      if FeatureFlags.provider_api_v1.enabled?
         office_details.map { _1['officeCodes'].pluck('firmOfficeCode') }.flatten
       else
         office_details.pluck('firmOfficeCode')

--- a/app/services/office_code_service.rb
+++ b/app/services/office_code_service.rb
@@ -1,8 +1,12 @@
 class OfficeCodeService
   class << self
-    def call(username)
-      office_details = ProviderDataApiClient.user_office_details(username)
-      office_details.pluck('firmOfficeCode')
+    def call(username, api_version = nil)
+      office_details = ProviderDataApiClient.user_office_details(username, api_version)
+      if api_version == 1
+        office_details.map { _1['officeCodes'].pluck('firmOfficeCode') }.flatten
+      else
+        office_details.pluck('firmOfficeCode')
+      end
     end
   end
 end

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -8,8 +8,8 @@ class ProviderDataApiClient
       )
     end
 
-    def user_office_details(user_login, api_version = nil)
-      if api_version == 1
+    def user_office_details(user_login)
+      if FeatureFlags.provider_api_v1.enabled?
         query(
           "api/v1/provider-users/#{ERB::Util.url_encode(user_login)}/provider-offices",
           200 => ->(data) { data['offices'] },

--- a/app/services/provider_data_api_client.rb
+++ b/app/services/provider_data_api_client.rb
@@ -8,12 +8,20 @@ class ProviderDataApiClient
       )
     end
 
-    def user_office_details(user_login)
-      query(
-        "provider-users/#{ERB::Util.url_encode(user_login)}/provider-offices",
-        200 => ->(data) { data['officeCodes'] },
-        204 => [],
-      )
+    def user_office_details(user_login, api_version = nil)
+      if api_version == 1
+        query(
+          "api/v1/provider-users/#{ERB::Util.url_encode(user_login)}/provider-offices",
+          200 => ->(data) { data['offices'] },
+          204 => [],
+        )
+      else
+        query(
+          "provider-users/#{ERB::Util.url_encode(user_login)}/provider-offices",
+          200 => ->(data) { data['officeCodes'] },
+          204 => [],
+        )
+      end
     end
 
     private

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -19,3 +19,8 @@ feature_flags:
     development: false
     uat: false
     production: false
+  provider_api_v1:
+    local: <%= ENV.fetch("PROVIDER_API_V1", true) %>
+    development: true
+    uat: true
+    production: false

--- a/spec/services/office_code_service_spec.rb
+++ b/spec/services/office_code_service_spec.rb
@@ -43,6 +43,37 @@ RSpec.describe OfficeCodeService do
     end
   end
 
+  context 'when using v1 endpoint' do
+    subject { described_class.call(user_login, 1) }
+
+    let(:user_offices_endpoint) { 'https://provider-api.example.com/api/v1/provider-users/LOGIN/provider-offices' }
+    let(:populated_code_payload) do
+      { offices: [
+        {
+          'officeCodes' => [
+            { 'firmOfficeCode' => 'AAAAAA' },
+            { 'firmOfficeCode' => 'BBBBBB' }
+          ]
+        },
+        {
+          'officeCodes' => [
+            { 'firmOfficeCode' => 'CCCCCC' },
+            { 'firmOfficeCode' => 'DDDDDD' }
+          ]
+        }
+      ] }.to_json
+    end
+    let(:populated_codes) { %w[AAAAAA BBBBBB CCCCCC DDDDDD] }
+
+    before do
+      stub_request(:get, user_offices_endpoint).to_return(status: 200, body: populated_code_payload, headers: headers)
+    end
+
+    it 'retrieves office codes from the provider data API in 2 steps' do
+      expect(subject).to eq populated_codes
+    end
+  end
+
   context 'when endpoint call errors' do
     before do
       stub_request(:get, user_offices_endpoint).to_return(status: 500)

--- a/spec/services/office_code_service_spec.rb
+++ b/spec/services/office_code_service_spec.rb
@@ -22,9 +22,11 @@ RSpec.describe OfficeCodeService do
   let(:headers) { { 'Content-type' => 'application/json' } }
   let(:user_offices_endpoint) { 'https://provider-api.example.com/provider-users/LOGIN/provider-offices' }
   let(:populated_codes) { %w[AAAAAA BBBBBB] }
+  let(:v1_enabled) { false }
 
   context 'when all is working correctly' do
     before do
+      allow(FeatureFlags).to receive(:provider_api_v1).and_return(double(:provider_api_v1, enabled?: v1_enabled))
       stub_request(:get, user_offices_endpoint).to_return(status: 200, body: populated_code_payload, headers: headers)
     end
 
@@ -35,6 +37,7 @@ RSpec.describe OfficeCodeService do
 
   context 'when user has no office codes' do
     before do
+      allow(FeatureFlags).to receive(:provider_api_v1).and_return(double(:provider_api_v1, enabled?: v1_enabled))
       stub_request(:get, user_offices_endpoint).to_return(status: 204, headers: headers)
     end
 
@@ -44,8 +47,7 @@ RSpec.describe OfficeCodeService do
   end
 
   context 'when using v1 endpoint' do
-    subject { described_class.call(user_login, 1) }
-
+    let(:v1_enabled) { true }
     let(:user_offices_endpoint) { 'https://provider-api.example.com/api/v1/provider-users/LOGIN/provider-offices' }
     let(:populated_code_payload) do
       { offices: [
@@ -66,6 +68,7 @@ RSpec.describe OfficeCodeService do
     let(:populated_codes) { %w[AAAAAA BBBBBB CCCCCC DDDDDD] }
 
     before do
+      allow(FeatureFlags).to receive(:provider_api_v1).and_return(double(:provider_api_v1, enabled?: v1_enabled))
       stub_request(:get, user_offices_endpoint).to_return(status: 200, body: populated_code_payload, headers: headers)
     end
 
@@ -76,6 +79,7 @@ RSpec.describe OfficeCodeService do
 
   context 'when endpoint call errors' do
     before do
+      allow(FeatureFlags).to receive(:provider_api_v1).and_return(double(:provider_api_v1, enabled?: v1_enabled))
       stub_request(:get, user_offices_endpoint).to_return(status: 500)
     end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2262)

## Notes for reviewer
I want to do a test run in UAT before enabling this in production, so production feature flag is off for now 

[Old endpoint
](https://laa-provider-details-api-prod.apps.live.cloud-platform.service.justice.gov.uk/swagger-ui/index.html#/Provider%20Users%20Endpoints/getProviderUsersOffices)
[New endpoint](https://laa-provider-details-api-prod.apps.live.cloud-platform.service.justice.gov.uk/swagger-ui/index.html?urls.primaryName=V1#/Provider%20Users%20Endpoints/getProviderUsersOfficesV1)