### PR TITLE
[CRM457-2443] add enhanced_rates_claimed if claim has uplift

### DIFF
--- a/app/services/nsm/importers/xml/v1/crm7_claim.xsd
+++ b/app/services/nsm/importers/xml/v1/crm7_claim.xsd
@@ -135,7 +135,6 @@
   <xs:simpleType name="reasonForClaimType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="core_costs_exceed_higher_limit"/>
-      <xs:enumeration value="enhanced_rates_claimed"/>
       <xs:enumeration value="counsel_or_agent_assigned"/>
       <xs:enumeration value="representation_order_withdrawn"/>
       <xs:enumeration value="extradition"/>

--- a/app/services/nsm/importers/xml/v1/importer.rb
+++ b/app/services/nsm/importers/xml/v1/importer.rb
@@ -11,12 +11,14 @@ module Nsm
           end
 
           def call
+            resolve_reasons_for_claim
+            enhanced_rates_if_uplifts
+
             create_work_items
             create_defendants
             create_disbursements
             create_firm_office
             create_solicitor
-            resolve_reasons_for_claim
 
             claim.update(hash)
           end
@@ -66,6 +68,12 @@ module Nsm
 
           def resolve_reasons_for_claim
             hash['reasons_for_claim'] = hash['reasons_for_claim']['reason']
+          end
+
+          def enhanced_rates_if_uplifts
+            work_uplift = hash.dig('work_items', 'work_item')&.detect { _1['uplift'].present? }
+            uplifts = work_uplift || hash['calls_uplift'].present? || hash['letters_uplift'].present?
+            hash['reasons_for_claim'] << 'enhanced_rates_claimed' if uplifts
           end
         end
       end

--- a/spec/fixtures/files/import_sample.xml
+++ b/spec/fixtures/files/import_sample.xml
@@ -81,7 +81,6 @@
   <plea_category>category_1a</plea_category>
   <reason_for_claim_other_details>test</reason_for_claim_other_details>
   <reasons_for_claim>
-    <reason>enhanced_rates_claimed</reason>
     <reason>core_costs_exceed_higher_limit</reason>
     <reason>other</reason>
     <reason>representation_order_withdrawn</reason>

--- a/spec/services/nsm/importers/xml/v1/importer_spec.rb
+++ b/spec/services/nsm/importers/xml/v1/importer_spec.rb
@@ -150,6 +150,23 @@ RSpec.describe Nsm::Importers::Xml::V1::Importer do
     end
   end
 
+  describe '#enhanced_rates_if_uplifts' do
+    context 'when no uplifts present' do
+      let(:hash) do
+        xml_hash.except!('calls_uplift', 'letters_uplift')
+        xml_hash.tap { |h| h['work_items']['work_item'].each { _1.delete('uplift') } }
+      end
+
+      it 'enhanced_rates_claimed not included if uplifts absent' do
+        expect(claim.reasons_for_claim).not_to include('enhanced_rates_claimed')
+      end
+    end
+
+    it 'adds enhanced_rates_claimed if uplifts present' do
+      expect(claim.reasons_for_claim).to include('enhanced_rates_claimed')
+    end
+  end
+
   describe '#create_solicitor' do
     it 'creates solicitor if present' do
       expect(claim.solicitor).to have_attributes(first_name: 'Mickey',


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2443)

## Notes for reviewer
removed enhanced_rates_claimed as this is now predicated on presences of uplift fields

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
