### PR TITLE
Remove E2E tests from "merge to main" pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,6 @@ jobs:
           channel: laa-non-standard-crime-claims-prod-alerts
           event: fail
           template: basic_fail_1
-          branch_pattern: .main|main.
 
   deploy-dev:
     executor: cloud-platform-executor
@@ -476,18 +475,6 @@ workflows:
             - rspec-tests
       - build-to-ecr:
           context: laa-submit-crime-forms-dev
-          filters:
-            branches:
-              only:
-                - main
-      - e2e-test-main:
-          context:
-            - laa-crime-forms-e2e-tests
-            - laa-non-standard-crime-claims-alerting
-          requires:
-            - build-to-ecr
-            - linter-tests
-            - rspec-tests
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,14 +493,10 @@ workflows:
                 - main
       - deploy-dev:
           context: laa-submit-crime-forms-dev
-          requires:
-            - e2e-test-main
       - deploy-uat:
           context:
             - laa-submit-crime-forms-uat
             - laa-non-standard-crime-claims-alerting
-          requires:
-            - e2e-test-main
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,6 +384,7 @@ jobs:
           channel: laa-non-standard-crime-claims-prod-alerts
           event: fail
           template: basic_fail_1
+          branch_pattern: .main|main.
 
   deploy-dev:
     executor: cloud-platform-executor


### PR DESCRIPTION
## Description of change

The tests run as part of the regular PR process, any failures after
that are attributed to the brittleness of the suite and should
therefore be ignored.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2477)