### PR TITLE
Re-enable skipped Chrome tests & shift back to 100% coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ end
 group :test do
   gem 'axe-core-rspec'
   gem 'capybara'
+  gem 'capybara-lockstep'
   gem 'capybara-selenium'
   gem 'launchy'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.2.3)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
@@ -585,6 +590,7 @@ DEPENDENCIES
   axe-core-rspec
   bootsnap (~> 1.18.4)
   capybara
+  capybara-lockstep
   capybara-selenium
   clamby (~> 1.6)
   cssbundling-rails

--- a/app/presenters/nsm/check_answers/adjustments_card.rb
+++ b/app/presenters/nsm/check_answers/adjustments_card.rb
@@ -12,19 +12,11 @@ module Nsm
         super()
       end
 
-      def rows
-        nil
-      end
-
       def custom
         {
           partial: 'nsm/steps/view_claim/adjustments',
           locals: { claim:, prefix: }
         }
-      end
-
-      def title
-        nil
       end
     end
   end

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -20,6 +20,7 @@
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', nonce: true, type: 'module' %>
+  <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
 
   <%= yield :head %>
   <%= yield :analytics if @analytics_cookies_accepted %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -67,4 +67,8 @@ Rails.application.configure do
   config.logstasher.log_level = Logger::INFO
   config.logstasher.suppress_app_log = false
   config.logstasher.source = 'laa-submit-crime-forms-test'
+
+  # Install middleware for capybara-lockstep to catch edge cases
+  # https://github.com/makandra/capybara-lockstep?tab=readme-ov-file#including-the-middleware-optional
+  config.middleware.insert_before 0, Capybara::Lockstep::Middleware
 end

--- a/lib/tasks/simplecov/process_coverage.rake
+++ b/lib/tasks/simplecov/process_coverage.rake
@@ -9,7 +9,7 @@ if ENV['CI']
       SimpleCov.collate Dir['./coverage_results/.resultset*.json'], 'rails' do
         enable_coverage :branch
         primary_coverage :branch
-        minimum_coverage branch: 99.5, line: 99.88
+        minimum_coverage branch: 100, line: 100
         refuse_coverage_drop :line, :branch
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,9 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
+  options = Selenium::WebDriver::Chrome::Options.new(
+    unhandled_prompt_behavior: 'ignore'
+  )
   options.add_argument('--headless=new')
   options.add_argument('--window-size=1080,1920')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ SimpleCov.start 'rails' do
   # Do not fail coverage on circleci as it breaks parrallel spec runs, instead rely on coverage step in CI
   unless ENV['CI']
     primary_coverage :branch
-    minimum_coverage branch: 99.5, line: 99.88
+    minimum_coverage branch: 100, line: 100
 
     SimpleCov.at_exit do
       SimpleCov.result.format!

--- a/spec/system/nsm/case_details/suggestion_autocomplete_spec.rb
+++ b/spec/system/nsm/case_details/suggestion_autocomplete_spec.rb
@@ -1,7 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'Test suggestion autocomplete for main_offence', :javascript, skip: 'selenium driver failing in chrome 134',
-type: :system do
+RSpec.describe 'Test suggestion autocomplete for main_offence', :javascript, type: :system do
   let(:claim) { create(:claim, :case_type_breach, :main_defendant) }
 
   it 'can select a value from the autocomplete' do

--- a/spec/system/nsm/disbursement_type/suggestion_autocomplete_spec.rb
+++ b/spec/system/nsm/disbursement_type/suggestion_autocomplete_spec.rb
@@ -1,7 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'Test suggestion autocomplete for court', :javascript, skip: 'selenium driver failing in chrome 134',
-type: :system do
+RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :system do
   let(:claim) { create(:claim, :case_type_breach, :firm_details) }
   let(:other_type_field) { 'nsm_steps_disbursement_type_form[other_type_suggestion]' }
 

