### PR TITLE
Ensure that we default to scoping searches to just the office codes

### DIFF
--- a/app/services/search/app_store_service.rb
+++ b/app/services/search/app_store_service.rb
@@ -14,7 +14,7 @@ module Search
           last_state_change_from: filters[:updated_from],
           last_state_change_to: filters[:updated_to],
           status_with_assignment: build_status_with_assignment(filters),
-          account_number: filters[:office_code].presence
+          account_number: filters[:office_code].presence || filters[:current_provider].office_codes
         )
       end
 


### PR DESCRIPTION
## Description of change

Prevents a data breach incident that was letting any providers search
for anyone else's claims if they didn't specify an account number

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2488)