### PR TITLE
Bump sqlite to resolve CVE-2025-6965

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Non-standard magistrates' court payment team"
 
 # TODO: still needed?
 # temp fix to security issue in base image: ruby:3.2.2-alpine3.18
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libxml2
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libxml2 sqlite
 
 # dependencies required both at runtime and build time
 RUN apk add --update \


### PR DESCRIPTION
## Description of change

https://security.snyk.io/vuln/SNYK-ALPINE321-SQLITE-11191065