### PR TITLE
When deleting PA applications, skip quotes without a document

### DIFF
--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -80,8 +80,10 @@ class PriorAuthorityApplication < ApplicationRecord
       file_uploader.destroy(file.file_path) if file_uploader.exists?(file.file_path)
     end
 
-    quotes.each do |file|
-      file_uploader.destroy(file.document.file_path) if file_uploader.exists?(file.document.file_path)
+    quotes.each do |quote|
+      next if quote.document.nil?
+
+      file_uploader.destroy(quote.document.file_path) if file_uploader.exists?(quote.document.file_path)
     end
   end
 end

--- a/spec/models/prior_authority_application_spec.rb
+++ b/spec/models/prior_authority_application_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe PriorAuthorityApplication do
     context 'when application is a draft' do
       let(:application) { create(:prior_authority_application, :full, :as_draft) }
 
+      context 'and has a quote without a document' do
+        let(:quote) { double('quote', document: nil) }
+
+        it 'removes attachments for drafts without erroring' do
+          allow_any_instance_of(FileUpload::FileUploader).to receive(:exists?).with(test_file_path).and_return(true)
+          expect_any_instance_of(FileUpload::FileUploader).to receive(:destroy).with(test_file_path)
+          application.destroy
+        end
+      end
+
       it 'removes attachments for drafts' do
         allow_any_instance_of(FileUpload::FileUploader).to receive(:exists?).with(test_file_path).and_return(true)
         expect_any_instance_of(FileUpload::FileUploader).to receive(:destroy).with(test_file_path).at_least(:twice)


### PR DESCRIPTION
## Description of change

When deleting Prior Authority applications, skip quotes that don't have a document uploaded

[Link to issue](https://mojdt.slack.com/archives/C06UR7V28RZ/p1743523826360149)