--- a/spec/system/nsm/hearing_details/suggestion_autocomplete_spec.rb
+++ b/spec/system/nsm/hearing_details/suggestion_autocomplete_spec.rb
@@ -1,7 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'Test suggestion autocomplete for court', :javascript, skip: 'selenium driver failing in chrome 134',
-type: :system do
+RSpec.describe 'Test suggestion autocomplete for court', :javascript, type: :system do
   let(:claim) { create(:claim, :case_details) }
 
   before do

--- a/spec/system/prior_authority/case_detail_spec.rb
+++ b/spec/system/prior_authority/case_detail_spec.rb
@@ -1,37 +1,35 @@
 require 'system_helper'
 
-RSpec.describe 'Prior authority applications - add case details', type: :system do
+RSpec.describe 'Prior authority applications - add case details', :javascript, type: :system do
   before do
     fill_in_until_step(:your_application_progress)
   end
 
-  describe 'skipped', :javascript, skip: 'selenium driver failing in chrome 134' do
-    it 'allows case detail creation' do
-      expect(page).to have_content 'Case and hearing details Not yet started'
+  it 'allows case detail creation' do
+    expect(page).to have_content 'Case and hearing details Not yet started'
 
-      click_on 'Case and hearing details'
-      expect(page).to have_title 'Case details'
+    click_on 'Case and hearing details'
+    expect(page).to have_title 'Case details'
 
-      fill_in 'What was the main offence', with: 'Supply a controlled drug of Class A - Heroin'
-      within('.govuk-form-group', text: 'Date of representation order') do
-        fill_in 'Day', with: '27'
-        fill_in 'Month', with: '12'
-        fill_in 'Year', with: '2023'
-      end
-
-      fill_in 'MAAT ID number', with: '1234567'
-      within('.govuk-form-group', text: 'Is your client detained?') do
-        choose 'Yes'
-        fill_in 'Where is your client detained?', with: 'HMP Bedford'
-      end
-
-      within('.govuk-form-group', text: 'Is this case subject to POCA (Proceeds of Crime Act 2002)?') do
-        2.times { choose 'Yes' } # The first time may simply close the autocomplete suggestion box opened above
-      end
-
-      click_on 'Save and continue'
-      expect(page).to have_content 'Hearing details'
+    fill_in 'What was the main offence', with: 'Supply a controlled drug of Class A - Heroin'
+    within('.govuk-form-group', text: 'Date of representation order') do
+      fill_in 'Day', with: '27'
+      fill_in 'Month', with: '12'
+      fill_in 'Year', with: '2023'
     end
+
+    fill_in 'MAAT ID number', with: '1234567'
+    within('.govuk-form-group', text: 'Is your client detained?') do
+      choose 'Yes'
+      fill_in 'Where is your client detained?', with: 'HMP Bedford'
+    end
+
+    within('.govuk-form-group', text: 'Is this case subject to POCA (Proceeds of Crime Act 2002)?') do
+      2.times { choose 'Yes' } # The first time may simply close the autocomplete suggestion box opened above
+    end
+
+    click_on 'Save and continue'
+    expect(page).to have_content 'Hearing details'
   end
 
   it 'validates client detail fields' do

--- a/spec/system/prior_authority/further_information_request_spec.rb
+++ b/spec/system/prior_authority/further_information_request_spec.rb
@@ -1,6 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'provider responds to further information request', :stub_oauth_token, type: :system do
+RSpec.describe 'provider responds to further information request', :javascript, :stub_oauth_token, type: :system do
   let(:application) { create(:prior_authority_application, :full, :with_further_information_request) }
 
   before do
@@ -34,33 +34,31 @@ RSpec.describe 'provider responds to further information request', :stub_oauth_t
     expect(page).to have_current_path edit_prior_authority_steps_check_answers_path(application)
   end
 
-  describe 'skipped', :javascript, skip: 'selenium driver failing in chrome 134' do
-    it 'allows user to submit further information with attachments' do
-      expect(page).to have_no_content('test.png')
-      fill_in 'Enter the information requested', with: 'here is the information requested'
-      find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
-      click_on 'Save and continue'
+  it 'allows user to submit further information with attachments' do
+    expect(page).to have_no_content('test.png')
+    fill_in 'Enter the information requested', with: 'here is the information requested'
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+    click_on 'Save and continue'
 
