### PR TITLE
CRM457-2736 & CRM457-2738: Active Office Code Updates

### DIFF
--- a/app/services/active_office_code_service.rb
+++ b/app/services/active_office_code_service.rb
@@ -29,8 +29,8 @@ class ActiveOfficeCodeService
     private
 
     def known_active_code?(office_code)
-      return true if always_active_office_codes.include?(office_code)
       return false if always_inactive_office_codes.include?(office_code)
+      return true if always_active_office_codes.include?(office_code)
 
       false
     end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket 1](https://dsdmoj.atlassian.net/browse/CRM457-2736)
[Link to relevant ticket 2](https://dsdmoj.atlassian.net/browse/CRM457-2737)


## Notes for reviewer

1. Checks for inactive offices in office code overrides before active offices to prevent inactive offices ever being accessed in our service 
2. Returns unavailable from ALL non 200/204 responses from schedule API call in Provider Data API client so that we gracefully handle more scenarios of the API being down