### PR TITLE
Restrict access for downloads to providers that should have access to the submission

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,11 +1,26 @@
 class DownloadsController < ApplicationController
   def show
     document = SupportingDocument.find(params[:id])
+    return head :forbidden unless current_provider.office_codes.include?(parent(document).office_code)
+
     download_url = LaaCrimeFormsCommon::S3Files.temporary_download_url(
       S3_BUCKET,
       document.file_path,
       document.file_name
     )
     redirect_to download_url, allow_other_host: true
+  end
+
+  private
+
+  def parent(document)
+    @parent ||= case document.documentable_type
+                when 'Quote'
+                  document.documentable.prior_authority_application
+                when 'FurtherInformation'
+                  document.documentable.submission
+                else
+                  document.documentable
+                end
   end
 end

--- a/app/presenters/app_store/v1/supporting_document.rb
+++ b/app/presenters/app_store/v1/supporting_document.rb
@@ -1,6 +1,7 @@
 module AppStore
   module V1
     class SupportingDocument < AppStore::V1::Base
+      attribute :id, :string
       attribute :file_name, :string
       attribute :file_type, :string
       attribute :file_size, :integer

--- a/app/presenters/nsm/check_answers/base.rb
+++ b/app/presenters/nsm/check_answers/base.rb
@@ -21,7 +21,7 @@ module Nsm
 
       def rows
         row_data.map do |row|
-          row_content(row[:head_key], row[:text], row[:head_opts] || {}, footer: row[:footer])
+          row_content(row[:head_key], row[:text], row[:href], row[:head_opts] || {}, footer: row[:footer])
         end
       end
 
@@ -29,8 +29,9 @@ module Nsm
         []
       end
 
-      def row_content(head_key, text, head_opts = {}, footer: false)
+      def row_content(head_key, text, href, head_opts = {}, footer: false)
         heading = head_opts[:text] || translate_table_key(section, head_key, **head_opts)
+        text = tag.a(text, href:) if href
         row = {
           key: {
             text: heading

--- a/app/presenters/nsm/check_answers/evidence_uploads_card.rb
+++ b/app/presenters/nsm/check_answers/evidence_uploads_card.rb
@@ -41,7 +41,7 @@ module Nsm
           {
             head_key: 'supporting_evidence',
             text: evidence[:file_name],
-            href: url_helper.download_path(evidence),
+            href: (url_helper.download_path(evidence) unless evidence[:id].nil?),
             head_opts: { count: index + 1 }
           }
         end

--- a/app/presenters/nsm/check_answers/evidence_uploads_card.rb
+++ b/app/presenters/nsm/check_answers/evidence_uploads_card.rb
@@ -41,6 +41,7 @@ module Nsm
           {
             head_key: 'supporting_evidence',
             text: evidence[:file_name],
+            href: url_helper.download_path(evidence),
             head_opts: { count: index + 1 }
           }
         end

--- a/spec/factories/supporting_documents.rb
+++ b/spec/factories/supporting_documents.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     end
 
     factory :quote_document do
+      documentable_type { 'Quote' }
       document_type { 'quote_document' }
     end
   end

--- a/spec/presenters/nsm/check_answers/evidence_upload_card_spec.rb
+++ b/spec/presenters/nsm/check_answers/evidence_upload_card_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Nsm::CheckAnswers::EvidenceUploadsCard do
   let(:supporting_evidence) { [first_evidence, second_evidence] }
   let(:send_by_post) { false }
   let(:first_evidence) do
-    { file_name: 'Defendant Report.pdf' }
+    { id: 'test', file_name: 'Defendant Report.pdf' }
   end
   let(:second_evidence) do
-    { file_name: 'Offences.pdf' }
+    { id: 'test', file_name: 'Offences.pdf' }
   end
 
   before do
@@ -39,11 +39,13 @@ RSpec.describe Nsm::CheckAnswers::EvidenceUploadsCard do
               },
               {
                 head_key: 'supporting_evidence',
+                href: '/downloads/test?file_name=Defendant+Report.pdf',
                 text: 'Defendant Report.pdf',
                 head_opts: { count: 1 }
               },
               {
                 head_key: 'supporting_evidence',
+                href: '/downloads/test?file_name=Offences.pdf',
                 text: 'Offences.pdf',
                 head_opts: { count: 2 }
               }
@@ -96,11 +98,13 @@ RSpec.describe Nsm::CheckAnswers::EvidenceUploadsCard do
             [
               {
                 head_key: 'supporting_evidence',
+                href: '/downloads/test?file_name=Defendant+Report.pdf',
                 text: 'Defendant Report.pdf',
                 head_opts: { count: 1 }
               },
               {
                 head_key: 'supporting_evidence',
+                 href: '/downloads/test?file_name=Offences.pdf',
                 text: 'Offences.pdf',
                 head_opts: { count: 2 }
               }

--- a/spec/system/nsm/view_claim_spec.rb
+++ b/spec/system/nsm/view_claim_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe 'View claim page', :stub_oauth_token, type: :system do
     stub_nsm_app_store_payload(claim)
   end
 
+  context 'when viewing a claim', :javascript do
+    before do
+      visit nsm_steps_view_claim_path(claim)
+    end
+
+    context 'and I should be able to download attachments' do
+      it 'I can download attachments' do
+        file_name = SupportingDocument.first.file_name
+        click_on file_name
+
+        expect(page).to have_current_path(/X-Amz-Signature/)
+        expect(current_url).to include('response-content-disposition=attachment')
+        expect(current_url).to include("filename%3D%22#{CGI.escape(file_name)}%22")
+      end
+    end
+  end
+
   it 'shows a cost summary table on the claimed costs page' do
     visit claimed_costs_work_items_nsm_steps_view_claim_path(claim.id)
 


### PR DESCRIPTION
## Description of change

Applies to both NSM & PA, impacts a few tests as well and we also now
make evidence links on NSM "view claim" screen actual clickable links.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2660)