### PR TITLE
Add a test case to handle broken XML

### DIFF
--- a/spec/fixtures/files/unmatched_fields.xml
+++ b/spec/fixtures/files/unmatched_fields.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<claim>

--- a/spec/system/nsm/import_spec.rb
+++ b/spec/system/nsm/import_spec.rb
@@ -1,6 +1,26 @@
 require 'pdf-reader'
 require 'system_helper'
 
+def import_file(file, advance_to_details: false)
+  attach_file(file_fixture(file))
+  # progress to defendant details form
+
+  click_on 'Save and continue' # 'What you are claiming for'
+  return unless advance_to_details
+
+  click_on 'Save and continue' # 'Which firm office account number is this claim for?'
+  click_on 'Save and continue' # 'Was this case worked on in an office in an undesignated area?'
+  click_on 'Save and continue' # 'Is the first court that heard this case in an undesignated area?'
+end
+
+def check_error_pages(page_body, page, error)
+  output = StringIO.new
+  output.puts(page_body)
+  pdf = PDF::Reader.new(output)
+
+  expect(pdf.page(page)).to have_content(error)
+end
+
 RSpec.describe 'Import claims' do
   before do
     visit provider_saml_omniauth_callback_path
@@ -13,20 +33,15 @@ RSpec.describe 'Import claims' do
   end
 
   it 'lets me import a claim' do
-    attach_file(file_fixture('import_sample.xml'))
-    click_on 'Save and continue'
+    import_file('import_sample.xml')
     expect(page).to have_content('You imported 3 work items and 2 disbursements.')
     expect(page).to have_content('To submit the claim, check the uploaded claim details and update any incomplete information.')
   end
 
   context 'defendants import' do
     before do
-      attach_file(file_fixture('import_sample_with_missing_fields.xml'))
-      # progress to defendant details form
-      click_on 'Save and continue' # 'What you are claiming for'
-      click_on 'Save and continue' # 'Which firm office account number is this claim for?'
-      click_on 'Save and continue' # 'Was this case worked on in an office in an undesignated area?'
-      click_on 'Save and continue' # 'Is the first court that heard this case in an undesignated area?'
+      import_file('import_sample_with_missing_fields.xml', advance_to_details: true)
+
       click_on 'Firm details' # 'Your claim progress'
       click_on 'Save and continue' # 'Firm details'
       click_on 'Save and continue' # 'Contact details'
@@ -55,18 +70,31 @@ RSpec.describe 'Import claims' do
   end
 
   it 'validates file type' do
-    attach_file(file_fixture('test.json'))
-    click_on 'Save and continue'
+    import_file('test.json')
+
     expect(page).to have_content "The file must be of type 'XML'"
   end
 
   it 'handles unreadable files' do
-    attach_file(file_fixture('unreadable_import.xml'))
-    click_on 'Save and continue'
+    import_file('unreadable_import.xml')
+
     expect(page).to have_content('The XML file must contain data in the correct format')
 
     click_on 'error summary (PDF)'
 
+    output = StringIO.new
+    output.puts(page.body)
+    pdf = PDF::Reader.new(output)
+    expect(pdf.page(1)).to have_content("2:0: ERROR: Element 'claim': Missing child element(s)")
+  end
+
+  it 'handles unmatched fields' do
+    import_file('unmatched_fields.xml')
+
+    expect(page).to have_content('The XML file must contain data in the correct format')
+    click_on 'error summary (PDF)'
+
+    check_error_pages(page.body, 1, "2:0: ERROR: Element 'claim': Missing child element(s)")
     output = StringIO.new
     output.puts(page.body)
     pdf = PDF::Reader.new(output)


### PR DESCRIPTION
## Description of change

Adds a test case to cover broken XML and tidy up the import test

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2450)