### PR TITLE
Add hint text to clarify how multiple rates should be submitted

### DIFF
--- a/app/views/prior_authority/steps/service_cost/_cost_fields.html.erb
+++ b/app/views/prior_authority/steps/service_cost/_cost_fields.html.erb
@@ -1,3 +1,5 @@
+<p><%= t(".multiple_rates") %></p>
+
 <% if @form_object.variable_cost_type? %>
   <%= form.govuk_radio_buttons_fieldset :user_chosen_cost_type, legend: { text: t('.user_chosen_cost_type'), size: 's' } do %>
     <%= form.govuk_radio_button :user_chosen_cost_type, @form_object.class::PER_ITEM, label: { text: t('.per_item') }, link_errors: true do %>

--- a/config/locales/en/prior_authority/steps.yml
+++ b/config/locales/en/prior_authority/steps.yml
@@ -118,6 +118,7 @@ en:
           related_to_post_mortem: Is this related to a post-mortem?
           total_cost: Total cost
         cost_fields:
+          multiple_rates: If there are multiple rates, enter one here and add the others as additional costs.
           user_chosen_cost_type: How are you being charged?
           per_item: Charged per item
           per_hour: Charged by the hour


### PR DESCRIPTION
## Description of change

Include extra hint text to clarify how multiple rates should be submitted as per the [prototype](https://crmfour-proto-main.apps.live.cloud-platform.service.justice.gov.uk/latest-pa/provider/form/question3-quote-prep?serviceType=Transcription).

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2390)