### PR TITLE
Show all service types when the box is focused even when empty

### DIFF
--- a/app/javascript/autocomplete.js
+++ b/app/javascript/autocomplete.js
@@ -43,6 +43,7 @@ export function convertSelectToAutocomplete() {
       showNoOptionsFound: name === null && !useCustom,
       name: name,
       autoselect: element.dataset.autoselect === "true",
+      showAllValues: element.dataset.showAllValues == "true",
       source: (query, populateResults) => {
         const trimmed = sanitizeInput(query);
         const filtered = [...element.options].filter((opt) =>

--- a/app/views/prior_authority/steps/primary_quote/edit.html.erb
+++ b/app/views/prior_authority/steps/primary_quote/edit.html.erb
@@ -14,7 +14,7 @@
       <% if @form_object.draft? %>
         <%= suggestion_select form, :service_type_autocomplete, PriorAuthority::QuoteServices.values, :to_sym, :translated, width: 20,
                               options: { include_blank: true }, label: { size: "m" }, hint: { size: "s", text: t(".service_name_hint")},
-                              data: { custom: false, autoselect: false, values: @services.to_json } %>
+                              data: { custom: false, autoselect: false, values: @services.to_json, show_all_values: true } %>
       <% else %>
         <h2 class="govuk-heading-l"><%= @form_object.service_type_translation %></h2>
       <% end %>


### PR DESCRIPTION
## Description of change

Allow the service type combo box in PA function more like a drop-down
box and hopefully reduce the amount of free-text entries.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2478)