### PR TITLE
Update from_omniauth to handle office codes as well

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -19,7 +19,9 @@ class Provider < ApplicationRecord
 
   class << self
     def from_omniauth(auth, office_codes)
-      user = find_by(email: auth.info.email) ||
+      sorted_office_codes = office_codes.sort
+      user = where(email: auth.info.email)
+             .find { |u| u.office_codes.sort == sorted_office_codes } ||
              find_by(auth_provider: auth.provider, uid: auth.uid) ||
              new
 
@@ -28,7 +30,7 @@ class Provider < ApplicationRecord
           email: auth.info.email,
           description: auth.info.description,
           roles: auth.info.roles,
-          office_codes: office_codes,
+          office_codes: sorted_office_codes,
           auth_provider: auth.provider,
           uid: auth.uid
         )

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-
 RSpec.describe Provider, type: :model do
   subject { described_class.new(attributes) }
 
@@ -10,7 +9,6 @@ RSpec.describe Provider, type: :model do
       office_codes: office_codes,
     }
   end
-
   let(:office_codes) { %w[A1 B2 C3] }
 
   describe '#display_name' do
@@ -41,6 +39,24 @@ RSpec.describe Provider, type: :model do
           expect { described_class.from_omniauth(auth, office_codes) }.to change(described_class, :count).by(1)
         end
       end
+
+      context 'when single office code' do
+        let(:office_codes) { %w[A1] }
+
+        it 'creates a new user record' do
+          expect { described_class.from_omniauth(auth, office_codes) }.to change(described_class, :count).by(1)
+        end
+      end
+
+      context 'when no office codes provided' do
+        let(:office_codes) { [] }
+
+        it 'creates a new user record with empty office codes' do
+          expect { described_class.from_omniauth(auth, office_codes) }.to change(described_class, :count).by(1)
+          user = described_class.last
+          expect(user.office_codes).to eq([])
+        end
+      end
     end
 
     context 'migration scenarios' do
@@ -54,18 +70,6 @@ RSpec.describe Provider, type: :model do
         )
       end
 
-      context 'user with same email migrating to new provider' do
-        it 'updates existing user with new auth info' do
-          expect { described_class.from_omniauth(auth, office_codes) }
-            .not_to change(described_class, :count)
-
-          existing_user.reload
-          expect(existing_user.auth_provider).to eq('govuk')
-          expect(existing_user.uid).to eq(auth.uid)
-          expect(existing_user.office_codes).to eq(office_codes)
-        end
-      end
-
       context 'user changed email but kept same provider/uid temporarily' do
         let(:info) { double('info', email: 'newemail@test.com', description: 'desc', roles: 'a,b') }
         let(:auth) { double('auth', provider: 'old_saml', uid: 'old-uid-123', info: info) }
@@ -73,21 +77,46 @@ RSpec.describe Provider, type: :model do
         it 'finds by auth info and updates email' do
           expect { described_class.from_omniauth(auth, office_codes) }
             .not_to change(described_class, :count)
-
           existing_user.reload
           expect(existing_user.email).to eq('newemail@test.com')
           expect(existing_user.office_codes).to eq(office_codes)
         end
       end
 
-      context 'user has different office codes after migration' do
-        let(:new_office_codes) { %w[C3 D4] }
+      context 'existing user with same provider/uid gets new office codes' do
+        let(:auth) { double('auth', provider: 'old_saml', uid: 'old-uid-123', info: info) }
+        let(:office_codes) { %w[X1 Y2 Z3] }
 
         it 'updates office codes for existing user' do
-          described_class.from_omniauth(auth, new_office_codes)
-
+          expect { described_class.from_omniauth(auth, office_codes) }
+            .not_to change(described_class, :count)
           existing_user.reload
-          expect(existing_user.office_codes).to eq(new_office_codes)
+          expect(existing_user.office_codes).to eq(%w[X1 Y2 Z3])
+          expect(existing_user.email).to eq('test@test.com')
+        end
+      end
+
+      context 'existing user loses office codes' do
+        let(:auth) { double('auth', provider: 'old_saml', uid: 'old-uid-123', info: info) }
+        let(:office_codes) { [] }
+
+        it 'removes office codes for existing user' do
+          expect { described_class.from_omniauth(auth, office_codes) }
+            .not_to change(described_class, :count)
+          existing_user.reload
+          expect(existing_user.office_codes).to eq([])
+        end
+      end
+
+      context 'existing user has unsorted office codes' do
+        let(:auth) { double('auth', provider: 'old_saml', uid: 'old-uid-123', info: info) }
+        let(:office_codes) { %w[C3 B2 A1] }
+
+        it 'removes office codes for existing user' do
+          expect { described_class.from_omniauth(auth, office_codes) }
+            .not_to change(described_class, :count)
+          existing_user.reload
+          expect(existing_user.office_codes).to eq(%w[A1 B2 C3])
         end
       end
     end


### PR DESCRIPTION
When attempting to migrate a user from the old system, compare the
list of office codes as well

## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2673)