### PR TITLE
Crm457-2704: Remove Core Search Fields alongside LAA Reference

### DIFF
--- a/db/migrate/20250805120900_remove_laa_reference.rb
+++ b/db/migrate/20250805120900_remove_laa_reference.rb
@@ -1,6 +1,6 @@
 class RemoveLaaReference < ActiveRecord::Migration[8.0]
   def change
-    remove_column :claims, :laa_reference, :string
-    remove_column :prior_authority_applications, :laa_reference, :string
+    remove_column :claims, :laa_reference, :string, force: :cascade
+    remove_column :prior_authority_applications, :laa_reference, :string, force: :cascade
   end
 end

--- a/db/migrate/20250805120900_remove_laa_reference.rb
+++ b/db/migrate/20250805120900_remove_laa_reference.rb
@@ -1,5 +1,7 @@
 class RemoveLaaReference < ActiveRecord::Migration[8.0]
   def change
+    remove_column :claims, :core_search_fields, :virtual
+    remove_column :prior_authority_applications, :core_search_fields, :virtual
     remove_column :claims, :laa_reference, :string, force: :cascade
     remove_column :prior_authority_applications, :laa_reference, :string, force: :cascade
   end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2704)

## Notes for reviewer
This did not initially work locally because of syncing issues with the schema field and the migrations, was able to run a clean setup to test that this should work locally and remote