### PR TITLE
Add office code for UAT Test Scenario 8

### DIFF
--- a/config/office_code_overrides.yml
+++ b/config/office_code_overrides.yml
@@ -30,7 +30,9 @@ development:
     - YYYYYY
 
 uat:
-  active_office_codes: []
+  active_office_codes:
+    # Test office for 2nd SILAS test account
+    - 0Z981E
   inactive_office_codes:
     # Test office for A.CLARKE (see 1Password for login), has eforms role
     - 0X416R


### PR DESCRIPTION
## Description of change
Add office code: 0Z981E to active office code override list so that we can use it for testing what happens when PDA is down