### PR TITLE
Enable new Import a Claim flow in UAT/Production

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -17,8 +17,8 @@ feature_flags:
   import_claims:
     local: <%= ENV.fetch("IMPORT_CLAIMS", true) %>
     development: true
-    uat: false
-    production: false
+    uat: true
+    production: true
   provider_api_v1:
     local: <%= ENV.fetch("PROVIDER_API_V1", true) %>
     development: true


### PR DESCRIPTION
## Description of change

Enabling the feature flag to allow provider access to the new 'Import a Claim' flow.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2501)