### PR TITLE
Correctly handle no file uploaded error for imports

### DIFF
--- a/app/services/nsm/importers/xml/v1/importer.rb
+++ b/app/services/nsm/importers/xml/v1/importer.rb
@@ -77,7 +77,10 @@ module Nsm
           end
 
           def resolve_reasons_for_claim
+            hash['reasons_for_claim'] ||= []
             hash['reasons_for_claim'] = hash['reasons_for_claim']['reason']
+          rescue StandardError
+            # pass through
           end
 
           def populate_other_info


### PR DESCRIPTION
## Description of change

Rather than shadowing all errors that can occur, instead just handle
the case we care about.

As well as this, update the XML import to handle `reasons_for_claim`
missing and removing any possible attributes that can be part of a
`<claim>` node.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2534)