### PR TITLE
CRM457-2430: Provider: Disbursement Sorting on Type Breaks

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -112,7 +112,7 @@ class Claim < ApplicationRecord
     @sorted_disbursement_ids ||= disbursements.sort_by do |disb|
       [
         disb.disbursement_date || Time.new(2000, 1, 1).in_time_zone.to_date,
-        disb.translated_disbursement_type&.downcase,
+        disb.translated_disbursement_type.downcase,
         disb.created_at
       ]
     end.map(&:id)

--- a/app/models/concerns/disbursement_details.rb
+++ b/app/models/concerns/disbursement_details.rb
@@ -6,9 +6,8 @@ module DisbursementDetails
   end
 
   def translated_disbursement_type
+    return '' if other_type.nil? && disbursement_type.nil?
     if disbursement_type == DisbursementTypes::OTHER.to_s
-      return '' if other_type.nil?
-
       # rubocop:disable Performance/InefficientHashSearch
       # (False positive - Rubocop sees `.values` and wrongly infers OtherDisbursementTypes is a hash)
       known_other = OtherDisbursementTypes.values.include?(OtherDisbursementTypes.new(other_type))

--- a/app/models/concerns/disbursement_details.rb
+++ b/app/models/concerns/disbursement_details.rb
@@ -7,6 +7,8 @@ module DisbursementDetails
 
   def translated_disbursement_type
     if disbursement_type == DisbursementTypes::OTHER.to_s
+      return '' if other_type.nil?
+
       # rubocop:disable Performance/InefficientHashSearch
       # (False positive - Rubocop sees `.values` and wrongly infers OtherDisbursementTypes is a hash)
       known_other = OtherDisbursementTypes.values.include?(OtherDisbursementTypes.new(other_type))

--- a/app/models/concerns/disbursement_details.rb
+++ b/app/models/concerns/disbursement_details.rb
@@ -7,6 +7,7 @@ module DisbursementDetails
 
   def translated_disbursement_type
     return '' if other_type.nil? && disbursement_type.nil?
+
     if disbursement_type == DisbursementTypes::OTHER.to_s
       # rubocop:disable Performance/InefficientHashSearch
       # (False positive - Rubocop sees `.values` and wrongly infers OtherDisbursementTypes is a hash)

--- a/app/models/concerns/disbursement_details.rb
+++ b/app/models/concerns/disbursement_details.rb
@@ -6,8 +6,6 @@ module DisbursementDetails
   end
 
   def translated_disbursement_type
-    return '' if other_type.nil? && disbursement_type.nil?
-
     if disbursement_type == DisbursementTypes::OTHER.to_s
       # rubocop:disable Performance/InefficientHashSearch
       # (False positive - Rubocop sees `.values` and wrongly infers OtherDisbursementTypes is a hash)
@@ -18,6 +16,8 @@ module DisbursementDetails
       other_type
     elsif disbursement_type
       I18n.t("laa_crime_forms_common.nsm.disbursement_type.#{disbursement_type}")
+    else
+      ''
     end
   end
 

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -27,5 +27,11 @@ RSpec.describe Disbursement do
 
       it { expect(subject.translated_disbursement_type).to eq('Custom') }
     end
+
+    context 'when other type but undefined' do
+      let(:attributes) { { disbursement_type: 'other', other_type: nil } }
+
+      it { expect(subject.translated_disbursement_type).to eq('') }
+    end
   end
 end

--- a/spec/models/disbursement_spec.rb
+++ b/spec/models/disbursement_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Disbursement do
     context 'when not set' do
       let(:attributes) { { disbursement_type: nil } }
 
-      it { expect(subject.translated_disbursement_type).to be_nil }
+      it { expect(subject.translated_disbursement_type).to eq('') }
     end
 
     context 'when standard type' do

--- a/spec/system/nsm/disbursements_spec.rb
+++ b/spec/system/nsm/disbursements_spec.rb
@@ -256,6 +256,42 @@ RSpec.describe 'User can manage disbursements', type: :system do
     expect(page).not_to have_content 'You cannot save and continue if any disbursements are incomplete'
   end
 
+  it 'can add a mix of complete and incomplete disbursements' do
+    visit edit_nsm_steps_disbursement_add_path(claim.id)
+    choose 'Yes'
+
+    click_on 'Save and continue'
+
+    within('.govuk-fieldset', text: 'Date') do
+      fill_in 'Day', with: '20'
+      fill_in 'Month', with: '4'
+      fill_in 'Year', with: '2023'
+    end
+
+    choose 'Car'
+    click_on 'Save and continue'
+
+    fill_in 'Number of miles', with: 100
+    fill_in 'Enter details of this disbursement', with: 'details'
+
+    expect(page).to have_content 'Do you need to add another disbursement?'
+    choose 'Yes'
+
+    click_on 'Save and continue'
+
+    within('.govuk-fieldset', text: 'Date') do
+      fill_in 'Day', with: '20'
+      fill_in 'Month', with: '4'
+      fill_in 'Year', with: '2023'
+    end
+
+    click_on 'Save and come back later'
+
+    click_on 'Disbursements costs'
+
+    expect(page).to have_content 'Summary of Disbursements'
+  end
+
   context 'when disbursements exist' do
     before { visit edit_nsm_steps_disbursements_path(claim.id) }
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2430)

- Protect translated_disbursement_type method from returning nil
- Add additional testing to cover previously broken scenario

