### PR TITLE
Only translate the other_type when present when deleting disbursements

### DIFF
--- a/app/views/nsm/steps/disbursement_delete/edit.html.erb
+++ b/app/views/nsm/steps/disbursement_delete/edit.html.erb
@@ -19,7 +19,7 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <% if @form_object.record.disbursement_type == DisbursementTypes::OTHER.to_s %>
+            <% if @form_object.record.disbursement_type == DisbursementTypes::OTHER.to_s && @form_object.record.other_type.present? %>
               <% if OtherDisbursementTypes.values.include?(OtherDisbursementTypes.new(@form_object.record.other_type)) %>
                 <%= t("laa_crime_forms_common.nsm.other_disbursement_type.#{@form_object.record.other_type}") %>
               <% else %>


### PR DESCRIPTION
## Description of change

When displaying the confirmation screen for disbursement deletion, fallback to the "Other disbursement type" branch unless we have a type present.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2550)

## Screenshots of changes (if applicable)
![image](https://github.com/user-attachments/assets/5457567a-2698-448b-8756-f5b2f0ce6039)

