### PR TITLE
Return all XML validation errors

### DIFF
--- a/app/services/nsm/importers/xml/import_service.rb
+++ b/app/services/nsm/importers/xml/import_service.rb
@@ -25,7 +25,7 @@ module Nsm
 
         def validate
           schema.validate(xml).map do |error|
-            @import_form.errors.add(:file_upload, error)
+            @import_form.errors.add(SecureRandom.uuid, error)
           end
         end
 


### PR DESCRIPTION
## Description of change

A component (determined by the error key) can only have a single error
associated to it currently.

Each iteration of the loop replaces the existing error with the next
and you just end up with a single error.

An alternative here is to put all the errors into a single
newline-separated array, but that means the errors show up next to the
component.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2445)