### PR TITLE
Use correct env name for Dev Release Actions/Workflows

### DIFF
--- a/.github/actions/delete-dev-release/action.yml
+++ b/.github/actions/delete-dev-release/action.yml
@@ -1,5 +1,5 @@
-name: "Delete UAT deployment"
-description: 'Deletes a UAT deployment with a name that matches the merged or closed branch'
+name: "Delete Dev deployment"
+description: 'Deletes a dev deployment with a name that matches the merged or closed branch'
 inputs:
   k8s_cluster:
     description: "Kubernetes cluster name"

--- a/.github/workflows/delete-dev-release.yml
+++ b/.github/workflows/delete-dev-release.yml
@@ -1,4 +1,4 @@
-name: Delete UAT release
+name: Delete Dev release
 
 on:
   pull_request:


### PR DESCRIPTION
## Description of change

No Ticket

## Notes for reviewer

The workflow that deletes old dev branches is called Delete UAT release, when it should be Delete Dev release - the corresponding action references UAT also. Updating as it's confusing to people inspecting config