### PR TITLE
Factor PDA out of the equation on login

### DIFF
--- a/app/controllers/providers/omniauth_callbacks_controller.rb
+++ b/app/controllers/providers/omniauth_callbacks_controller.rb
@@ -6,6 +6,8 @@ module Providers
       active_office_codes = ActiveOfficeCodeService.call(office_codes)
 
       if active_office_codes.any?
+        provider = Provider.from_omniauth(auth_data, office_codes)
+
         sign_in_and_redirect(
           provider, event: :authentication
         )
@@ -32,16 +34,8 @@ module Providers
       request.env['omniauth.auth']
     end
 
-    def provider
-      Provider.from_omniauth(auth_data)
-    end
-
     def office_codes
-      if FeatureFlags.omniauth_test_mode.enabled?
-        auth_data.info.office_codes
-      else
-        @office_codes ||= provider.office_codes
-      end
+      auth_data.info.office_codes
     end
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -18,12 +18,13 @@ class Provider < ApplicationRecord
   has_many :prior_authority_applications, dependent: :destroy
 
   class << self
-    def from_omniauth(auth)
+    def from_omniauth(auth, office_codes)
       find_or_initialize_by(auth_provider: auth.provider, uid: auth.uid).tap do |record|
         record.update(
           email: auth.info.email,
           description: auth.info.description,
           roles: auth.info.roles,
+          office_codes: office_codes,
         )
       end
     end

--- a/app/services/active_office_code_service.rb
+++ b/app/services/active_office_code_service.rb
@@ -5,20 +5,11 @@ class ActiveOfficeCodeService
     end
 
     def active?(office_code)
-      return true if always_active_office_codes.include?(office_code)
-      return false if always_inactive_office_codes.include?(office_code)
-
-      contract_active?(office_code)
+      always_inactive_office_codes.exclude?(office_code)
     end
-
-    delegate :contract_active?, to: :ProviderDataApiClient
 
     def always_inactive_office_codes
       Rails.configuration.x.office_code_overrides.inactive_office_codes
-    end
-
-    def always_active_office_codes
-      Rails.configuration.x.office_code_overrides.active_office_codes
     end
   end
 end

--- a/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/providers/omniauth_callbacks_controller_spec.rb
@@ -78,22 +78,5 @@ RSpec.describe Providers::OmniauthCallbacksController, type: :controller do
         expect(response).to redirect_to '/errors/inactive_offices'
       end
     end
-
-    context 'when not in test mode' do
-      before do
-        allow(FeatureFlags).to receive(:omniauth_test_mode).and_return(double(:omniauth_test_mode, enabled?: false))
-        allow(OfficeCodeService).to receive(:call).with('test-user').and_return(%w[DDDDDD EEEEEE])
-        allow(ActiveOfficeCodeService).to receive(:call).with(%w[DDDDDD EEEEEE]).and_return(['EEEEEE'])
-        get :saml
-      end
-
-      it 'redirects to root path' do
-        expect(response).to redirect_to(root_path)
-      end
-
-      it 'sets the office codes' do
-        expect(Provider.find_by(email: 'provider@example.com').office_codes).to eq %w[DDDDDD EEEEEE]
-      end
-    end
   end
 end


### PR DESCRIPTION
## Description of change

Until PDA comes back, we have to rely on the local set of office codes.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2621)