### PR TITLE
Add public ingress to allow Pingdom to use without whitelist

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,6 @@
 ENVIRONMENT=$1
 # Convert the branch name into a string that can be turned into a valid URL
 BRANCH_RELEASE_NAME=$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
-PINGDOM_IPS=$(curl -s https://my.pingdom.com/probes/ipv4 | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 SHARED_IPS=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 
 deploy_branch() {
@@ -24,7 +23,6 @@ deploy_branch() {
                 --set ingress.tls[0].host="$RELEASE_HOST" \
                 --set nameOverride="$BRANCH_RELEASE_NAME"\
                 --set fullnameOverride="$BRANCH_RELEASE_NAME"\
-                --set-string pingdomIPs="$PINGDOM_IPS" \
                 --set-string sharedIPs="$SHARED_IPS" \
                 --set branch=true
 
@@ -37,7 +35,6 @@ deploy_main() {
                           --values ./helm_deploy/values-"$ENVIRONMENT".yaml \
                           --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \
                           --set image.tag="main-$CIRCLE_SHA1" \
-                          --set-string pingdomIPs="$PINGDOM_IPS" \
                           --set-string sharedIPs="$SHARED_IPS"
 }
 

--- a/helm_deploy/templates/_helpers.tpl
+++ b/helm_deploy/templates/_helpers.tpl
@@ -95,6 +95,6 @@ Function to return a list of whitelisted IPs allowed to access the service.
 */}}
 {{- define "laa-submit-crime-forms.whitelist" -}}
 {{- if .Values.ingress.whitelist.enabled }}
-    {{- if .Values.ingress.whitelist.addresses }}{{- join "," .Values.ingress.whitelist.addresses }},{{- end }}{{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
+    {{- if .Values.ingress.whitelist.addresses }}{{- join "," .Values.ingress.whitelist.addresses }},{{- end }}{{- .Values.sharedIPs }}
 {{- end -}}
 {{- end -}}

--- a/helm_deploy/templates/public-ingress.yaml
+++ b/helm_deploy/templates/public-ingress.yaml
@@ -1,0 +1,38 @@
+{{- $fullName := include "laa-submit-crime-forms.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: public-{{ $fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "laa-submit-crime-forms.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method !~ ^GET$) {
+        return 405;
+      }
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: public-{{- index .Values.ingress.annotations "external-dns.alpha.kubernetes.io/set-identifier" }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /ping
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          - path: /ready
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+      {{- end }}

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -33,7 +33,7 @@ ingress:
   whitelist:
     enabled: false
   annotations:
-    nginx.ingress.kubernetes.io/permanent-redirect: https://laa-holding-page-production.apps.live.cloud-platform.service.justice.gov.uk
+    nginx.ingress.kubernetes.io/temporal-redirect: https://laa-holding-page-production.apps.live.cloud-platform.service.justice.gov.uk
     external-dns.alpha.kubernetes.io/set-identifier: laa-submit-crime-forms-app-laa-submit-crime-forms-prod-green
   hosts:
     - host: submit-crime-forms.service.justice.gov.uk


### PR DESCRIPTION
## Description of change

Remove the need to add Pingdom IPs to the whitelist by allowing the healthcheck endpoints to be public for `GET` requests only

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2628)