-      expect(application.reload.further_informations.first)
-        .to have_attributes(
-          information_supplied: 'here is the information requested'
-        )
+    expect(application.reload.further_informations.first)
+      .to have_attributes(
+        information_supplied: 'here is the information requested'
+      )
 
-      expect(application.further_informations.first.supporting_documents.first.file_name).to eq 'test.png'
-    end
+    expect(application.further_informations.first.supporting_documents.first.file_name).to eq 'test.png'
+  end
 
-    it 'allows user to upload and delete attachments' do
-      expect(page).to have_no_content('test.png')
+  it 'allows user to upload and delete attachments' do
+    expect(page).to have_no_content('test.png')
 
-      find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
 
-      within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
+    within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
 
-      click_on 'Delete'
+    click_on 'Delete'
 
-      within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
-      expect(page).to have_no_css('.govuk-table')
-    end
+    within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
+    expect(page).to have_no_css('.govuk-table')
   end
 
   it 'takes me back to application details' do

--- a/spec/system/prior_authority/primary_quote_spec.rb
+++ b/spec/system/prior_authority/primary_quote_spec.rb
@@ -1,6 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'PA - add primary quote', :javascript, skip: 'selenium driver failing in chrome 134', type: :system do
+RSpec.describe 'PA - add primary quote', :javascript, type: :system do
   before do
     fill_in_until_step(:your_application_progress)
   end

--- a/spec/system/prior_authority/reason_why_spec.rb
+++ b/spec/system/prior_authority/reason_why_spec.rb
@@ -1,6 +1,6 @@
 require 'system_helper'
 
-RSpec.describe 'Prior authority applications - add case contact', type: :system do
+RSpec.describe 'Prior authority applications - add case contact', :javascript, type: :system do
   let(:application) { create(:prior_authority_application, :about_request_enabled) }
 
   before do
@@ -21,29 +21,27 @@ RSpec.describe 'Prior authority applications - add case contact', type: :system 
     )
   end
 
-  describe 'skipped', :javascript, skip: 'selenium driver failing in chrome 134' do
-    it 'allows user to submit a reason with attachments' do
-      fill_in 'Why is prior authority required?', with: 'important reasons'
-      find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
-      click_on 'Save and continue'
+  it 'allows user to submit a reason with attachments' do
+    fill_in 'Why is prior authority required?', with: 'important reasons'
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+    click_on 'Save and continue'
 
-      expect(application.reload).to have_attributes(
-        reason_why: 'important reasons'
-      )
-      expect(application.supporting_documents.first.file_name).to eq 'test.png'
-    end
+    expect(application.reload).to have_attributes(
+      reason_why: 'important reasons'
+    )
+    expect(application.supporting_documents.first.file_name).to eq 'test.png'
+  end
 
-    it 'allows user to upload and delete attachments' do
-      expect(page).to have_no_content('test.png')
+  it 'allows user to upload and delete attachments' do
+    expect(page).to have_no_content('test.png')
 
-      find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
+    find('.moj-multi-file-upload__dropzone').drop(file_fixture('test.png'))
 
-      within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
+    within('.govuk-table') { expect(page).to have_content(/test.png.*Delete/) }
 
-      click_on 'Delete'
+    click_on 'Delete'
 
-      within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
-      expect(page).to have_no_css('.govuk-table')
-    end
+    within('.moj-banner') { expect(page).to have_content('test.png has been deleted') }
+    expect(page).to have_no_css('.govuk-table')
   end
 end


### PR DESCRIPTION
## Description of change
Thanks to
https://mojdt.slack.com/archives/C014YJ90G48/p1745834811181699, we
were made aware that there is a genuine issue to track against
Capybara.

So in lieu of an actual fix, there is a package capybara-lockstep
which correctly waits for components to be available before attempting
tests. This fixes whatever the random issue with Chrome was and lets
us go back to 100% coverage.

[Link to relevant discussion](https://mojdt.slack.com/archives/C014YJ90G48/p1745834811181699)