### PR TITLE
CRM457-2759: Can't Import NSM Claim With No Reasons for Claim Specified

### DIFF
--- a/app/services/nsm/importers/xml/v1/importer.rb
+++ b/app/services/nsm/importers/xml/v1/importer.rb
@@ -94,6 +94,7 @@ module Nsm
           def enhanced_rates_if_uplifts
             work_uplift = hash.dig('work_items', 'work_item')&.detect { _1['uplift'].present? }
             uplifts = work_uplift || hash['calls_uplift'].present? || hash['letters_uplift'].present?
+            hash['reasons_for_claim'] ||= []
             hash['reasons_for_claim'] << 'enhanced_rates_claimed' if uplifts
           end
         end

--- a/spec/services/nsm/importers/xml/v1/importer_spec.rb
+++ b/spec/services/nsm/importers/xml/v1/importer_spec.rb
@@ -195,6 +195,27 @@ RSpec.describe Nsm::Importers::Xml::V1::Importer do
       end
     end
 
+    context 'when no reasons for claim present and no uplifts present' do
+      let(:hash) do
+        xml_hash.except!('calls_uplift', 'letters_uplift', 'reasons_for_claim')
+        xml_hash.tap { |h| h['work_items']['work_item'].each { _1.delete('uplift') } }
+      end
+
+      it 'returns an empty array' do
+        expect(claim.reasons_for_claim).to eq []
+      end
+    end
+
+    context 'when no reasons for claim present' do
+      let(:hash) do
+        xml_hash.except('reasons_for_claim')
+      end
+
+      it 'adds enhanced_rates_claimed if uplifts present' do
+        expect(claim.reasons_for_claim).to include('enhanced_rates_claimed')
+      end
+    end
+
     it 'adds enhanced_rates_claimed if uplifts present' do
       expect(claim.reasons_for_claim).to include('enhanced_rates_claimed')
     end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2759)

## Notes for reviewer

- Default to [] when <reasons_for_claim> tag doesn't exist in XML file 
- Added tests